### PR TITLE
Apply naming conventions from Terrier

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,18 @@ Checks:     '
             -modernize-avoid-c-arrays,
             -readability-magic-numbers,
             '
+# TODO(WAN): To be enabled in Fall 2020.
+#CheckOptions:
+#  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
+#  - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
+#  - { key: readability-identifier-naming.FunctionCase,        value: CamelCase  }
+#  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
+#  - { key: readability-identifier-naming.MemberCase,          value: lower_case }
+#  - { key: readability-identifier-naming.MemberSuffix,        value: _          }
+#  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+#  - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
+#  - { key: readability-identifier-naming.UnionCase,           value: CamelCase  }
+#  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(src|test)/include'
 AnalyzeTemporaryDtors: true

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -14,10 +14,10 @@
 
 namespace bustub {
 
-std::atomic<bool> ENABLE_LOGGING(false);
+std::atomic<bool> enable_logging(false);
 
-std::chrono::duration<int64_t> LOG_TIMEOUT = std::chrono::seconds(1);
+std::chrono::duration<int64_t> log_timeout = std::chrono::seconds(1);
 
-std::chrono::milliseconds CYCLE_DETECTION_INTERVAL = std::chrono::milliseconds(50);
+std::chrono::milliseconds cycle_detection_interval = std::chrono::milliseconds(50);
 
 }  // namespace bustub

