### PR TITLE
Add make build-tests to build the test executables without running them.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(VALGRIND_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/build_support/valgrind.sup
 ##########################################
 # "make check-tests"
 ##########################################
+add_custom_target(build-tests COMMAND ${CMAKE_CTEST_COMMAND} --show-only)
 add_custom_target(check-tests COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
 
 ##########################################
@@ -41,6 +42,7 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
 
     # Add the test target separately and as part of "make check-tests".
     add_executable(${bustub_test_name} EXCLUDE_FROM_ALL ${bustub_test_source})
+    add_dependencies(build-tests ${bustub_test_name})
     add_dependencies(check-tests ${bustub_test_name})
 
     target_link_libraries(${bustub_test_name} bustub_shared gtest gmock_main)


### PR DESCRIPTION
This introduces `make build-tests` for grading purposes.