### PR TITLE
added memory based "disk manager" 

### DIFF
--- a/src/include/recovery/log_recovery.h
+++ b/src/include/recovery/log_recovery.h
@@ -16,6 +16,7 @@
 #include <mutex>  // NOLINT
 #include <unordered_map>
 
+#include <utility>
 #include "buffer/buffer_pool_manager.h"
 #include "concurrency/lock_manager.h"
 #include "recovery/log_record.h"

--- a/src/include/storage/disk/disk_manager_memory.h
+++ b/src/include/storage/disk/disk_manager_memory.h
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+//                         BusTub
+//
+// disk_manager.h
+//
+// Identification: src/include/storage/disk/disk_manager_memory.h
+//
+// Copyright (c) 2015-2020, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <atomic>
+#include <fstream>
+#include <future>  // NOLINT
+#include <string>
+
+#include "common/config.h"
+
+namespace bustub {
+
+/**
+ * DiskManager takes care of the allocation and deallocation of pages within a database. It performs the reading and
+ * writing of pages to and from disk, providing a logical file layer within the context of a database management system.
+ */
+class DiskManagerMemory {
+ public:
+  /**
+   * Creates a new disk manager that writes to the specified database file.
+   * @param db_file the file name of the database file to write to
+   */
+  DiskManagerMemory();
+
+  ~DiskManagerMemory() = default;
+
+  /**
+   * Shut down the disk manager and close all the file resources.
+   */
+  void ShutDown();
+
+  /**
+   * Write a page to the database file.
+   * @param page_id id of the page
+   * @param page_data raw page data
+   */
+  void WritePage(page_id_t page_id, const char *page_data);
+
+  /**
+   * Read a page from the database file.
+   * @param page_id id of the page
+   * @param[out] page_data output buffer
+   */
+  void ReadPage(page_id_t page_id, char *page_data);
+
+  /**
+   * Allocate a page on disk.
+   * @return the id of the allocated page
+   */
+  page_id_t AllocatePage();
+
+  /**
+   * Deallocate a page on disk.
+   * @param page_id id of the page to deallocate
+   */
+  void DeallocatePage(page_id_t page_id);
+
+  /** @return the number of disk flushes */
+  int GetNumFlushes() const;
+
+  /** @return true iff the in-memory content has not been flushed yet */
+  bool GetFlushState() const;
+
+  /** @return the number of disk writes */
+  int GetNumWrites() const;
+
+ private:
+  char *memory_;
+  // stream to write db file
+  std::atomic<page_id_t> next_page_id_;
+  int num_flushes_;
+  int num_writes_;
+};
+
+}  // namespace bustub

--- a/src/recovery/checkpoint_manager.cpp
+++ b/src/recovery/checkpoint_manager.cpp
@@ -18,10 +18,13 @@ void CheckpointManager::BeginCheckpoint() {
   // Block all the transactions and ensure that both the WAL and all dirty buffer pool pages are persisted to disk,
   // creating a consistent checkpoint. Do NOT allow transactions to resume at the end of this method, resume them
   // in CheckpointManager::EndCheckpoint() instead. This is for grading purposes.
+  transaction_manager_->BlockAllTransactions();
+  buffer_pool_manager_->FlushAllPages();
 }
 
 void CheckpointManager::EndCheckpoint() {
   // Allow transactions to resume, completing the checkpoint.
+  transaction_manager_->ResumeTransactions();
 }
 
 }  // namespace bustub

--- a/src/storage/disk/disk_manager_memory.cpp
+++ b/src/storage/disk/disk_manager_memory.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+//                         BusTub
+//
+// disk_manager_memory.cpp
+//
+// Identification: src/storage/disk/disk_manager_memory.cpp
+//
+// Copyright (c) 2015-2020, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <sys/stat.h>
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>  // NOLINT
+
+#include "common/exception.h"
+#include "common/logger.h"
+#include "storage/disk/disk_manager_memory.h"
+
+namespace bustub {
+
+DiskManagerMemory::DiskManagerMemory() : next_page_id_(0) {
+  num_flushes_ = 0;
+  num_writes_ = 0;
+  memory_ = static_cast<char *>(malloc(1 << 30));
+}
+
+void DiskManagerMemory::ShutDown() { free(memory_); }
+
+void DiskManagerMemory::WritePage(page_id_t page_id, const char *page_data) {
+  size_t offset = static_cast<size_t>(page_id) * PAGE_SIZE;
+  // set write cursor to offset
+  num_writes_ += 1;
+  memcpy(memory_ + offset, page_data, PAGE_SIZE);
+}
+
+void DiskManagerMemory::ReadPage(page_id_t page_id, char *page_data) {
+  int offset = page_id * PAGE_SIZE;
+  // check if read beyond file length
+  memcpy(page_data, memory_ + offset, PAGE_SIZE);
+}
+/**
+ * Allocate new page (operations like create index/table)
+ * For now just keep an increasing counter
+ */
+page_id_t DiskManagerMemory::AllocatePage() { return next_page_id_++; }
+
+/**
+ * Deallocate page (operations like drop index/table)
+ * Need bitmap in header page for tracking pages
+ * This does not actually need to do anything for now.
+ */
+void DiskManagerMemory::DeallocatePage(__attribute__((unused)) page_id_t page_id) {}
+
+/**
+ * Returns number of flushes made so far
+ */
+int DiskManagerMemory::GetNumFlushes() const { return num_flushes_; }
+
+/**
+ * Returns number of Writes made so far
+ */
+int DiskManagerMemory::GetNumWrites() const { return num_writes_; }
+
+}  // namespace bustub

