### PR TITLE
Make clang-format and clang-tidy configs forward-compatible for students running modern clang versions (>8)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,7 @@ BasedOnStyle: Google
 DerivePointerAlignment: false
 PointerAlignment: Right
 ColumnLimit: 120
+
+# Default for clang-8, changed in later clangs. Set explicitly for forwards
+# compatibility for students with modern clangs
+IncludeBlocks: Preserve

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,16 @@ Checks:     '
             -modernize-use-nodiscard,
             -modernize-avoid-c-arrays,
             -readability-magic-numbers,
+            -bugprone-branch-clone,
+            -bugprone-signed-char-misuse,
+            -bugprone-unhandled-self-assignment,
+            -clang-diagnostic-implicit-int-float-conversion,
+            -modernize-use-auto,
+            -modernize-use-trailing-return-type,
+            -readability-convert-member-functions-to-static,
+            -readability-make-member-function-const,
+            -readability-qualified-auto,
+            -readability-redundant-access-specifiers,
             '
 # TODO(WAN): To be enabled in Fall 2020.
 #CheckOptions:
@@ -64,3 +74,8 @@ AnalyzeTemporaryDtors: true
 #     We use C-style arrays in page.h, type.h and logger.h. They're a little more ergonomic than std::array. Thoughts?
 # -readability-magic-numbers,
 #     Let's not deal with people doing ridiculous things to hack around this. If it bites them, it bites them.
+# -bugprone-branch-clone, -bugprone-signed-char-misuse, -bugprone-unhandled-self-assignment,
+# -clang-diagnostic-implicit-int-float-conversion, -modernize-use-auto, -modernize-use-trailing-return-type,
+# -readability-convert-member-functions-to-static, -readability-make-member-function-const, -readability-qualified-auto,
+# -readability-redundant-access-specifiers
+#    Not available on clang-8. Disable for forward compatibility with students running modern clang versions.


### PR DESCRIPTION
Make clang-format forward compatible with modern clang (>8) by explicitly setting default options which have changed from clang 8 to clang 10.

Disable clang-tidy options added after clang-8. This prevents students using modern clang versions from getting clang-tidy errors. One alternative way to resolve this issue would be to actually make the modern clang-tidy fixes in the current codebase, but this patch solves the issue without causing any code churn.

Let me know if you guys would rather see the clang-tidy issue solved by actually upstreaming the fixes requested by clang-tidy 10.