--- a/src/common/util/string_util.cpp
+++ b/src/common/util/string_util.cpp
@@ -102,19 +102,19 @@ std::string StringUtil::Prefix(const std::string &str, const std::string &prefix
 
 std::string StringUtil::FormatSize(uint64_t bytes) {
   // http://ubuntuforums.org/showpost.php?p=10215516&postcount=5
-  double BASE = 1024;
-  double KB = BASE;
-  double MB = KB * BASE;
-  double GB = MB * BASE;
+  double base = 1024;
+  double kb = base;
+  double mb = kb * base;
+  double gb = mb * base;
 
   std::ostringstream os;
 
-  if (bytes >= GB) {
-    os << std::fixed << std::setprecision(2) << (bytes / GB) << " GB";
-  } else if (bytes >= MB) {
-    os << std::fixed << std::setprecision(2) << (bytes / MB) << " MB";
-  } else if (bytes >= KB) {
-    os << std::fixed << std::setprecision(2) << (bytes / KB) << " KB";
+  if (bytes >= gb) {
+    os << std::fixed << std::setprecision(2) << (bytes / gb) << " GB";
+  } else if (bytes >= mb) {
+    os << std::fixed << std::setprecision(2) << (bytes / mb) << " MB";
+  } else if (bytes >= kb) {
+    os << std::fixed << std::setprecision(2) << (bytes / kb) << " KB";
   } else {
     os << std::to_string(bytes) + " bytes";
   }
@@ -122,11 +122,11 @@ std::string StringUtil::FormatSize(uint64_t bytes) {
 }
 
 std::string StringUtil::Bold(const std::string &str) {
-  std::string SET_PLAIN_TEXT = "\033[0;0m";
-  std::string SET_BOLD_TEXT = "\033[0;1m";
+  std::string set_plain_text = "\033[0;0m";
+  std::string set_bold_text = "\033[0;1m";
 
   std::ostringstream os;
-  os << SET_BOLD_TEXT << str << SET_PLAIN_TEXT;
+  os << set_bold_text << str << set_plain_text;
   return (os.str());
 }
 

--- a/src/concurrency/lock_manager.cpp
+++ b/src/concurrency/lock_manager.cpp
@@ -42,7 +42,7 @@ std::vector<std::pair<txn_id_t, txn_id_t>> LockManager::GetEdgeList() {
 void LockManager::RunCycleDetection() {
   BUSTUB_ASSERT(Detection(), "Detection should be enabled!");
   while (enable_cycle_detection_) {
-    std::this_thread::sleep_for(CYCLE_DETECTION_INTERVAL);
+    std::this_thread::sleep_for(cycle_detection_interval);
     {
       std::unique_lock<std::mutex> l(latch_);
       // TODO(student): remove the continue and add your cycle detection and abort code here

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -19,7 +19,7 @@
 
 namespace bustub {
 
-std::unordered_map<txn_id_t, Transaction *> TransactionManager::txn_map_ = {};
+std::unordered_map<txn_id_t, Transaction *> TransactionManager::txn_map = {};
 
 Transaction *TransactionManager::Begin(Transaction *txn) {
   // Acquire the global transaction latch in shared mode.
@@ -29,11 +29,11 @@ Transaction *TransactionManager::Begin(Transaction *txn) {
     txn = new Transaction(next_txn_id_++);
   }
 
-  if (ENABLE_LOGGING) {
+  if (enable_logging) {
     // TODO(student): Add logging here.
   }
 
-  txn_map_[txn->GetTransactionId()] = txn;
+  txn_map[txn->GetTransactionId()] = txn;
   return txn;
 }
 
@@ -53,7 +53,7 @@ void TransactionManager::Commit(Transaction *txn) {
   }
   write_set->clear();
 
-  if (ENABLE_LOGGING) {
+  if (enable_logging) {
     // TODO(student): add logging here
   }
 
@@ -83,7 +83,7 @@ void TransactionManager::Abort(Transaction *txn) {
   }
   write_set->clear();
 
-  if (ENABLE_LOGGING) {
+  if (enable_logging) {
     // TODO(student): add logging here
   }
 

--- a/src/include/common/config.h
+++ b/src/include/common/config.h
@@ -19,13 +19,13 @@
 namespace bustub {
 
 /** Cycle detection is performed every CYCLE_DETECTION_INTERVAL milliseconds. */
-extern std::chrono::milliseconds CYCLE_DETECTION_INTERVAL;
+extern std::chrono::milliseconds cycle_detection_interval;
 
 /** True if logging should be enabled, false otherwise. */
-extern std::atomic<bool> ENABLE_LOGGING;
+extern std::atomic<bool> enable_logging;
 
 /** If ENABLE_LOGGING is true, the log should be flushed to disk every LOG_TIMEOUT. */
-extern std::chrono::duration<int64_t> LOG_TIMEOUT;
+extern std::chrono::duration<int64_t> log_timeout;
 
 static constexpr int INVALID_PAGE_ID = -1;                                    // invalid page id
 static constexpr int INVALID_TXN_ID = -1;                                     // invalid transaction id

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -57,7 +57,7 @@ class Exception : public std::runtime_error {
   Exception(ExceptionType exception_type, const std::string &message)
       : std::runtime_error(message), type_(exception_type) {
     std::string exception_message =
-        "\nException Type :: " + ExpectionTypeToString(type) + "\nMessage :: " + message + "\n";
+        "\nException Type :: " + ExpectionTypeToString(type_) + "\nMessage :: " + message + "\n";
     std::cerr << exception_message;
   }
 

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -49,13 +49,13 @@ enum class ExceptionType {
 
 class Exception : public std::runtime_error {
  public:
-  explicit Exception(const std::string &message) : std::runtime_error(message), type(ExceptionType::INVALID) {
+  explicit Exception(const std::string &message) : std::runtime_error(message), type_(ExceptionType::INVALID) {
     std::string exception_message = "Message :: " + message + "\n";
     std::cerr << exception_message;
   }
 
   Exception(ExceptionType exception_type, const std::string &message)
-      : std::runtime_error(message), type(exception_type) {
+      : std::runtime_error(message), type_(exception_type) {
     std::string exception_message =
         "\nException Type :: " + ExpectionTypeToString(type) + "\nMessage :: " + message + "\n";
     std::cerr << exception_message;
@@ -87,7 +87,7 @@ class Exception : public std::runtime_error {
   }
 
  private:
-  ExceptionType type;
+  ExceptionType type_;
 };
 
 class NotImplementedException : public Exception {

--- a/src/include/common/logger.h
+++ b/src/include/common/logger.h
@@ -47,10 +47,10 @@ static constexpr cstr PastLastSlash(cstr a, cstr b) {
 
 static constexpr cstr PastLastSlash(cstr a) { return PastLastSlash(a, a); }
 
-#define __SHORT_FILE__                              \
-  ({                                                \
-    constexpr cstr sf__{past_last_slash(__FILE__)}; \
-    sf__;                                           \
+#define __SHORT_FILE__                            \
+  ({                                              \
+    constexpr cstr sf__{PastLastSlash(__FILE__)}; \
+    sf__;                                         \
   })
 
 // Log levels.
@@ -98,10 +98,10 @@ void OutputLogHeader(const char *file, int line, const char *func, int level);
 #if LOG_LEVEL <= LOG_LEVEL_ERROR
 #define LOG_ERROR_ENABLED
 // #pragma message("LOG_ERROR was enabled.")
-#define LOG_ERROR(...)                                                       \
-  outputLogHeader_(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_ERROR); \
-  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                 \
-  fprintf(LOG_OUTPUT_STREAM, "\n");                                          \
+#define LOG_ERROR(...)                                                      \
+  OutputLogHeader(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_ERROR); \
+  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                \
+  fprintf(LOG_OUTPUT_STREAM, "\n");                                         \
   ::fflush(stdout)
 #else
 #define LOG_ERROR(...) ((void)0)
@@ -113,10 +113,10 @@ void OutputLogHeader(const char *file, int line, const char *func, int level);
 #if LOG_LEVEL <= LOG_LEVEL_WARN
 #define LOG_WARN_ENABLED
 // #pragma message("LOG_WARN was enabled.")
-#define LOG_WARN(...)                                                       \
-  outputLogHeader_(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_WARN); \
-  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                \
-  fprintf(LOG_OUTPUT_STREAM, "\n");                                         \
+#define LOG_WARN(...)                                                      \
+  OutputLogHeader(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_WARN); \
+  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                               \
+  fprintf(LOG_OUTPUT_STREAM, "\n");                                        \
   ::fflush(stdout)
 #else
 #define LOG_WARN(...) ((void)0)
@@ -128,10 +128,10 @@ void OutputLogHeader(const char *file, int line, const char *func, int level);
 #if LOG_LEVEL <= LOG_LEVEL_INFO
 #define LOG_INFO_ENABLED
 // #pragma message("LOG_INFO was enabled.")
-#define LOG_INFO(...)                                                       \
-  outputLogHeader_(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_INFO); \
-  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                \
-  fprintf(LOG_OUTPUT_STREAM, "\n");                                         \
+#define LOG_INFO(...)                                                      \
+  OutputLogHeader(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_INFO); \
+  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                               \
+  fprintf(LOG_OUTPUT_STREAM, "\n");                                        \
   ::fflush(stdout)
 #else
 #define LOG_INFO(...) ((void)0)
@@ -143,10 +143,10 @@ void OutputLogHeader(const char *file, int line, const char *func, int level);
 #if LOG_LEVEL <= LOG_LEVEL_DEBUG
 #define LOG_DEBUG_ENABLED
 // #pragma message("LOG_DEBUG was enabled.")
-#define LOG_DEBUG(...)                                                       \
-  outputLogHeader_(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_DEBUG); \
-  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                 \
-  fprintf(LOG_OUTPUT_STREAM, "\n");                                          \
+#define LOG_DEBUG(...)                                                      \
+  OutputLogHeader(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_DEBUG); \
+  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                \
+  fprintf(LOG_OUTPUT_STREAM, "\n");                                         \
   ::fflush(stdout)
 #else
 #define LOG_DEBUG(...) ((void)0)
@@ -158,10 +158,10 @@ void OutputLogHeader(const char *file, int line, const char *func, int level);
 #if LOG_LEVEL <= LOG_LEVEL_TRACE
 #define LOG_TRACE_ENABLED
 // #pragma message("LOG_TRACE was enabled.")
-#define LOG_TRACE(...)                                                       \
-  outputLogHeader_(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_TRACE); \
-  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                 \
-  fprintf(LOG_OUTPUT_STREAM, "\n");                                          \
+#define LOG_TRACE(...)                                                      \
+  OutputLogHeader(__SHORT_FILE__, __LINE__, __FUNCTION__, LOG_LEVEL_TRACE); \
+  ::fprintf(LOG_OUTPUT_STREAM, __VA_ARGS__);                                \
+  fprintf(LOG_OUTPUT_STREAM, "\n");                                         \
   ::fflush(stdout)
 #else
 #define LOG_TRACE(...) ((void)0)

--- a/src/include/common/logger.h
+++ b/src/include/common/logger.h
@@ -41,11 +41,11 @@ namespace bustub {
 // https://blog.galowicz.de/2016/02/20/short_file_macro/
 using cstr = const char *;
 
-static constexpr cstr past_last_slash(cstr a, cstr b) {
-  return *a == '\0' ? b : *b == '/' ? past_last_slash(a + 1, a + 1) : past_last_slash(a + 1, b);
+static constexpr cstr PastLastSlash(cstr a, cstr b) {
+  return *a == '\0' ? b : *b == '/' ? PastLastSlash(a + 1, a + 1) : PastLastSlash(a + 1, b);
 }
 
-static constexpr cstr past_last_slash(cstr a) { return past_last_slash(a, a); }
+static constexpr cstr PastLastSlash(cstr a) { return PastLastSlash(a, a); }
 
 #define __SHORT_FILE__                              \
   ({                                                \
@@ -86,7 +86,7 @@ static constexpr int LOG_LEVEL = LOG_LEVEL_INFO;
 #define __FUNCTION__ ""
 #endif
 
-void outputLogHeader_(const char *file, int line, const char *func, int level);
+void OutputLogHeader(const char *file, int line, const char *func, int level);
 
 // Two convenient macros for debugging
 // 1. Logging macros.
@@ -169,7 +169,7 @@ void outputLogHeader_(const char *file, int line, const char *func, int level);
 
 // Output log message header in this format: [type] [file:line:function] time -
 // ex: [ERROR] [somefile.cpp:123:doSome()] 2008/07/06 10:00:00 -
-inline void outputLogHeader_(const char *file, int line, const char *func, int level) {
+inline void OutputLogHeader(const char *file, int line, const char *func, int level) {
   time_t t = ::time(nullptr);
   tm *curTime = localtime(&t);  // NOLINT
   char time_str[32];            // FIXME

--- a/src/include/common/rwmutex.h
+++ b/src/include/common/rwmutex.h
@@ -26,7 +26,7 @@ namespace bustub {
 class RWMutex {
   using mutex_t = std::mutex;
   using cond_t = std::condition_variable;
-  static const uint32_t max_readers_ = UINT_MAX;
+  static const uint32_t MAX_READERS = UINT_MAX;
 
  public:
   RWMutex() = default;
@@ -62,7 +62,7 @@ class RWMutex {
    */
   void RLock() {
     std::unique_lock<mutex_t> lock(mutex_);
-    while (writer_entered_ || reader_count_ == max_readers_) {
+    while (writer_entered_ || reader_count_ == MAX_READERS) {
       reader_.wait(lock);
     }
     reader_count_++;
@@ -79,7 +79,7 @@ class RWMutex {
         writer_.notify_one();
       }
     } else {
-      if (reader_count_ == max_readers_ - 1) {
+      if (reader_count_ == MAX_READERS - 1) {
         reader_.notify_one();
       }
     }

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -58,7 +58,7 @@ class TransactionManager {
    */
 
   /** The transaction map is a global list of all the running transactions in the system. */
-  static std::unordered_map<txn_id_t, Transaction *> txn_map_;
+  static std::unordered_map<txn_id_t, Transaction *> txn_map;
 
   /**
    * Locates and returns the transaction with the given transaction ID.
@@ -66,8 +66,8 @@ class TransactionManager {
    * @return the transaction with the given transaction id
    */
   static Transaction *GetTransaction(txn_id_t txn_id) {
-    assert(TransactionManager::txn_map_.find(txn_id) != TransactionManager::txn_map_.end());
-    auto *res = TransactionManager::txn_map_[txn_id];
+    assert(TransactionManager::txn_map.find(txn_id) != TransactionManager::txn_map.end());
+    auto *res = TransactionManager::txn_map[txn_id];
     assert(res != nullptr);
     return res;
   }

--- a/src/include/storage/index/generic_key.h
+++ b/src/include/storage/index/generic_key.h
@@ -67,7 +67,7 @@ class GenericKey {
   }
 
   // actual location of data, extends past the end.
-  char data[KeySize];
+  char data_[KeySize];
 };
 
 /**

--- a/src/include/storage/index/generic_key.h
+++ b/src/include/storage/index/generic_key.h
@@ -31,14 +31,14 @@ class GenericKey {
  public:
   inline void SetFromKey(const Tuple &tuple) {
     // intialize to 0
-    memset(data, 0, KeySize);
-    memcpy(data, tuple.GetData(), tuple.GetLength());
+    memset(data_, 0, KeySize);
+    memcpy(data_, tuple.GetData(), tuple.GetLength());
   }
 
   // NOTE: for test purpose only
   inline void SetFromInteger(int64_t key) {
-    memset(data, 0, KeySize);
-    memcpy(data, &key, sizeof(int64_t));
+    memset(data_, 0, KeySize);
+    memcpy(data_, &key, sizeof(int64_t));
   }
 
   inline Value ToValue(Schema *schema, uint32_t column_idx) const {
@@ -47,17 +47,17 @@ class GenericKey {
     const TypeId column_type = col.GetType();
     const bool is_inlined = col.IsInlined();
     if (is_inlined) {
-      data_ptr = (data + col.GetOffset());
+      data_ptr = (data_ + col.GetOffset());
     } else {
-      int32_t offset = *reinterpret_cast<int32_t *>(const_cast<char *>(data + col.GetOffset()));
-      data_ptr = (data + offset);
+      int32_t offset = *reinterpret_cast<int32_t *>(const_cast<char *>(data_ + col.GetOffset()));
+      data_ptr = (data_ + offset);
     }
     return Value::DeserializeFrom(data_ptr, column_type);
   }
 
   // NOTE: for test purpose only
   // interpret the first 8 bytes as int64_t from data vector
-  inline int64_t ToString() const { return *reinterpret_cast<int64_t *>(const_cast<char *>(data)); }
+  inline int64_t ToString() const { return *reinterpret_cast<int64_t *>(const_cast<char *>(data_)); }
 
   // NOTE: for test purpose only
   // interpret the first 8 bytes as int64_t from data vector

--- a/src/include/storage/table/table_heap.h
+++ b/src/include/storage/table/table_heap.h
@@ -108,12 +108,12 @@ class TableHeap {
   /**
    * Return the begin iterator of the table.
    */
-  TableIterator begin(Transaction *txn);
+  TableIterator Begin(Transaction *txn);
 
   /**
    * Return the end iterator of the table.
    */
-  TableIterator end();
+  TableIterator End();
 
   /**
    * Return the id of the first page of this table.

--- a/src/include/type/timestamp_type.h
+++ b/src/include/type/timestamp_type.h
@@ -20,7 +20,7 @@ namespace bustub {
 
 class TimestampType : public Type {
  public:
-  static constexpr uint64_t kUsecsPerDate = 86400000000UL;
+  static constexpr uint64_t K_USECS_PER_DATE = 86400000000UL;
 
   ~TimestampType() override = default;
   TimestampType();

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -40,7 +40,7 @@ class Type {
   static Value GetMinValue(TypeId type_id);
   static Value GetMaxValue(TypeId type_id);
 
-  inline static Type *GetInstance(TypeId type_id) { return kTypes[type_id]; }
+  inline static Type *GetInstance(TypeId type_id) { return k_types[type_id]; }
 
   inline TypeId GetTypeId() const { return type_id_; }
 
@@ -112,6 +112,6 @@ class Type {
   // The actual type ID
   TypeId type_id_;
   // Singleton instances.
-  static Type *kTypes[14];
+  static Type *k_types[14];
 };
 }  // namespace bustub

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -41,7 +41,7 @@ class Value {
   friend class VarlenType;
 
  public:
-  explicit Value(const TypeId type) : manage_data_(false), type_id_(type) { size_.len = BUSTUB_VALUE_NULL; }
+  explicit Value(const TypeId type) : manage_data_(false), type_id_(type) { size_.len_ = BUSTUB_VALUE_NULL; }
   // BOOLEAN and TINYINT
   Value(TypeId type, int8_t i);
   // DECIMAL
@@ -63,7 +63,7 @@ class Value {
   Value(const Value &other);
   Value &operator=(Value other);
   ~Value();
-  // nothrow
+  // NOLINTNEXTLINE
   friend void Swap(Value &first, Value &second) {
     std::swap(first.value_, second.value_);
     std::swap(first.size_, second.size_);
@@ -118,7 +118,7 @@ class Value {
 
   inline Value OperateNull(const Value &o) const { return Type::GetInstance(type_id_)->OperateNull(*this, o); }
   inline bool IsZero() const { return Type::GetInstance(type_id_)->IsZero(*this); }
-  inline bool IsNull() const { return size_.len == BUSTUB_VALUE_NULL; }
+  inline bool IsNull() const { return size_.len_ == BUSTUB_VALUE_NULL; }
 
   // Serialize this value into the given storage space. The inlined parameter
   // indicates whether we are allowed to inline this value into the storage

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -64,7 +64,7 @@ class Value {
   Value &operator=(Value other);
   ~Value();
   // nothrow
-  friend void swap(Value &first, Value &second) {
+  friend void Swap(Value &first, Value &second) {
     std::swap(first.value_, second.value_);
     std::swap(first.size_, second.size_);
     std::swap(first.manage_data_, second.manage_data_);
@@ -140,20 +140,20 @@ class Value {
  protected:
   // The actual value item
   union Val {
-    int8_t boolean;
-    int8_t tinyint;
-    int16_t smallint;
-    int32_t integer;
-    int64_t bigint;
-    double decimal;
-    uint64_t timestamp;
-    char *varlen;
-    const char *const_varlen;
+    int8_t boolean_;
+    int8_t tinyint_;
+    int16_t smallint_;
+    int32_t integer_;
+    int64_t bigint_;
+    double decimal_;
+    uint64_t timestamp_;
+    char *varlen_;
+    const char *const_varlen_;
   } value_;
 
   union {
-    uint32_t len;
-    TypeId elem_type_id;
+    uint32_t len_;
+    TypeId elem_type_id_;
   } size_;
 
   bool manage_data_;

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -411,11 +411,11 @@ class ValueFactory {
               (str[26] != '+' && str[26] != '-')) {
             throw Exception("Timestamp format error.");
           }
-          bool isDigit[29] = {true,  true, true, true,  false, true, true,  false, true, true,
+          bool is_digit[29] = {true,  true, true, true,  false, true, true,  false, true, true,
                               false, true, true, false, true,  true, false, true,  true, false,
                               true,  true, true, true,  true,  true, false, true,  true};
           for (int i = 0; i < 29; i++) {
-            if (isDigit[i]) {
+            if (is_digit[i]) {
               if (str[i] < '0' || str[i] > '9') {
                 throw Exception("Timestamp format error.");
               }

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -412,8 +412,8 @@ class ValueFactory {
             throw Exception("Timestamp format error.");
           }
           bool is_digit[29] = {true,  true, true, true,  false, true, true,  false, true, true,
-                              false, true, true, false, true,  true, false, true,  true, false,
-                              true,  true, true, true,  true,  true, false, true,  true};
+                               false, true, true, false, true,  true, false, true,  true, false,
+                               true,  true, true, true,  true,  true, false, true,  true};
           for (int i = 0; i < 29; i++) {
             if (is_digit[i]) {
               if (str[i] < '0' || str[i] > '9') {

--- a/src/storage/table/table_heap.cpp
+++ b/src/storage/table/table_heap.cpp
@@ -166,7 +166,7 @@ bool TableHeap::DeleteTableHeap() {
   return true;
 }
 
-TableIterator TableHeap::begin(Transaction *txn) {
+TableIterator TableHeap::Begin(Transaction *txn) {
   // Start an iterator from the first page.
   auto page = static_cast<TablePage *>(buffer_pool_manager_->FetchPage(first_page_id_));
   page->RLatch();
@@ -179,6 +179,6 @@ TableIterator TableHeap::begin(Transaction *txn) {
   return TableIterator(this, rid, txn);
 }
 
-TableIterator TableHeap::end() { return TableIterator(this, RID(INVALID_PAGE_ID, -1), nullptr); }
+TableIterator TableHeap::End() { return TableIterator(this, RID(INVALID_PAGE_ID, -1), nullptr); }
 
 }  // namespace bustub

--- a/src/storage/table/table_iterator.cpp
+++ b/src/storage/table/table_iterator.cpp
@@ -24,12 +24,12 @@ TableIterator::TableIterator(TableHeap *table_heap, RID rid, Transaction *txn)
 }
 
 const Tuple &TableIterator::operator*() {
-  assert(*this != table_heap_->end());
+  assert(*this != table_heap_->End());
   return *tuple_;
 }
 
 Tuple *TableIterator::operator->() {
-  assert(*this != table_heap_->end());
+  assert(*this != table_heap_->End());
   return tuple_;
 }
 
@@ -55,7 +55,7 @@ TableIterator &TableIterator::operator++() {
   }
   tuple_->rid_ = next_tuple_rid;
 
-  if (*this != table_heap_->end()) {
+  if (*this != table_heap_->End()) {
     table_heap_->GetTuple(tuple_->rid_, tuple_, txn_);
   }
   // release until copy the tuple

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -17,55 +17,55 @@
 
 #include "type/bigint_type.h"
 namespace bustub {
-#define BIGINT_COMPARE_FUNC(OP)                                          \
-  switch (right.GetTypeId()) {                                           \
-    case TypeId::TINYINT:                                                \
-      return GetCmpBool(left.value_.bigint OP right.GetAs<int8_t>());    \
-    case TypeId::SMALLINT:                                               \
-      return GetCmpBool(left.value_.bigint OP right.GetAs<int16_t>());   \
-    case TypeId::INTEGER:                                                \
-      return GetCmpBool(left.value_.bigint OP right.GetAs<int32_t>());   \
-    case TypeId::BIGINT:                                                 \
-      return GetCmpBool(left.value_.bigint OP right.GetAs<int64_t>());   \
-    case TypeId::DECIMAL:                                                \
-      return GetCmpBool(left.value_.bigint OP right.GetAs<double>());    \
-    case TypeId::VARCHAR: {                                              \
-      auto r_value = right.CastAs(TypeId::BIGINT);                       \
-      return GetCmpBool(left.value_.bigint OP r_value.GetAs<int64_t>()); \
-    }                                                                    \
-    default:                                                             \
-      break;                                                             \
+#define BIGINT_COMPARE_FUNC(OP)                                           \
+  switch (right.GetTypeId()) {                                            \
+    case TypeId::TINYINT:                                                 \
+      return GetCmpBool(left.value_.bigint_ OP right.GetAs<int8_t>());    \
+    case TypeId::SMALLINT:                                                \
+      return GetCmpBool(left.value_.bigint_ OP right.GetAs<int16_t>());   \
+    case TypeId::INTEGER:                                                 \
+      return GetCmpBool(left.value_.bigint_ OP right.GetAs<int32_t>());   \
+    case TypeId::BIGINT:                                                  \
+      return GetCmpBool(left.value_.bigint_ OP right.GetAs<int64_t>());   \
+    case TypeId::DECIMAL:                                                 \
+      return GetCmpBool(left.value_.bigint_ OP right.GetAs<double>());    \
+    case TypeId::VARCHAR: {                                               \
+      auto r_value = right.CastAs(TypeId::BIGINT);                        \
+      return GetCmpBool(left.value_.bigint_ OP r_value.GetAs<int64_t>()); \
+    }                                                                     \
+    default:                                                              \
+      break;                                                              \
   }  // SWITCH
 
-#define BIGINT_MODIFY_FUNC(METHOD, OP)                                            \
-  switch (right.GetTypeId()) {                                                    \
-    case TypeId::TINYINT:                                                         \
-      /* NOLINTNEXTLINE */                                                        \
-      return METHOD<int64_t, int8_t>(left, right);                                \
-    case TypeId::SMALLINT:                                                        \
-      /* NOLINTNEXTLINE */                                                        \
-      return METHOD<int64_t, int16_t>(left, right);                               \
-    case TypeId::INTEGER:                                                         \
-      /* NOLINTNEXTLINE */                                                        \
-      return METHOD<int64_t, int32_t>(left, right);                               \
-    case TypeId::BIGINT:                                                          \
-      /* NOLINTNEXTLINE */                                                        \
-      return METHOD<int64_t, int64_t>(left, right);                               \
-    case TypeId::DECIMAL:                                                         \
-      /* NOLINTNEXTLINE */                                                        \
-      return Value(TypeId::DECIMAL, left.value_.bigint OP right.GetAs<double>()); \
-    case TypeId::VARCHAR: {                                                       \
-      auto r_value = right.CastAs(TypeId::BIGINT);                                \
-      /* NOLINTNEXTLINE */                                                        \
-      return METHOD<int64_t, int64_t>(left, r_value);                             \
-    }                                                                             \
-    default:                                                                      \
-      break;                                                                      \
+#define BIGINT_MODIFY_FUNC(METHOD, OP)                                             \
+  switch (right.GetTypeId()) {                                                     \
+    case TypeId::TINYINT:                                                          \
+      /* NOLINTNEXTLINE */                                                         \
+      return METHOD<int64_t, int8_t>(left, right);                                 \
+    case TypeId::SMALLINT:                                                         \
+      /* NOLINTNEXTLINE */                                                         \
+      return METHOD<int64_t, int16_t>(left, right);                                \
+    case TypeId::INTEGER:                                                          \
+      /* NOLINTNEXTLINE */                                                         \
+      return METHOD<int64_t, int32_t>(left, right);                                \
+    case TypeId::BIGINT:                                                           \
+      /* NOLINTNEXTLINE */                                                         \
+      return METHOD<int64_t, int64_t>(left, right);                                \
+    case TypeId::DECIMAL:                                                          \
+      /* NOLINTNEXTLINE */                                                         \
+      return Value(TypeId::DECIMAL, left.value_.bigint_ OP right.GetAs<double>()); \
+    case TypeId::VARCHAR: {                                                        \
+      auto r_value = right.CastAs(TypeId::BIGINT);                                 \
+      /* NOLINTNEXTLINE */                                                         \
+      return METHOD<int64_t, int64_t>(left, r_value);                              \
+    }                                                                              \
+    default:                                                                       \
+      break;                                                                       \
   }  // SWITCH
 
 BigintType::BigintType() : IntegerParentType(BIGINT) {}
 
-bool BigintType::IsZero(const Value &val) const { return (val.value_.bigint == 0); }
+bool BigintType::IsZero(const Value &val) const { return (val.value_.bigint_ == 0); }
 
 Value BigintType::Add(const Value &left, const Value &right) const {
   assert(left.CheckInteger());
@@ -139,7 +139,7 @@ Value BigintType::Modulo(const Value &left, const Value &right) const {
     case TypeId::BIGINT:
       return ModuloValue<int64_t, int64_t>(left, right);
     case TypeId::DECIMAL:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.bigint, right.GetAs<double>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.bigint_, right.GetAs<double>()));
     case TypeId::VARCHAR: {
       auto r_value = right.CastAs(TypeId::BIGINT);
       return ModuloValue<int64_t, int64_t>(left, r_value);
@@ -156,10 +156,10 @@ Value BigintType::Sqrt(const Value &val) const {
     return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
   }
 
-  if (val.value_.bigint < 0) {
+  if (val.value_.bigint_ < 0) {
     throw Exception(ExceptionType::DECIMAL, "Cannot take square root of a negative number.");
   }
-  return Value(TypeId::DECIMAL, std::sqrt(val.value_.bigint));
+  return Value(TypeId::DECIMAL, std::sqrt(val.value_.bigint_));
 }
 
 Value BigintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
@@ -255,11 +255,11 @@ std::string BigintType::ToString(const Value &val) const {
   if (val.IsNull()) {
     return "bigint_null";
   }
-  return std::to_string(val.value_.bigint);
+  return std::to_string(val.value_.bigint_);
 }
 
 void BigintType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<int64_t *>(storage) = val.value_.bigint;
+  *reinterpret_cast<int64_t *>(storage) = val.value_.bigint_;
 }
 
 // Deserialize a value of the given type from the given storage space.
@@ -268,7 +268,7 @@ Value BigintType::DeserializeFrom(const char *storage) const {
   return Value(type_id_, val);
 }
 
-Value BigintType::Copy(const Value &val) const { return Value(TypeId::BIGINT, val.value_.bigint); }
+Value BigintType::Copy(const Value &val) const { return Value(TypeId::BIGINT, val.value_.bigint_); }
 
 Value BigintType::CastAs(const Value &val, const TypeId type_id) const {
   switch (type_id) {

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -16,7 +16,7 @@
 #include "type/boolean_type.h"
 
 namespace bustub {
-#define BOOLEAN_COMPARE_FUNC(OP) GetCmpBool(left.value_.boolean OP right.CastAs(TypeId::BOOLEAN).value_.boolean)
+#define BOOLEAN_COMPARE_FUNC(OP) GetCmpBool(left.value_.boolean_ OP right.CastAs(TypeId::BOOLEAN).value_.boolean_)
 
 BooleanType::BooleanType() : Type(TypeId::BOOLEAN) {}
 
@@ -76,17 +76,17 @@ CmpBool BooleanType::CompareGreaterThanEquals(const Value &left, const Value &ri
 
 std::string BooleanType::ToString(const Value &val) const {
   assert(GetTypeId() == TypeId::BOOLEAN);
-  if (val.value_.boolean == 1) {
+  if (val.value_.boolean_ == 1) {
     return "true";
   }
-  if (val.value_.boolean == 0) {
+  if (val.value_.boolean_ == 0) {
     return "false";
   }
   return "boolean_null";
 }
 
 void BooleanType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<int8_t *>(storage) = val.value_.boolean;
+  *reinterpret_cast<int8_t *>(storage) = val.value_.boolean_;
 }
 
 // Deserialize a value of the given type from the given storage space.
@@ -95,7 +95,7 @@ Value BooleanType::DeserializeFrom(const char *storage) const {
   return Value(TypeId::BOOLEAN, val);
 }
 
-Value BooleanType::Copy(const Value &val) const { return Value(TypeId::BOOLEAN, val.value_.boolean); }
+Value BooleanType::Copy(const Value &val) const { return Value(TypeId::BOOLEAN, val.value_.boolean_); }
 
 Value BooleanType::CastAs(const Value &val, const TypeId type_id) const {
   switch (type_id) {

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -19,44 +19,44 @@
 #include "type/decimal_type.h"
 
 namespace bustub {
-#define DECIMAL_COMPARE_FUNC(OP)                                         \
-  switch (right.GetTypeId()) {                                           \
-    case TypeId::TINYINT:                                                \
-      return GetCmpBool(left.value_.decimal OP right.GetAs<int8_t>());   \
-    case TypeId::SMALLINT:                                               \
-      return GetCmpBool(left.value_.decimal OP right.GetAs<int16_t>());  \
-    case TypeId::INTEGER:                                                \
-      return GetCmpBool(left.value_.decimal OP right.GetAs<int32_t>());  \
-    case TypeId::BIGINT:                                                 \
-      return GetCmpBool(left.value_.decimal OP right.GetAs<int64_t>());  \
-    case TypeId::DECIMAL:                                                \
-      return GetCmpBool(left.value_.decimal OP right.GetAs<double>());   \
-    case TypeId::VARCHAR: {                                              \
-      auto r_value = right.CastAs(TypeId::DECIMAL);                      \
-      return GetCmpBool(left.value_.decimal OP r_value.GetAs<double>()); \
-    }                                                                    \
-    default:                                                             \
-      break;                                                             \
+#define DECIMAL_COMPARE_FUNC(OP)                                          \
+  switch (right.GetTypeId()) {                                            \
+    case TypeId::TINYINT:                                                 \
+      return GetCmpBool(left.value_.decimal_ OP right.GetAs<int8_t>());   \
+    case TypeId::SMALLINT:                                                \
+      return GetCmpBool(left.value_.decimal_ OP right.GetAs<int16_t>());  \
+    case TypeId::INTEGER:                                                 \
+      return GetCmpBool(left.value_.decimal_ OP right.GetAs<int32_t>());  \
+    case TypeId::BIGINT:                                                  \
+      return GetCmpBool(left.value_.decimal_ OP right.GetAs<int64_t>());  \
+    case TypeId::DECIMAL:                                                 \
+      return GetCmpBool(left.value_.decimal_ OP right.GetAs<double>());   \
+    case TypeId::VARCHAR: {                                               \
+      auto r_value = right.CastAs(TypeId::DECIMAL);                       \
+      return GetCmpBool(left.value_.decimal_ OP r_value.GetAs<double>()); \
+    }                                                                     \
+    default:                                                              \
+      break;                                                              \
   }  // SWITCH
 
-#define DECIMAL_MODIFY_FUNC(OP)                                                      \
-  switch (right.GetTypeId()) {                                                       \
-    case TypeId::TINYINT:                                                            \
-      return Value(TypeId::DECIMAL, left.value_.decimal OP right.GetAs<int8_t>());   \
-    case TypeId::SMALLINT:                                                           \
-      return Value(TypeId::DECIMAL, left.value_.decimal OP right.GetAs<int16_t>());  \
-    case TypeId::INTEGER:                                                            \
-      return Value(TypeId::DECIMAL, left.value_.decimal OP right.GetAs<int32_t>());  \
-    case TypeId::BIGINT:                                                             \
-      return Value(TypeId::DECIMAL, left.value_.decimal OP right.GetAs<int64_t>());  \
-    case TypeId::DECIMAL:                                                            \
-      return Value(TypeId::DECIMAL, left.value_.decimal OP right.GetAs<double>());   \
-    case TypeId::VARCHAR: {                                                          \
-      auto r_value = right.CastAs(TypeId::DECIMAL);                                  \
-      return Value(TypeId::DECIMAL, left.value_.decimal OP r_value.GetAs<double>()); \
-    }                                                                                \
-    default:                                                                         \
-      break;                                                                         \
+#define DECIMAL_MODIFY_FUNC(OP)                                                       \
+  switch (right.GetTypeId()) {                                                        \
+    case TypeId::TINYINT:                                                             \
+      return Value(TypeId::DECIMAL, left.value_.decimal_ OP right.GetAs<int8_t>());   \
+    case TypeId::SMALLINT:                                                            \
+      return Value(TypeId::DECIMAL, left.value_.decimal_ OP right.GetAs<int16_t>());  \
+    case TypeId::INTEGER:                                                             \
+      return Value(TypeId::DECIMAL, left.value_.decimal_ OP right.GetAs<int32_t>());  \
+    case TypeId::BIGINT:                                                              \
+      return Value(TypeId::DECIMAL, left.value_.decimal_ OP right.GetAs<int64_t>());  \
+    case TypeId::DECIMAL:                                                             \
+      return Value(TypeId::DECIMAL, left.value_.decimal_ OP right.GetAs<double>());   \
+    case TypeId::VARCHAR: {                                                           \
+      auto r_value = right.CastAs(TypeId::DECIMAL);                                   \
+      return Value(TypeId::DECIMAL, left.value_.decimal_ OP r_value.GetAs<double>()); \
+    }                                                                                 \
+    default:                                                                          \
+      break;                                                                          \
   }  // SWITCH
 
 // static inline double ValMod(double x, double y) {
@@ -67,7 +67,7 @@ DecimalType::DecimalType() : NumericType(TypeId::DECIMAL) {}
 
 bool DecimalType::IsZero(const Value &val) const {
   assert(GetTypeId() == TypeId::DECIMAL);
-  return (val.value_.decimal == 0);
+  return (val.value_.decimal_ == 0);
 }
 
 Value DecimalType::Add(const Value &left, const Value &right) const {
@@ -132,18 +132,18 @@ Value DecimalType::Modulo(const Value &left, const Value &right) const {
   }
   switch (right.GetTypeId()) {
     case TypeId::TINYINT:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal, right.GetAs<int8_t>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal_, right.GetAs<int8_t>()));
     case TypeId::SMALLINT:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal, right.GetAs<int16_t>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal_, right.GetAs<int16_t>()));
     case TypeId::INTEGER:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal, right.GetAs<int32_t>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal_, right.GetAs<int32_t>()));
     case TypeId::BIGINT:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal, right.GetAs<int64_t>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal_, right.GetAs<int64_t>()));
     case TypeId::DECIMAL:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal, right.GetAs<double>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal_, right.GetAs<double>()));
     case TypeId::VARCHAR: {
       auto r_value = right.CastAs(TypeId::DECIMAL);
-      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal, r_value.GetAs<double>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.decimal_, r_value.GetAs<double>()));
     }
     default:
       break;
@@ -182,10 +182,10 @@ Value DecimalType::Sqrt(const Value &val) const {
   if (val.IsNull()) {
     return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
   }
-  if (val.value_.decimal < 0) {
+  if (val.value_.decimal_ < 0) {
     throw Exception(ExceptionType::DECIMAL, "Cannot take square root of a negative number.");
   }
-  return Value(TypeId::DECIMAL, std::sqrt(val.value_.decimal));
+  return Value(TypeId::DECIMAL, std::sqrt(val.value_.decimal_));
 }
 
 Value DecimalType::OperateNull(const Value &left __attribute__((unused)),
@@ -321,11 +321,11 @@ std::string DecimalType::ToString(const Value &val) const {
   if (val.IsNull()) {
     return "decimal_null";
   }
-  return std::to_string(val.value_.decimal);
+  return std::to_string(val.value_.decimal_);
 }
 
 void DecimalType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<double *>(storage) = val.value_.decimal;
+  *reinterpret_cast<double *>(storage) = val.value_.decimal_;
 }
 
 // Deserialize a value of the given type from the given storage space.
@@ -334,5 +334,5 @@ Value DecimalType::DeserializeFrom(const char *storage) const {
   return Value(type_id_, val);
 }
 
-Value DecimalType::Copy(const Value &val) const { return Value(TypeId::DECIMAL, val.value_.decimal); }
+Value DecimalType::Copy(const Value &val) const { return Value(TypeId::DECIMAL, val.value_.decimal_); }
 }  // namespace bustub

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -18,54 +18,54 @@
 #include "type/integer_type.h"
 
 namespace bustub {
-#define INT_COMPARE_FUNC(OP)                                              \
-  switch (right.GetTypeId()) {                                            \
-    case TypeId::TINYINT:                                                 \
-      return GetCmpBool(left.value_.integer OP right.GetAs<int8_t>());    \
-    case TypeId::SMALLINT:                                                \
-      return GetCmpBool(left.value_.integer OP right.GetAs<int16_t>());   \
-    case TypeId::INTEGER:                                                 \
-      return GetCmpBool(left.value_.integer OP right.GetAs<int32_t>());   \
-    case TypeId::BIGINT:                                                  \
-      return GetCmpBool(left.value_.integer OP right.GetAs<int64_t>());   \
-    case TypeId::DECIMAL:                                                 \
-      return GetCmpBool(left.value_.integer OP right.GetAs<double>());    \
-    case TypeId::VARCHAR: {                                               \
-      auto r_value = right.CastAs(TypeId::INTEGER);                       \
-      return GetCmpBool(left.value_.integer OP r_value.GetAs<int32_t>()); \
-    }                                                                     \
-    default:                                                              \
-      break;                                                              \
+#define INT_COMPARE_FUNC(OP)                                               \
+  switch (right.GetTypeId()) {                                             \
+    case TypeId::TINYINT:                                                  \
+      return GetCmpBool(left.value_.integer_ OP right.GetAs<int8_t>());    \
+    case TypeId::SMALLINT:                                                 \
+      return GetCmpBool(left.value_.integer_ OP right.GetAs<int16_t>());   \
+    case TypeId::INTEGER:                                                  \
+      return GetCmpBool(left.value_.integer_ OP right.GetAs<int32_t>());   \
+    case TypeId::BIGINT:                                                   \
+      return GetCmpBool(left.value_.integer_ OP right.GetAs<int64_t>());   \
+    case TypeId::DECIMAL:                                                  \
+      return GetCmpBool(left.value_.integer_ OP right.GetAs<double>());    \
+    case TypeId::VARCHAR: {                                                \
+      auto r_value = right.CastAs(TypeId::INTEGER);                        \
+      return GetCmpBool(left.value_.integer_ OP r_value.GetAs<int32_t>()); \
+    }                                                                      \
+    default:                                                               \
+      break;                                                               \
   }  // SWITCH
 
-#define INT_MODIFY_FUNC(METHOD, OP)                                                \
-  switch (right.GetTypeId()) {                                                     \
-    case TypeId::TINYINT:                                                          \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int32_t, int8_t>(left, right);                                 \
-    case TypeId::SMALLINT:                                                         \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int32_t, int16_t>(left, right);                                \
-    case TypeId::INTEGER:                                                          \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int32_t, int32_t>(left, right);                                \
-    case TypeId::BIGINT:                                                           \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int32_t, int64_t>(left, right);                                \
-    case TypeId::DECIMAL:                                                          \
-      return Value(TypeId::DECIMAL, left.value_.integer OP right.GetAs<double>()); \
-    case TypeId::VARCHAR: {                                                        \
-      auto r_value = right.CastAs(TypeId::INTEGER);                                \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int32_t, int32_t>(left, r_value);                              \
-    }                                                                              \
-    default:                                                                       \
-      break;                                                                       \
+#define INT_MODIFY_FUNC(METHOD, OP)                                                 \
+  switch (right.GetTypeId()) {                                                      \
+    case TypeId::TINYINT:                                                           \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int32_t, int8_t>(left, right);                                  \
+    case TypeId::SMALLINT:                                                          \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int32_t, int16_t>(left, right);                                 \
+    case TypeId::INTEGER:                                                           \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int32_t, int32_t>(left, right);                                 \
+    case TypeId::BIGINT:                                                            \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int32_t, int64_t>(left, right);                                 \
+    case TypeId::DECIMAL:                                                           \
+      return Value(TypeId::DECIMAL, left.value_.integer_ OP right.GetAs<double>()); \
+    case TypeId::VARCHAR: {                                                         \
+      auto r_value = right.CastAs(TypeId::INTEGER);                                 \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int32_t, int32_t>(left, r_value);                               \
+    }                                                                               \
+    default:                                                                        \
+      break;                                                                        \
   }  // SWITCH
 
 IntegerType::IntegerType(TypeId type) : IntegerParentType(type) {}
 
-bool IntegerType::IsZero(const Value &val) const { return (val.value_.integer == 0); }
+bool IntegerType::IsZero(const Value &val) const { return (val.value_.integer_ == 0); }
 
 Value IntegerType::Add(const Value &left, const Value &right) const {
   assert(left.CheckInteger());
@@ -139,7 +139,7 @@ Value IntegerType::Modulo(const Value &left, const Value &right) const {
     case TypeId::BIGINT:
       return ModuloValue<int32_t, int64_t>(left, right);
     case TypeId::DECIMAL:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.integer, right.GetAs<double>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.integer_, right.GetAs<double>()));
     case TypeId::VARCHAR: {
       auto r_value = right.CastAs(TypeId::INTEGER);
       return ModuloValue<int32_t, int32_t>(left, r_value);
@@ -157,10 +157,10 @@ Value IntegerType::Sqrt(const Value &val) const {
     return OperateNull(val, val);
   }
 
-  if (val.value_.integer < 0) {
+  if (val.value_.integer_ < 0) {
     throw Exception(ExceptionType::DECIMAL, "Cannot take square root of a negative number.");
   }
-  return Value(TypeId::DECIMAL, std::sqrt(val.value_.integer));
+  return Value(TypeId::DECIMAL, std::sqrt(val.value_.integer_));
 }
 
 Value IntegerType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
@@ -259,11 +259,11 @@ std::string IntegerType::ToString(const Value &val) const {
   if (val.IsNull()) {
     return "integer_null";
   }
-  return std::to_string(val.value_.integer);
+  return std::to_string(val.value_.integer_);
 }
 
 void IntegerType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<int32_t *>(storage) = val.value_.integer;
+  *reinterpret_cast<int32_t *>(storage) = val.value_.integer_;
 }
 
 // Deserialize a value of the given type from the given storage space.
@@ -274,7 +274,7 @@ Value IntegerType::DeserializeFrom(const char *storage) const {
 
 Value IntegerType::Copy(const Value &val) const {
   assert(val.CheckInteger());
-  return Value(val.GetTypeId(), val.value_.integer);
+  return Value(val.GetTypeId(), val.value_.integer_);
 }
 
 Value IntegerType::CastAs(const Value &val, const TypeId type_id) const {

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -18,54 +18,54 @@
 #include "type/smallint_type.h"
 
 namespace bustub {
-#define SMALLINT_COMPARE_FUNC(OP)                                          \
-  switch (right.GetTypeId()) {                                             \
-    case TypeId::TINYINT:                                                  \
-      return GetCmpBool(left.value_.smallint OP right.GetAs<int8_t>());    \
-    case TypeId::SMALLINT:                                                 \
-      return GetCmpBool(left.value_.smallint OP right.GetAs<int16_t>());   \
-    case TypeId::INTEGER:                                                  \
-      return GetCmpBool(left.value_.smallint OP right.GetAs<int32_t>());   \
-    case TypeId::BIGINT:                                                   \
-      return GetCmpBool(left.value_.smallint OP right.GetAs<int64_t>());   \
-    case TypeId::DECIMAL:                                                  \
-      return GetCmpBool(left.value_.smallint OP right.GetAs<double>());    \
-    case TypeId::VARCHAR: {                                                \
-      auto r_value = right.CastAs(TypeId::SMALLINT);                       \
-      return GetCmpBool(left.value_.smallint OP r_value.GetAs<int16_t>()); \
-    }                                                                      \
-    default:                                                               \
-      break;                                                               \
+#define SMALLINT_COMPARE_FUNC(OP)                                           \
+  switch (right.GetTypeId()) {                                              \
+    case TypeId::TINYINT:                                                   \
+      return GetCmpBool(left.value_.smallint_ OP right.GetAs<int8_t>());    \
+    case TypeId::SMALLINT:                                                  \
+      return GetCmpBool(left.value_.smallint_ OP right.GetAs<int16_t>());   \
+    case TypeId::INTEGER:                                                   \
+      return GetCmpBool(left.value_.smallint_ OP right.GetAs<int32_t>());   \
+    case TypeId::BIGINT:                                                    \
+      return GetCmpBool(left.value_.smallint_ OP right.GetAs<int64_t>());   \
+    case TypeId::DECIMAL:                                                   \
+      return GetCmpBool(left.value_.smallint_ OP right.GetAs<double>());    \
+    case TypeId::VARCHAR: {                                                 \
+      auto r_value = right.CastAs(TypeId::SMALLINT);                        \
+      return GetCmpBool(left.value_.smallint_ OP r_value.GetAs<int16_t>()); \
+    }                                                                       \
+    default:                                                                \
+      break;                                                                \
   }  // SWITCH
 
-#define SMALLINT_MODIFY_FUNC(METHOD, OP)                                            \
-  switch (right.GetTypeId()) {                                                      \
-    case TypeId::TINYINT:                                                           \
-      /* NOLINTNEXTLINE */                                                          \
-      return METHOD<int16_t, int8_t>(left, right);                                  \
-    case TypeId::SMALLINT:                                                          \
-      /* NOLINTNEXTLINE */                                                          \
-      return METHOD<int16_t, int16_t>(left, right);                                 \
-    case TypeId::INTEGER:                                                           \
-      /* NOLINTNEXTLINE */                                                          \
-      return METHOD<int16_t, int32_t>(left, right);                                 \
-    case TypeId::BIGINT:                                                            \
-      /* NOLINTNEXTLINE */                                                          \
-      return METHOD<int16_t, int64_t>(left, right);                                 \
-    case TypeId::DECIMAL:                                                           \
-      return Value(TypeId::DECIMAL, left.value_.smallint OP right.GetAs<double>()); \
-    case TypeId::VARCHAR: {                                                         \
-      auto r_value = right.CastAs(TypeId::SMALLINT);                                \
-      /* NOLINTNEXTLINE */                                                          \
-      return METHOD<int16_t, int16_t>(left, r_value);                               \
-    }                                                                               \
-    default:                                                                        \
-      break;                                                                        \
+#define SMALLINT_MODIFY_FUNC(METHOD, OP)                                             \
+  switch (right.GetTypeId()) {                                                       \
+    case TypeId::TINYINT:                                                            \
+      /* NOLINTNEXTLINE */                                                           \
+      return METHOD<int16_t, int8_t>(left, right);                                   \
+    case TypeId::SMALLINT:                                                           \
+      /* NOLINTNEXTLINE */                                                           \
+      return METHOD<int16_t, int16_t>(left, right);                                  \
+    case TypeId::INTEGER:                                                            \
+      /* NOLINTNEXTLINE */                                                           \
+      return METHOD<int16_t, int32_t>(left, right);                                  \
+    case TypeId::BIGINT:                                                             \
+      /* NOLINTNEXTLINE */                                                           \
+      return METHOD<int16_t, int64_t>(left, right);                                  \
+    case TypeId::DECIMAL:                                                            \
+      return Value(TypeId::DECIMAL, left.value_.smallint_ OP right.GetAs<double>()); \
+    case TypeId::VARCHAR: {                                                          \
+      auto r_value = right.CastAs(TypeId::SMALLINT);                                 \
+      /* NOLINTNEXTLINE */                                                           \
+      return METHOD<int16_t, int16_t>(left, r_value);                                \
+    }                                                                                \
+    default:                                                                         \
+      break;                                                                         \
   }  // SWITCH
 
 SmallintType::SmallintType() : IntegerParentType(TypeId::SMALLINT) {}
 
-bool SmallintType::IsZero(const Value &val) const { return (val.value_.smallint == 0); }
+bool SmallintType::IsZero(const Value &val) const { return (val.value_.smallint_ == 0); }
 
 Value SmallintType::Add(const Value &left, const Value &right) const {
   assert(left.CheckInteger());
@@ -140,7 +140,7 @@ Value SmallintType::Modulo(const Value &left, const Value &right) const {
     case TypeId::BIGINT:
       return ModuloValue<int16_t, int64_t>(left, right);
     case TypeId::DECIMAL:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.smallint, right.GetAs<double>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.smallint_, right.GetAs<double>()));
     case TypeId::VARCHAR: {
       auto r_value = right.CastAs(TypeId::SMALLINT);
       return ModuloValue<int16_t, int16_t>(left, r_value);
@@ -157,10 +157,10 @@ Value SmallintType::Sqrt(const Value &val) const {
     return Value(TypeId::DECIMAL, static_cast<double>(BUSTUB_DECIMAL_NULL));
   }
 
-  if (val.value_.smallint < 0) {
+  if (val.value_.smallint_ < 0) {
     throw Exception(ExceptionType::DECIMAL, "Cannot take square root of a negative number.");
   }
-  return Value(TypeId::DECIMAL, std::sqrt(val.value_.smallint));
+  return Value(TypeId::DECIMAL, std::sqrt(val.value_.smallint_));
 }
 
 Value SmallintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
@@ -261,22 +261,22 @@ std::string SmallintType::ToString(const Value &val) const {
       if (val.IsNull()) {
         return "tinyint_null";
       }
-      return std::to_string(val.value_.tinyint);
+      return std::to_string(val.value_.tinyint_);
     case TypeId::SMALLINT:
       if (val.IsNull()) {
         return "smallint_null";
       }
-      return std::to_string(val.value_.smallint);
+      return std::to_string(val.value_.smallint_);
     case TypeId::INTEGER:
       if (val.IsNull()) {
         return "integer_null";
       }
-      return std::to_string(val.value_.integer);
+      return std::to_string(val.value_.integer_);
     case TypeId::BIGINT:
       if (val.IsNull()) {
         return "bigint_null";
       }
-      return std::to_string(val.value_.bigint);
+      return std::to_string(val.value_.bigint_);
     default:
       break;
   }
@@ -284,7 +284,7 @@ std::string SmallintType::ToString(const Value &val) const {
 }
 
 void SmallintType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<int16_t *>(storage) = val.value_.smallint;
+  *reinterpret_cast<int16_t *>(storage) = val.value_.smallint_;
 }
 
 // Deserialize a value of the given type from the given storage space.
@@ -296,7 +296,7 @@ Value SmallintType::DeserializeFrom(const char *storage) const {
 Value SmallintType::Copy(const Value &val) const {
   assert(val.CheckInteger());
 
-  return Value(TypeId::SMALLINT, val.value_.smallint);
+  return Value(TypeId::SMALLINT, val.value_.smallint_);
 
   throw Exception("type error");
 }

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -96,7 +96,7 @@ std::string TimestampType::ToString(const Value &val) const {
   if (val.IsNull()) {
     return "timestamp_null";
   }
-  uint64_t tm = val.value_.timestamp;
+  uint64_t tm = val.value_.timestamp_;
   auto micro = static_cast<uint32_t>(tm % 1000000);
   tm /= 1000000;
   auto second = static_cast<uint32_t>(tm % 100000);
@@ -131,7 +131,7 @@ std::string TimestampType::ToString(const Value &val) const {
 }
 
 void TimestampType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<uint64_t *>(storage) = val.value_.timestamp;
+  *reinterpret_cast<uint64_t *>(storage) = val.value_.timestamp_;
 }
 
 // Deserialize a value of the given type from the given storage space.

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -19,54 +19,54 @@
 #include "type/tinyint_type.h"
 
 namespace bustub {
-#define TINYINT_COMPARE_FUNC(OP)                                         \
-  switch (right.GetTypeId()) {                                           \
-    case TypeId::TINYINT:                                                \
-      return GetCmpBool(left.value_.tinyint OP right.GetAs<int8_t>());   \
-    case TypeId::SMALLINT:                                               \
-      return GetCmpBool(left.value_.tinyint OP right.GetAs<int16_t>());  \
-    case TypeId::INTEGER:                                                \
-      return GetCmpBool(left.value_.tinyint OP right.GetAs<int32_t>());  \
-    case TypeId::BIGINT:                                                 \
-      return GetCmpBool(left.value_.tinyint OP right.GetAs<int64_t>());  \
-    case TypeId::DECIMAL:                                                \
-      return GetCmpBool(left.value_.tinyint OP right.GetAs<double>());   \
-    case TypeId::VARCHAR: {                                              \
-      auto r_value = right.CastAs(TypeId::TINYINT);                      \
-      return GetCmpBool(left.value_.tinyint OP r_value.GetAs<int8_t>()); \
-    }                                                                    \
-    default:                                                             \
-      break;                                                             \
+#define TINYINT_COMPARE_FUNC(OP)                                          \
+  switch (right.GetTypeId()) {                                            \
+    case TypeId::TINYINT:                                                 \
+      return GetCmpBool(left.value_.tinyint_ OP right.GetAs<int8_t>());   \
+    case TypeId::SMALLINT:                                                \
+      return GetCmpBool(left.value_.tinyint_ OP right.GetAs<int16_t>());  \
+    case TypeId::INTEGER:                                                 \
+      return GetCmpBool(left.value_.tinyint_ OP right.GetAs<int32_t>());  \
+    case TypeId::BIGINT:                                                  \
+      return GetCmpBool(left.value_.tinyint_ OP right.GetAs<int64_t>());  \
+    case TypeId::DECIMAL:                                                 \
+      return GetCmpBool(left.value_.tinyint_ OP right.GetAs<double>());   \
+    case TypeId::VARCHAR: {                                               \
+      auto r_value = right.CastAs(TypeId::TINYINT);                       \
+      return GetCmpBool(left.value_.tinyint_ OP r_value.GetAs<int8_t>()); \
+    }                                                                     \
+    default:                                                              \
+      break;                                                              \
   }  // SWITCH
 
-#define TINYINT_MODIFY_FUNC(METHOD, OP)                                            \
-  switch (right.GetTypeId()) {                                                     \
-    case TypeId::TINYINT:                                                          \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int8_t, int8_t>(left, right);                                  \
-    case TypeId::SMALLINT:                                                         \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int8_t, int16_t>(left, right);                                 \
-    case TypeId::INTEGER:                                                          \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int8_t, int32_t>(left, right);                                 \
-    case TypeId::BIGINT:                                                           \
-      /* NOLINTNEXTLINE */                                                         \
-      return METHOD<int8_t, int64_t>(left, right);                                 \
-    case TypeId::DECIMAL:                                                          \
-      return Value(TypeId::DECIMAL, left.value_.tinyint OP right.GetAs<double>()); \
-    case TypeId::VARCHAR: {                                                        \
-      auto r_value = right.CastAs(TypeId::TINYINT);                                \
-      /* NOLINTNEXTLINE  */                                                        \
-      return METHOD<int8_t, int8_t>(left, r_value);                                \
-    }                                                                              \
-    default:                                                                       \
-      break;                                                                       \
+#define TINYINT_MODIFY_FUNC(METHOD, OP)                                             \
+  switch (right.GetTypeId()) {                                                      \
+    case TypeId::TINYINT:                                                           \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int8_t, int8_t>(left, right);                                   \
+    case TypeId::SMALLINT:                                                          \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int8_t, int16_t>(left, right);                                  \
+    case TypeId::INTEGER:                                                           \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int8_t, int32_t>(left, right);                                  \
+    case TypeId::BIGINT:                                                            \
+      /* NOLINTNEXTLINE */                                                          \
+      return METHOD<int8_t, int64_t>(left, right);                                  \
+    case TypeId::DECIMAL:                                                           \
+      return Value(TypeId::DECIMAL, left.value_.tinyint_ OP right.GetAs<double>()); \
+    case TypeId::VARCHAR: {                                                         \
+      auto r_value = right.CastAs(TypeId::TINYINT);                                 \
+      /* NOLINTNEXTLINE  */                                                         \
+      return METHOD<int8_t, int8_t>(left, r_value);                                 \
+    }                                                                               \
+    default:                                                                        \
+      break;                                                                        \
   }  // SWITCH
 
 TinyintType::TinyintType() : IntegerParentType(TINYINT) {}
 
-bool TinyintType::IsZero(const Value &val) const { return (val.value_.tinyint == 0); }
+bool TinyintType::IsZero(const Value &val) const { return (val.value_.tinyint_ == 0); }
 
 Value TinyintType::Add(const Value &left, const Value &right) const {
   assert(left.CheckInteger());
@@ -141,7 +141,7 @@ Value TinyintType::Modulo(const Value &left, const Value &right) const {
     case TypeId::BIGINT:
       return ModuloValue<int8_t, int64_t>(left, right);
     case TypeId::DECIMAL:
-      return Value(TypeId::DECIMAL, ValMod(left.value_.tinyint, right.GetAs<double>()));
+      return Value(TypeId::DECIMAL, ValMod(left.value_.tinyint_, right.GetAs<double>()));
     case TypeId::VARCHAR: {
       auto r_value = right.CastAs(TypeId::TINYINT);
       return ModuloValue<int8_t, int8_t>(left, r_value);
@@ -159,10 +159,10 @@ Value TinyintType::Sqrt(const Value &val) const {
     return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
   }
 
-  if (val.value_.tinyint < 0) {
+  if (val.value_.tinyint_ < 0) {
     throw Exception(ExceptionType::DECIMAL, "Cannot take square root of a negative number.");
   }
-  return Value(TypeId::DECIMAL, std::sqrt(val.value_.tinyint));
+  return Value(TypeId::DECIMAL, std::sqrt(val.value_.tinyint_));
 
   throw Exception("type error");
 }
@@ -263,11 +263,11 @@ std::string TinyintType::ToString(const Value &val) const {
   if (val.IsNull()) {
     return "tinyint_null";
   }
-  return std::to_string(val.value_.tinyint);
+  return std::to_string(val.value_.tinyint_);
 }
 
 void TinyintType::SerializeTo(const Value &val, char *storage) const {
-  *reinterpret_cast<int8_t *>(storage) = val.value_.tinyint;
+  *reinterpret_cast<int8_t *>(storage) = val.value_.tinyint_;
 }
 
 // Deserialize a value of the given type from the given storage space.
@@ -278,7 +278,7 @@ Value TinyintType::DeserializeFrom(const char *storage) const {
 
 Value TinyintType::Copy(const Value &val) const {
   assert(val.CheckInteger());
-  return Value(TypeId::TINYINT, val.value_.tinyint);
+  return Value(TypeId::TINYINT, val.value_.tinyint_);
 }
 
 Value TinyintType::CastAs(const Value &val, const TypeId type_id) const {

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -23,7 +23,7 @@
 
 namespace bustub {
 
-Type *Type::kTypes[] = {
+Type *Type::k_types[] = {
     new Type(TypeId::INVALID),        new BooleanType(), new TinyintType(), new SmallintType(),
     new IntegerType(TypeId::INTEGER), new BigintType(),  new DecimalType(), new VarlenType(TypeId::VARCHAR),
 };

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -42,7 +42,7 @@ Value::Value(const Value &other) {
 }
 
 Value &Value::operator=(Value other) {
-  swap(*this, other);
+  Swap(*this, other);
   return *this;
 }
 

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -25,12 +25,12 @@ Value::Value(const Value &other) {
   value_ = other.value_;
   switch (type_id_) {
     case TypeId::VARCHAR:
-      if (size_.len == BUSTUB_VALUE_NULL) {
-        value_.varlen = nullptr;
+      if (size_.len_ == BUSTUB_VALUE_NULL) {
+        value_.varlen_ = nullptr;
       } else {
         if (manage_data_) {
-          value_.varlen = new char[size_.len];
-          memcpy(value_.varlen, other.value_.varlen, size_.len);
+          value_.varlen_ = new char[size_.len_];
+          memcpy(value_.varlen_, other.value_.varlen_, size_.len_);
         } else {
           value_ = other.value_;
         }
@@ -50,24 +50,24 @@ Value &Value::operator=(Value other) {
 Value::Value(TypeId type, int8_t i) : Value(type) {
   switch (type) {
     case TypeId::BOOLEAN:
-      value_.boolean = i;
-      size_.len = (value_.boolean == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.boolean_ = i;
+      size_.len_ = (value_.boolean_ == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
-      value_.tinyint = i;
-      size_.len = (value_.tinyint == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.tinyint_ = i;
+      size_.len_ = (value_.tinyint_ == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
-      value_.smallint = i;
-      size_.len = (value_.smallint == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.smallint_ = i;
+      size_.len_ = (value_.smallint_ == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
-      value_.integer = i;
-      size_.len = (value_.integer == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.integer_ = i;
+      size_.len_ = (value_.integer_ == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
-      value_.bigint = i;
-      size_.len = (value_.bigint == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.bigint_ = i;
+      size_.len_ = (value_.bigint_ == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
       throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for one-byte Value constructor");
@@ -78,28 +78,28 @@ Value::Value(TypeId type, int8_t i) : Value(type) {
 Value::Value(TypeId type, int16_t i) : Value(type) {
   switch (type) {
     case TypeId::BOOLEAN:
-      value_.boolean = i;
-      size_.len = (value_.boolean == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.boolean_ = i;
+      size_.len_ = (value_.boolean_ == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
-      value_.tinyint = i;
-      size_.len = (value_.tinyint == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.tinyint_ = i;
+      size_.len_ = (value_.tinyint_ == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
-      value_.smallint = i;
-      size_.len = (value_.smallint == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.smallint_ = i;
+      size_.len_ = (value_.smallint_ == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
-      value_.integer = i;
-      size_.len = (value_.integer == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.integer_ = i;
+      size_.len_ = (value_.integer_ == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
-      value_.bigint = i;
-      size_.len = (value_.bigint == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.bigint_ = i;
+      size_.len_ = (value_.bigint_ == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
-      value_.timestamp = i;
-      size_.len = (value_.timestamp == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.timestamp_ = i;
+      size_.len_ = (value_.timestamp_ == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
       throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for two-byte Value constructor");
@@ -110,31 +110,31 @@ Value::Value(TypeId type, int16_t i) : Value(type) {
 Value::Value(TypeId type, int32_t i) : Value(type) {
   switch (type) {
     case TypeId::BOOLEAN:
-      value_.boolean = i;
-      size_.len = (value_.boolean == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.boolean_ = i;
+      size_.len_ = (value_.boolean_ == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
-      value_.tinyint = i;
-      size_.len = (value_.tinyint == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.tinyint_ = i;
+      size_.len_ = (value_.tinyint_ == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
-      value_.smallint = i;
-      size_.len = (value_.smallint == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.smallint_ = i;
+      size_.len_ = (value_.smallint_ == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
-      value_.integer = i;
-      size_.len = (value_.integer == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.integer_ = i;
+      size_.len_ = (value_.integer_ == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
-      value_.bigint = i;
-      size_.len = (value_.bigint == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.bigint_ = i;
+      size_.len_ = (value_.bigint_ == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
-      value_.timestamp = i;
-      size_.len = (value_.timestamp == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.timestamp_ = i;
+      size_.len_ = (value_.timestamp_ == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
-      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for integer Value constructor");
+      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for integer_ Value constructor");
   }
 }
 
@@ -142,28 +142,28 @@ Value::Value(TypeId type, int32_t i) : Value(type) {
 Value::Value(TypeId type, int64_t i) : Value(type) {
   switch (type) {
     case TypeId::BOOLEAN:
-      value_.boolean = i;
-      size_.len = (value_.boolean == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.boolean_ = i;
+      size_.len_ = (value_.boolean_ == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
-      value_.tinyint = i;
-      size_.len = (value_.tinyint == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.tinyint_ = i;
+      size_.len_ = (value_.tinyint_ == BUSTUB_INT8_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
-      value_.smallint = i;
-      size_.len = (value_.smallint == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.smallint_ = i;
+      size_.len_ = (value_.smallint_ == BUSTUB_INT16_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
-      value_.integer = i;
-      size_.len = (value_.integer == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.integer_ = i;
+      size_.len_ = (value_.integer_ == BUSTUB_INT32_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
-      value_.bigint = i;
-      size_.len = (value_.bigint == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.bigint_ = i;
+      size_.len_ = (value_.bigint_ == BUSTUB_INT64_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
-      value_.timestamp = i;
-      size_.len = (value_.timestamp == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.timestamp_ = i;
+      size_.len_ = (value_.timestamp_ == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
       throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for eight-byte Value constructor");
@@ -174,15 +174,15 @@ Value::Value(TypeId type, int64_t i) : Value(type) {
 Value::Value(TypeId type, uint64_t i) : Value(type) {
   switch (type) {
     case TypeId::BIGINT:
-      value_.boolean = i;
-      size_.len = (value_.boolean == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.boolean_ = i;
+      size_.len_ = (value_.boolean_ == BUSTUB_BOOLEAN_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
-      value_.timestamp = i;
-      size_.len = (value_.timestamp == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.timestamp_ = i;
+      size_.len_ = (value_.timestamp_ == BUSTUB_TIMESTAMP_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
-      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for timestamp Value constructor");
+      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for timestamp_ Value constructor");
   }
 }
 
@@ -190,8 +190,8 @@ Value::Value(TypeId type, uint64_t i) : Value(type) {
 Value::Value(TypeId type, double d) : Value(type) {
   switch (type) {
     case TypeId::DECIMAL:
-      value_.decimal = d;
-      size_.len = (value_.decimal == BUSTUB_DECIMAL_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.decimal_ = d;
+      size_.len_ = (value_.decimal_ == BUSTUB_DECIMAL_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
       throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for double Value constructor");
@@ -202,8 +202,8 @@ Value::Value(TypeId type, double d) : Value(type) {
 Value::Value(TypeId type, float f) : Value(type) {
   switch (type) {
     case TypeId::DECIMAL:
-      value_.decimal = f;
-      size_.len = (value_.decimal == BUSTUB_DECIMAL_NULL ? BUSTUB_VALUE_NULL : 0);
+      value_.decimal_ = f;
+      size_.len_ = (value_.decimal_ == BUSTUB_DECIMAL_NULL ? BUSTUB_VALUE_NULL : 0);
       break;
     default:
       throw Exception(ExceptionType::INCOMPATIBLE_TYPE, "Invalid Type for float value constructor");
@@ -215,20 +215,20 @@ Value::Value(TypeId type, const char *data, uint32_t len, bool manage_data) : Va
   switch (type) {
     case TypeId::VARCHAR:
       if (data == nullptr) {
-        value_.varlen = nullptr;
-        size_.len = BUSTUB_VALUE_NULL;
+        value_.varlen_ = nullptr;
+        size_.len_ = BUSTUB_VALUE_NULL;
       } else {
         manage_data_ = manage_data;
         if (manage_data_) {
           assert(len < BUSTUB_VARCHAR_MAX_LEN);
-          value_.varlen = new char[len];
-          assert(value_.varlen != nullptr);
-          size_.len = len;
-          memcpy(value_.varlen, data, len);
+          value_.varlen_ = new char[len];
+          assert(value_.varlen_ != nullptr);
+          size_.len_ = len;
+          memcpy(value_.varlen_, data, len);
         } else {
           // FUCK YOU GCC I do what I want.
-          value_.const_varlen = data;
-          size_.len = len;
+          value_.const_varlen_ = data;
+          size_.len_ = len;
         }
       }
       break;
@@ -243,10 +243,10 @@ Value::Value(TypeId type, const std::string &data) : Value(type) {
       manage_data_ = true;
       // TODO(TAs): How to represent a null string here?
       uint32_t len = static_cast<uint32_t>(data.length()) + 1;
-      value_.varlen = new char[len];
-      assert(value_.varlen != nullptr);
-      size_.len = len;
-      memcpy(value_.varlen, data.c_str(), len);
+      value_.varlen_ = new char[len];
+      assert(value_.varlen_ != nullptr);
+      size_.len_ = len;
+      memcpy(value_.varlen_, data.c_str(), len);
       break;
     }
     default:
@@ -259,7 +259,7 @@ Value::~Value() {
   switch (type_id_) {
     case TypeId::VARCHAR:
       if (manage_data_) {
-        delete[] value_.varlen;
+        delete[] value_.varlen_;
       }
       break;
     default:

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -41,10 +41,10 @@ VarlenType::VarlenType(TypeId type) : Type(type) {}
 VarlenType::~VarlenType() = default;
 
 // Access the raw variable length data
-const char *VarlenType::GetData(const Value &val) const { return val.value_.varlen; }
+const char *VarlenType::GetData(const Value &val) const { return val.value_.varlen_; }
 
 // Get the length of the variable length data (including the length field)
-uint32_t VarlenType::GetLength(const Value &val) const { return val.size_.len; }
+uint32_t VarlenType::GetLength(const Value &val) const { return val.size_.len_; }
 
 CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
   assert(left.CheckComparable(right));
@@ -162,7 +162,7 @@ void VarlenType::SerializeTo(const Value &val, char *storage) const {
     return;
   }
   memcpy(storage, &len, sizeof(uint32_t));
-  memcpy(storage + sizeof(uint32_t), val.value_.varlen, len);
+  memcpy(storage + sizeof(uint32_t), val.value_.varlen_, len);
 }
 
 // Deserialize a value of the given type from the given storage space.

--- a/test/common/rwmutex_test.cpp
+++ b/test/common/rwmutex_test.cpp
@@ -36,7 +36,7 @@ class Counter {
 
  private:
   int count_{0};
-  RWMutex mutex{};
+  RWMutex mutex_{};
 };
 
 // NOLINTNEXTLINE

--- a/test/concurrency/lock_manager_test.cpp
+++ b/test/concurrency/lock_manager_test.cpp
@@ -97,7 +97,7 @@ TEST(LockManagerTest, DISABLED_BasicCycleTest) {
 // NOLINTNEXTLINE
 TEST(LockManagerTest, DISABLED_BasicDeadlockDetectionTest) {
   LockManager lock_mgr{TwoPLMode::REGULAR, DeadlockMode::DETECTION};
-  CYCLE_DETECTION_INTERVAL = std::chrono::milliseconds(500);
+  cycle_detection_interval = std::chrono::milliseconds(500);
   TransactionManager txn_mgr{&lock_mgr};
   RID rid0{0, 0};
   RID rid1{1, 1};
@@ -139,7 +139,7 @@ TEST(LockManagerTest, DISABLED_BasicDeadlockDetectionTest) {
   });
 
   // Sleep for enough time to break cycle
-  std::this_thread::sleep_for(CYCLE_DETECTION_INTERVAL * 2);
+  std::this_thread::sleep_for(cycle_detection_interval * 2);
 
   t0.join();
   t1.join();

--- a/test/table/tuple_test.cpp
+++ b/test/table/tuple_test.cpp
@@ -26,7 +26,7 @@ namespace bustub {
 // NOLINTNEXTLINE
 TEST(TupleTest, DISABLED_TableHeapTest) {
   // test1: parse create sql statement
-  std::string createStmt = "a varchar(20), b smallint, c bigint, d bool, e varchar(16)";
+  std::string create_stmt = "a varchar(20), b smallint, c bigint, d bool, e varchar(16)";
   Column col1{"a", TypeId::VARCHAR, 20};
   Column col2{"b", TypeId::SMALLINT};
   Column col3{"c", TypeId::BIGINT};

--- a/test/table/tuple_test.cpp
+++ b/test/table/tuple_test.cpp
@@ -51,8 +51,8 @@ TEST(TupleTest, DISABLED_TableHeapTest) {
     rid_v.push_back(rid);
   }
 
-  TableIterator itr = table->begin(transaction);
-  while (itr != table->end()) {
+  TableIterator itr = table->Begin(transaction);
+  while (itr != table->End()) {
     // std::cout << itr->ToString(schema) << std::endl;
     ++itr;
   }

--- a/test/type/type_test.cpp
+++ b/test/type/type_test.cpp
@@ -22,7 +22,7 @@ namespace bustub {
 //===--------------------------------------------------------------------===//
 // Type Tests
 //===--------------------------------------------------------------------===//
-const std::vector<TypeId> typeTestTypes = {
+const std::vector<TypeId> TYPE_TEST_TYPES = {
     TypeId::BOOLEAN, TypeId::TINYINT, TypeId::SMALLINT, TypeId::INTEGER, TypeId::BIGINT, TypeId::DECIMAL,
 };
 
@@ -54,7 +54,7 @@ TEST(TypeTests, InvalidTypeTest) {
 
 // NOLINTNEXTLINE
 TEST(TypeTests, GetInstanceTest) {
-  for (auto col_type : typeTestTypes) {
+  for (auto col_type : TYPE_TEST_TYPES) {
     auto t = Type::GetInstance(col_type);
     EXPECT_NE(nullptr, t);
     EXPECT_EQ(col_type, t->GetTypeId());
@@ -64,9 +64,9 @@ TEST(TypeTests, GetInstanceTest) {
 
 // NOLINTNEXTLINE
 TEST(TypeTests, MaxValueTest) {
-  for (auto col_type : typeTestTypes) {
-    auto maxVal = Type::GetMaxValue(col_type);
-    EXPECT_FALSE(maxVal.IsNull());
+  for (auto col_type : TYPE_TEST_TYPES) {
+    auto max_val = Type::GetMaxValue(col_type);
+    EXPECT_FALSE(max_val.IsNull());
     // NOTE: We should not be allowed to create a value that is greater than
     // the max value.
   }
@@ -74,9 +74,9 @@ TEST(TypeTests, MaxValueTest) {
 
 // NOLINTNEXTLINE
 TEST(TypeTests, MinValueTest) {
-  for (auto col_type : typeTestTypes) {
-    auto minVal = Type::GetMinValue(col_type);
-    EXPECT_FALSE(minVal.IsNull());
+  for (auto col_type : TYPE_TEST_TYPES) {
+    auto min_val = Type::GetMinValue(col_type);
+    EXPECT_FALSE(min_val.IsNull());
     // NOTE: We should not be allowed to create a value that is less than
     // the min value.
   }


### PR DESCRIPTION
This brings in Matt's naming convention clang-tidy checks from Terrier and applies it to the existing codebase. It should not conflict with existing student files because it does not touch the clock replacer or buffer pool stuff. We will not enforce this check on current students; we will switch it back on before Fall 2020.