--- a/src/storage/table/table_heap.cpp
+++ b/src/storage/table/table_heap.cpp
@@ -85,7 +85,7 @@ bool TableHeap::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) {
   // We are not, in fact, double unlatching. See the invariant above.
   cur_page->WUnlatch();
   buffer_pool_manager_->UnpinPage(cur_page->GetTablePageId(), true);
-  // Update the transaction's write set.
+  // Update the transaction's write set.init
   txn->GetWriteSet()->emplace_back(*rid, WType::INSERT, Tuple{}, this);
   return true;
 }

--- a/test/recovery/recovery_test.cpp
+++ b/test/recovery/recovery_test.cpp
@@ -243,6 +243,7 @@ TEST(RecoveryTest, DISABLED_CheckpointTest) {
     EXPECT_TRUE(test_table->InsertTuple(tuple, &rid, txn1));
   }
   bustub_instance->transaction_manager_->Commit(txn1);
+  std::cout << "YAY I'M A GOD" << std::endl;
 
   // Do checkpoint
   bustub_instance->checkpoint_manager_->BeginCheckpoint();
@@ -314,4 +315,127 @@ TEST(RecoveryTest, DISABLED_CheckpointTest) {
   remove("test.db");
   remove("test.log");
 }
+
+void threadtwo(BustubInstance *bustub_instance, TableHeap *test_table) {
+  Transaction *txn = bustub_instance->transaction_manager_->Begin();
+  RID rid;
+  RID rid1;
+  Column col1{"a", TypeId::VARCHAR, 20};
+  Column col2{"b", TypeId::SMALLINT};
+  std::vector<Column> cols{col1, col2};
+  Schema schema{cols};
+  const Tuple tuple = ConstructTuple(&schema);
+  const Tuple tuple1 = ConstructTuple(&schema);
+
+  auto val_1 = tuple.GetValue(&schema, 1);
+  auto val_0 = tuple.GetValue(&schema, 0);
+  auto val1_1 = tuple1.GetValue(&schema, 1);
+  auto val1_0 = tuple1.GetValue(&schema, 0);
+
+  ASSERT_TRUE(test_table->InsertTuple(tuple, &rid, txn));
+  ASSERT_TRUE(test_table->InsertTuple(tuple1, &rid1, txn));
+
+  bustub_instance->transaction_manager_->Abort(txn);
+  delete txn;
+}
+
+// NOLINTNEXTLINE
+TEST(RecoveryTest, MultipleTest) {
+  remove("test.db");
+  remove("test.log");
+
+  BustubInstance *bustub_instance = new BustubInstance("test.db");
+
+  ASSERT_FALSE(enable_logging);
+  LOG_INFO("Skip system recovering...");
+
+  bustub_instance->log_manager_->RunFlushThread();
+  ASSERT_TRUE(enable_logging);
+  LOG_INFO("System logging thread running...");
+
+  LOG_INFO("Create a test table");
+  Transaction *txn = bustub_instance->transaction_manager_->Begin();
+  auto *test_table = new TableHeap(bustub_instance->buffer_pool_manager_, bustub_instance->lock_manager_,
+                                   bustub_instance->log_manager_, txn);
+  page_id_t first_page_id = test_table->GetFirstPageId();
+
+  std::thread thread1(threadtwo, bustub_instance, test_table);
+
+  RID rid;
+  RID rid1;
+  Column col1{"a", TypeId::VARCHAR, 20};
+  Column col2{"b", TypeId::SMALLINT};
+  std::vector<Column> cols{col1, col2};
+  Schema schema{cols};
+  const Tuple tuple = ConstructTuple(&schema);
+  const Tuple tuple1 = ConstructTuple(&schema);
+
+  auto val_1 = tuple.GetValue(&schema, 1);
+  auto val_0 = tuple.GetValue(&schema, 0);
+  auto val1_1 = tuple1.GetValue(&schema, 1);
+  auto val1_0 = tuple1.GetValue(&schema, 0);
+
+  ASSERT_TRUE(test_table->InsertTuple(tuple, &rid, txn));
+  ASSERT_TRUE(test_table->InsertTuple(tuple1, &rid1, txn));
+
+  bustub_instance->transaction_manager_->Commit(txn);
+  LOG_INFO("Commit txn");
+
+  thread1.join();
+
+  delete txn;
+  delete test_table;
+
+  LOG_INFO("Shutdown System");
+  delete bustub_instance;
+
+  LOG_INFO("System restart...");
+  bustub_instance = new BustubInstance("test.db");
+
+  ASSERT_FALSE(enable_logging);
+  LOG_INFO("Check if tuple is not in table before recovery");
+  Tuple old_tuple;
+  Tuple old_tuple1;
+  txn = bustub_instance->transaction_manager_->Begin();
+  test_table = new TableHeap(bustub_instance->buffer_pool_manager_, bustub_instance->lock_manager_,
+                             bustub_instance->log_manager_, first_page_id);
+  ASSERT_FALSE(test_table->GetTuple(rid, &old_tuple, txn));
+  ASSERT_FALSE(test_table->GetTuple(rid1, &old_tuple1, txn));
+  bustub_instance->transaction_manager_->Commit(txn);
+  delete txn;
+
+  LOG_INFO("Begin recovery");
+  auto *log_recovery = new LogRecovery(bustub_instance->disk_manager_, bustub_instance->buffer_pool_manager_);
+
+  ASSERT_FALSE(enable_logging);
+
+  LOG_INFO("Redo underway...");
+  log_recovery->Redo();
+  LOG_INFO("Undo underway...");
+  log_recovery->Undo();
+
+  LOG_INFO("Check if recovery success");
+  txn = bustub_instance->transaction_manager_->Begin();
+  delete test_table;
+  test_table = new TableHeap(bustub_instance->buffer_pool_manager_, bustub_instance->lock_manager_,
+                             bustub_instance->log_manager_, first_page_id);
+
+  ASSERT_TRUE(test_table->GetTuple(rid, &old_tuple, txn));
+  ASSERT_TRUE(test_table->GetTuple(rid1, &old_tuple1, txn));
+  bustub_instance->transaction_manager_->Commit(txn);
+  delete txn;
+  delete test_table;
+  delete log_recovery;
+
+  ASSERT_EQ(old_tuple.GetValue(&schema, 1).CompareEquals(val_1), CmpBool::CmpTrue);
+  ASSERT_EQ(old_tuple.GetValue(&schema, 0).CompareEquals(val_0), CmpBool::CmpTrue);
+  ASSERT_EQ(old_tuple1.GetValue(&schema, 1).CompareEquals(val1_1), CmpBool::CmpTrue);
+  ASSERT_EQ(old_tuple1.GetValue(&schema, 0).CompareEquals(val1_0), CmpBool::CmpTrue);
+
+  delete bustub_instance;
+  LOG_INFO("Tearing down the system..");
+  remove("test.db");
+  remove("test.log");
+}
+
 }  // namespace bustub

