### PR TITLE
Fix clang-tidy in header files used for grading

### DIFF
--- a/src/common/util/string_util.cpp
+++ b/src/common/util/string_util.cpp
@@ -154,7 +154,7 @@ std::string StringUtil::Format(std::string fmt_str, ...) {
 
   while (true) {
     // Wrap the plain char array into the unique_ptr.
-    formatted.reset(new char[n]);
+    formatted = std::make_unique<char[]>(n);
     strcpy(&formatted[0], fmt_str.c_str());  // NOLINT
     va_start(ap, fmt_str);
     final_n = vsnprintf(&formatted[0], static_cast<size_t>(n), fmt_str.c_str(), ap);

--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -99,9 +99,7 @@ class Column {
       case TypeId::VARCHAR:
         // TODO(Amadou): Confirm this.
         return 12;
-      default: {
-        UNREACHABLE("Cannot get size of invalid type");
-      }
+      default: { UNREACHABLE("Cannot get size of invalid type"); }
     }
   }
 

--- a/src/include/storage/disk/disk_manager.h
+++ b/src/include/storage/disk/disk_manager.h
@@ -98,7 +98,7 @@ class DiskManager {
   inline bool HasFlushLogFuture() { return flush_log_f_ != nullptr; }
 
  private:
-  int GetFileSize(const std::string &name);
+  int GetFileSize(const std::string &file_name);
   // stream to write log file
   std::fstream log_io_;
   std::string log_name_;

--- a/src/include/type/integer_parent_type.h
+++ b/src/include/type/integer_parent_type.h
@@ -171,4 +171,5 @@ Value IntegerParentType::ModuloValue(const Value &left, const Value &right) cons
   }
   return Value(right.GetTypeId(), quot2);
 }
+
 }  // namespace bustub

--- a/src/include/type/integer_parent_type.h
+++ b/src/include/type/integer_parent_type.h
@@ -77,8 +77,8 @@ class IntegerParentType : public NumericType {
 
 template <class T1, class T2>
 Value IntegerParentType::AddValue(const Value &left, const Value &right) const {
-  T1 x = left.GetAs<T1>();
-  T2 y = right.GetAs<T2>();
+  auto x = left.GetAs<T1>();
+  auto y = right.GetAs<T2>();
   auto sum1 = static_cast<T1>(x + y);
   auto sum2 = static_cast<T2>(x + y);
 
@@ -100,8 +100,8 @@ Value IntegerParentType::AddValue(const Value &left, const Value &right) const {
 
 template <class T1, class T2>
 Value IntegerParentType::SubtractValue(const Value &left, const Value &right) const {
-  T1 x = left.GetAs<T1>();
-  T2 y = right.GetAs<T2>();
+  auto x = left.GetAs<T1>();
+  auto y = right.GetAs<T2>();
   auto diff1 = static_cast<T1>(x - y);
   auto diff2 = static_cast<T2>(x - y);
   if ((x - y) != diff1 && (x - y) != diff2) {
@@ -122,8 +122,8 @@ Value IntegerParentType::SubtractValue(const Value &left, const Value &right) co
 
 template <class T1, class T2>
 Value IntegerParentType::MultiplyValue(const Value &left, const Value &right) const {
-  T1 x = left.GetAs<T1>();
-  T2 y = right.GetAs<T2>();
+  auto x = left.GetAs<T1>();
+  auto y = right.GetAs<T2>();
   auto prod1 = static_cast<T1>(x * y);
   auto prod2 = static_cast<T2>(x * y);
   if ((x * y) != prod1 && (x * y) != prod2) {
@@ -144,8 +144,8 @@ Value IntegerParentType::MultiplyValue(const Value &left, const Value &right) co
 
 template <class T1, class T2>
 Value IntegerParentType::DivideValue(const Value &left, const Value &right) const {
-  T1 x = left.GetAs<T1>();
-  T2 y = right.GetAs<T2>();
+  auto x = left.GetAs<T1>();
+  auto y = right.GetAs<T2>();
   if (y == 0) {
     throw Exception(ExceptionType::DIVIDE_BY_ZERO, "Division by zero.");
   }
@@ -159,8 +159,8 @@ Value IntegerParentType::DivideValue(const Value &left, const Value &right) cons
 
 template <class T1, class T2>
 Value IntegerParentType::ModuloValue(const Value &left, const Value &right) const {
-  T1 x = left.GetAs<T1>();
-  T2 y = right.GetAs<T2>();
+  auto x = left.GetAs<T1>();
+  auto y = right.GetAs<T2>();
   if (y == 0) {
     throw Exception(ExceptionType::DIVIDE_BY_ZERO, "Division by zero.");
   }

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -98,9 +98,7 @@ class ValueFactory {
       case TypeId::VARCHAR:
         ret_value = GetVarcharValue(nullptr, false, nullptr);
         break;
-      default: {
-        throw Exception(ExceptionType::UNKNOWN_TYPE, "Attempting to create invalid null type");
-      }
+      default: { throw Exception(ExceptionType::UNKNOWN_TYPE, "Attempting to create invalid null type"); }
     }
     return ret_value;
   }

--- a/src/storage/page/header_page.cpp
+++ b/src/storage/page/header_page.cpp
@@ -96,7 +96,7 @@ int HeaderPage::FindRecord(const std::string &name) {
   int record_num = GetRecordCount();
 
   for (int i = 0; i < record_num; i++) {
-    char *raw_name = reinterpret_cast<char *>(GetData() + (4 + i * 36));
+    auto raw_name = reinterpret_cast<char *>(GetData() + (4 + i * 36));
     if (strcmp(raw_name, name.c_str()) == 0) {
       return i;
     }

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -108,7 +108,7 @@ std::string TimestampType::ToString(const Value &val) const {
   tm /= 100000;
   auto year = static_cast<uint16_t>(tm % 10000);
   tm /= 10000;
-  int tz = static_cast<int>(tm % 27);
+  auto tz = static_cast<int>(tm % 27);
   tz -= 12;
   tm /= 27;
   auto day = static_cast<uint16_t>(tm % 32);


### PR DESCRIPTION
clang-tidy only checks header files which are actually included and in use.

These files were not caught as part of the initial 5500 or so clang-tidy things because nothing was including them. We now need them for the autograder.