### PR TITLE
Fix typo in log_record.h and public several tuples in class LogRecord

### DIFF
--- a/src/include/recovery/log_record.h
+++ b/src/include/recovery/log_record.h
@@ -112,11 +112,19 @@ class LogRecord {
 
   ~LogRecord() = default;
 
+  inline Tuple &GetDeleteTuple() { return delete_tuple_; }
+
   inline RID &GetDeleteRID() { return delete_rid_; }
 
-  inline Tuple &GetInserteTuple() { return insert_tuple_; }
+  inline Tuple &GetInsertTuple() { return insert_tuple_; }
 
   inline RID &GetInsertRID() { return insert_rid_; }
+
+  inline Tuple &GetOriginalTuple() { return old_tuple_; }
+
+  inline Tuple &GetUpdateTuple() { return new_tuple_; }
+
+  inline RID &GetUpdateRID() { return update_rid_; }
 
   inline page_id_t GetNewPageRecord() { return prev_page_id_; }
 
@@ -152,20 +160,20 @@ class LogRecord {
   lsn_t prev_lsn_{INVALID_LSN};
   LogRecordType log_record_type_{LogRecordType::INVALID};
 
-  // case1: for delete opeartion, delete_tuple_ for UNDO opeartion
+  // case1: for delete operation, delete_tuple_ for UNDO operation
   RID delete_rid_;
   Tuple delete_tuple_;
 
-  // case2: for insert opeartion
+  // case2: for insert operation
   RID insert_rid_;
   Tuple insert_tuple_;
 
-  // case3: for update opeartion
+  // case3: for update operation
   RID update_rid_;
   Tuple old_tuple_;
   Tuple new_tuple_;
 
-  // case4: for new page opeartion
+  // case4: for new page operation
   page_id_t prev_page_id_{INVALID_PAGE_ID};
   page_id_t page_id_{INVALID_PAGE_ID};
   static const int HEADER_SIZE = 20;


### PR DESCRIPTION
I found some clear typo in log_record.h. Besides, some of the tuples in the class `LogRecord` are not public yet.