### PR TITLE
Fix a few bugs in DiskManager

### DIFF
--- a/src/storage/disk/disk_manager.cpp
+++ b/src/storage/disk/disk_manager.cpp
@@ -31,7 +31,7 @@ static char *buffer_used;
  */
 DiskManager::DiskManager(const std::string &db_file)
     : file_name_(db_file), next_page_id_(0), num_flushes_(0), num_writes_(0), flush_log_(false), flush_log_f_(nullptr) {
-  std::string::size_type n = file_name_.find('.');
+  std::string::size_type n = file_name_.rfind('.');
   if (n == std::string::npos) {
     LOG_DEBUG("wrong file format");
     return;

--- a/src/storage/disk/disk_manager.cpp
+++ b/src/storage/disk/disk_manager.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <thread>  // NOLINT
 
+#include "common/exception.h"
 #include "common/logger.h"
 #include "storage/disk/disk_manager.h"
 
@@ -46,6 +47,9 @@ DiskManager::DiskManager(const std::string &db_file)
     log_io_.close();
     // reopen with original mode
     log_io_.open(log_name_, std::ios::binary | std::ios::in | std::ios::app | std::ios::out);
+    if (!log_io_.is_open()) {
+      throw Exception("can't open dblog file");
+    }
   }
 
   db_io_.open(db_file, std::ios::binary | std::ios::in | std::ios::out | std::ios::out);
@@ -57,6 +61,9 @@ DiskManager::DiskManager(const std::string &db_file)
     db_io_.close();
     // reopen with original mode
     db_io_.open(db_file, std::ios::binary | std::ios::in | std::ios::out);
+    if (!db_io_.is_open()) {
+      throw Exception("can't open db file");
+    }
   }
   buffer_used = nullptr;
 }
@@ -94,16 +101,21 @@ void DiskManager::ReadPage(page_id_t page_id, char *page_data) {
   int offset = page_id * PAGE_SIZE;
   // check if read beyond file length
   if (offset > GetFileSize(file_name_)) {
-    LOG_DEBUG("I/O error while reading");
+    LOG_DEBUG("I/O error reading past end of file");
     // std::cerr << "I/O error while reading" << std::endl;
   } else {
     // set read cursor to offset
     db_io_.seekp(offset);
     db_io_.read(page_data, PAGE_SIZE);
+    if (db_io_.bad()) {
+      LOG_DEBUG("I/O error while reading");
+      return;
+    }
     // if file ends before reading PAGE_SIZE
     int read_count = db_io_.gcount();
     if (read_count < PAGE_SIZE) {
       LOG_DEBUG("Read less than a page");
+      db_io_.clear();
       // std::cerr << "Read less than a page" << std::endl;
       memset(page_data + read_count, 0, PAGE_SIZE - read_count);
     }
@@ -157,6 +169,11 @@ bool DiskManager::ReadLog(char *log_data, int size, int offset) {
   }
   log_io_.seekp(offset);
   log_io_.read(log_data, size);
+
+  if (log_io_.bad()) {
+    LOG_DEBUG("I/O error while reading log");
+    return false;
+  }
   // if log file ends before reading "size"
   int read_count = log_io_.gcount();
   if (read_count < size) {

--- a/test/storage/disk_manager_test.cpp
+++ b/test/storage/disk_manager_test.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+//                         BusTub
+//
+// disk_manager_test.cpp
+//
+// Identification: test/storage/disk/disk_manager_test.cpp
+//
+// Copyright (c) 2015-2019, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstring>
+
+#include "common/exception.h"
+#include "gtest/gtest.h"
+#include "storage/disk/disk_manager.h"
+
+namespace bustub {
+
+// NOLINTNEXTLINE
+TEST(DiskManagerTest, ReadWritePageTest) {
+  char buf[PAGE_SIZE] = {0};
+  char data[PAGE_SIZE] = {0};
+  std::string db_file("test.db");
+  auto dm = DiskManager(db_file);
+  std::strncpy(data, "A test string.", sizeof(data));
+
+  dm.ReadPage(0, buf);  // tolerate empty read
+
+  dm.WritePage(0, data);
+  dm.ReadPage(0, buf);
+  EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
+
+  std::memset(buf, 0, sizeof(buf));
+  dm.WritePage(5, data);
+  dm.ReadPage(5, buf);
+  EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
+
+  dm.ShutDown();
+  remove(db_file.c_str());
+}
+
+TEST(DiskManagerTest, ReadWriteLogTest) {
+  char buf[16] = {0};
+  char data[16] = {0};
+  std::string db_file("test.db");
+  auto dm = DiskManager(db_file);
+  std::strncpy(data, "A test string.", sizeof(data));
+
+  dm.ReadLog(buf, sizeof(buf), 0);  // tolerate empty read
+
+  dm.WriteLog(data, sizeof(data));
+  dm.ReadLog(buf, sizeof(buf), 0);
+  EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
+
+  dm.ShutDown();
+  remove(db_file.c_str());
+}
+
+TEST(DiskManagerTest, ThrowBadFileTest) { EXPECT_THROW(DiskManager("dev/null\\/foo/bar/baz/test.db"), Exception); }
+
+}  // namespace bustub


### PR DESCRIPTION
- The constructor doesn't re-check if `db_io_` or `log_io_` were
  successfully re-opened if the file doesn't exist. Checks were
  added for this, and we throw if either file fails to `open()`.
- `ReadPage()` tolerates partial reads that terminate prematurely at
  EOF, but this will cause the failbit to be set. The error flag is now 
  `clear()`'ed when less than a page is read so that subsequent
  operations can proceed.
- Like their `Write*()` counterparts, `ReadPage()` and `ReadLog()` should
  check error flags after each IO operation, and log errors appropriately.
- To find the filename extension, use `rfind()` to find the last `.` rather
  than the first.
- For good measure, add some tests that verify these fixes.
- If the filename lacks a `.`, we log an error and create a useless object. I suspect we should throw instead, but I stopped short of making that behavior change for now.