### PR TITLE
Remove nonportable and unused cmake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,6 @@ add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src" "${CMAKE_BINARY_DIR}/googl
 # COMPILER SETUP
 ######################################################################################################################
 
-# Store a truncated path in the pre-processor macro __BUSTUBFILE__.
-# Source: http://stackoverflow.com/a/16658858
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__BUSTUBFILE__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
-
 # Compiler flags.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wextra -Werror -march=native")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-attributes") #TODO: remove


### PR DESCRIPTION
The deleted cmake code is copied from a low-quality stack overflow
answer [0]. The answer suggests adding a CMAKE_CXX_FLAG in terms of $<,
which is a Makefile-ism. However, CMake is supposed to support other
build system targets such as Ninja. Referring to $< breaks the Ninja
build. It appears that the __BUSTUBFILE__ macro is unused in the code
base anyways so this patch just deletes the unused and buggy CMake code.
If this __BUSTUBFILE__ macro is desired, it should be implemented in
terms of portable CMake code such as in [1] instead.

[0] http://stackoverflow.com/a/16658858
[1] https://stackoverflow.com/questions/1706346/file-macro-manipulation-handling-at-compile-time/27990434#27990434