### PR TITLE
Explicitly zero out the tuple's data on construction.

### DIFF
--- a/src/storage/table/tuple.cpp
+++ b/src/storage/table/tuple.cpp
@@ -33,6 +33,7 @@ Tuple::Tuple(std::vector<Value> values, const Schema *schema) : allocated_(true)
   // 2. Allocate memory.
   size_ = tuple_size;
   data_ = new char[size_];
+  std::memset(data_, 0, size_);
 
   // 3. Serialize each attribute based on the input value.
   uint32_t column_count = schema->GetColumnCount();


### PR DESCRIPTION
It is unclear why this only has to be done for some submissions; people have obtained full scores without doing this. I suspect this may actually be covering up bugs in student implementations, but without concrete proof of that, this seems like a reasonable thing to be doing. We can revisit this in the winter break cleanup.