### PR TITLE
Fix the memory leak in the sample buffer pool test.

### DIFF
--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -99,7 +99,9 @@ class Column {
       case TypeId::VARCHAR:
         // TODO(Amadou): Confirm this.
         return 12;
-      default: { UNREACHABLE("Cannot get size of invalid type"); }
+      default: {
+        UNREACHABLE("Cannot get size of invalid type");
+      }
     }
   }
 

--- a/src/include/common/config.h
+++ b/src/include/common/config.h
@@ -36,7 +36,6 @@ static constexpr int BUFFER_POOL_SIZE = 10;                                   //
 static constexpr int LOG_BUFFER_SIZE = ((BUFFER_POOL_SIZE + 1) * PAGE_SIZE);  // size of a log buffer in byte
 static constexpr int BUCKET_SIZE = 50;                                        // size of extendible hash bucket
 
-
 using frame_id_t = int32_t;  // frame id type
 using page_id_t = int32_t;   // page id type
 using txn_id_t = int32_t;    // transaction id type

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -98,7 +98,9 @@ class ValueFactory {
       case TypeId::VARCHAR:
         ret_value = GetVarcharValue(nullptr, false, nullptr);
         break;
-      default: { throw Exception(ExceptionType::UNKNOWN_TYPE, "Attempting to create invalid null type"); }
+      default: {
+        throw Exception(ExceptionType::UNKNOWN_TYPE, "Attempting to create invalid null type");
+      }
     }
     return ret_value;
   }

--- a/test/buffer/buffer_pool_manager_test.cpp
+++ b/test/buffer/buffer_pool_manager_test.cpp
@@ -24,7 +24,7 @@ TEST(BufferPoolManagerTest, DISABLED_SampleTest) {
   const size_t buffer_pool_size = 10;
 
   auto *disk_manager = new DiskManager(db_name);
-  BufferPoolManager bpm{buffer_pool_size, disk_manager};
+  auto *bpm = new BufferPoolManager(buffer_pool_size, disk_manager);
 
   page_id_t page_id_temp;
   auto *page0 = bpm.NewPage(&page_id_temp);
@@ -69,6 +69,9 @@ TEST(BufferPoolManagerTest, DISABLED_SampleTest) {
   // Shutdown the disk manager and remove the temporary file we created.
   disk_manager->ShutDown();
   remove("test.db");
+
+  delete bpm;
+  delete disk_manager;
 }
 
 }  // namespace bustub

--- a/test/buffer/buffer_pool_manager_test.cpp
+++ b/test/buffer/buffer_pool_manager_test.cpp
@@ -27,7 +27,7 @@ TEST(BufferPoolManagerTest, DISABLED_SampleTest) {
   auto *bpm = new BufferPoolManager(buffer_pool_size, disk_manager);
 
   page_id_t page_id_temp;
-  auto *page0 = bpm.NewPage(&page_id_temp);
+  auto *page0 = bpm->NewPage(&page_id_temp);
 
   // Scenario: The buffer pool is empty. We should be able to create a new page.
   ASSERT_NE(nullptr, page0);
@@ -39,32 +39,32 @@ TEST(BufferPoolManagerTest, DISABLED_SampleTest) {
 
   // Scenario: We should be able to create new pages until we fill up the buffer pool.
   for (size_t i = 1; i < buffer_pool_size; ++i) {
-    EXPECT_NE(nullptr, bpm.NewPage(&page_id_temp));
+    EXPECT_NE(nullptr, bpm->NewPage(&page_id_temp));
   }
 
   // Scenario: Once the buffer pool is full, we should not be able to create any new pages.
   for (size_t i = buffer_pool_size; i < buffer_pool_size * 2; ++i) {
-    EXPECT_EQ(nullptr, bpm.NewPage(&page_id_temp));
+    EXPECT_EQ(nullptr, bpm->NewPage(&page_id_temp));
   }
 
   // Scenario: After unpinning pages {0, 1, 2, 3, 4} and pinning another 4 new pages,
   // there would still be one buffer page left for reading page 0.
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(true, bpm.UnpinPage(i, true));
+    EXPECT_EQ(true, bpm->UnpinPage(i, true));
   }
   for (int i = 0; i < 4; ++i) {
-    EXPECT_NE(nullptr, bpm.NewPage(&page_id_temp));
+    EXPECT_NE(nullptr, bpm->NewPage(&page_id_temp));
   }
 
   // Scenario: We should be able to fetch the data we wrote a while ago.
-  page0 = bpm.FetchPage(0);
+  page0 = bpm->FetchPage(0);
   EXPECT_EQ(0, strcmp(page0->GetData(), "Hello"));
 
   // Scenario: If we unpin page 0 and then make a new page, all the buffer pages should
   // now be pinned. Fetching page 0 should fail.
-  EXPECT_EQ(true, bpm.UnpinPage(0, true));
-  EXPECT_NE(nullptr, bpm.NewPage(&page_id_temp));
-  EXPECT_EQ(nullptr, bpm.FetchPage(0));
+  EXPECT_EQ(true, bpm->UnpinPage(0, true));
+  EXPECT_NE(nullptr, bpm->NewPage(&page_id_temp));
+  EXPECT_EQ(nullptr, bpm->FetchPage(0));
 
   // Shutdown the disk manager and remove the temporary file we created.
   disk_manager->ShutDown();


### PR DESCRIPTION
Google test is a bit of a pain. Even if you delete the disk manager, you'll leak memory. You need both disk manager and buffer pool manager to be pointers to be cleanly deleted.

We already fixed this in the autograder last/lastlast week, but we forgot to port it here. Hopefully the new infrastructure will fix this.