### PR TITLE
Initialise global variable in Disk Manager Constructor

### DIFF
--- a/src/storage/disk/disk_manager.cpp
+++ b/src/storage/disk/disk_manager.cpp
@@ -22,7 +22,7 @@
 
 namespace bustub {
 
-static char *buffer_used = nullptr;
+static char *buffer_used;
 
 /**
  * Constructor: open/create a single database file & log file
@@ -58,6 +58,7 @@ DiskManager::DiskManager(const std::string &db_file)
     // reopen with original mode
     db_io_.open(db_file, std::ios::binary | std::ios::in | std::ios::out);
   }
+  buffer_used = nullptr;
 }
 
 /**


### PR DESCRIPTION
The buffer_used global variable was initialized outside the constructor. For repeated instantiations of disk manager, as in the logging test cases, it does not get initialized causing `assert(log_data != buffer_used);` in disk_manager.cpp to fail.

This issue could not reproduced locally on Mac but consistently on AWS.