### PR TITLE
fix comments in log_record.h and executor_test.cpp

### DIFF
--- a/src/include/recovery/log_record.h
+++ b/src/include/recovery/log_record.h
@@ -54,9 +54,9 @@ enum class LogRecordType {
  * | HEADER | tuple_rid | tuple_size | old_tuple_data | tuple_size | new_tuple_data |
  *-----------------------------------------------------------------------------------
  * For new page type log record
- *--------------------------
- * | HEADER | prev_page_id |
- *--------------------------
+ *------------------------------------
+ * | HEADER | prev_page_id | page_id |
+ *------------------------------------
  */
 class LogRecord {
   friend class LogManager;

--- a/test/execution/executor_test.cpp
+++ b/test/execution/executor_test.cpp
@@ -255,7 +255,7 @@ TEST_F(ExecutorTest, DISABLED_SimpleSelectInsertTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ExecutorTest, DISABLED_SimpleHashJoinTest) {
-  // INSERT INTO empty_table2 SELECT colA, colB FROM test_1 WHERE colA < 500
+  // SELECT colA, colB, col1, col2 FROM test_1 JOIN test_2 ON colA = col1
   std::unique_ptr<AbstractPlanNode> scan_plan1;
   const Schema *out_schema1;
   {


### PR DESCRIPTION
Fix two misleading comments. 

1. The first one is in log_record.h. The NEWPAGE log type has a `page_id` field which was missing in the ASCII graph. I added it.
2. The other one is the comment below SimpleHashJoinTest which is obviously a test on JOIN and not INSERT. I changed the SQL to reflect what the test actually does. 
#72 