### PR TITLE
Fix check-format

### DIFF
--- a/test/buffer/buffer_pool_manager_test.cpp
+++ b/test/buffer/buffer_pool_manager_test.cpp
@@ -59,7 +59,7 @@ TEST(BufferPoolManagerTest, DISABLED_SampleTest) {
   // Scenario: We should be able to fetch the data we wrote a while ago.
   page0 = bpm.FetchPage(0);
   EXPECT_EQ(0, strcmp(page0->GetData(), "Hello"));
-  
+
   // Scenario: If we unpin page 0 and then make a new page, all the buffer pages should
   // now be pinned. Fetching page 0 should fail.
   EXPECT_EQ(true, bpm.UnpinPage(0, true));


### PR DESCRIPTION
Some whitespace got into the test file while CI wasn't up and is failing all the builds.