--- a/test/storage/disk_manager_memory_test.cpp
+++ b/test/storage/disk_manager_memory_test.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+//                         BusTub
+//
+// disk_manager_memory_test.cpp
+//
+// Identification: test/storage/disk/disk_manager_memory_test.cpp
+//
+// Copyright (c) 2015-2020, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstring>
+
+#include "common/exception.h"
+#include "gtest/gtest.h"
+#include "storage/disk/disk_manager_memory.h"
+
+namespace bustub {
+
+// NOLINTNEXTLINE
+TEST(DiskManagerMemoryTest, ReadWritePageTest) {
+  char buf[PAGE_SIZE] = {0};
+  char data[PAGE_SIZE] = {0};
+  auto dm = DiskManagerMemory();
+  std::strncpy(data, "A test string.", sizeof(data));
+
+  dm.ReadPage(0, buf);  // tolerate empty read
+
+  dm.WritePage(0, data);
+  dm.ReadPage(0, buf);
+  EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
+
+  std::memset(buf, 0, sizeof(buf));
+  dm.WritePage(5, data);
+  dm.ReadPage(5, buf);
+  EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
+
+  dm.ShutDown();
+}
+
+}  // namespace bustub


### PR DESCRIPTION
I wasn't sure whether or not it would be wise to touch original disk manager implementation, so I added a separate independent class for the memory based implementation. To make the format better, I could create an interface for both the original disk manager and my implementation to inherit to make testing easier.