### PR TITLE
Fix README.md for build docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ sudo apt install docker
 From the repository directory, run these commands to create a Docker image and container:
 
 ```
-$ docker build .
+$ docker build . -t bustub
 $ docker create -t -i --name bustub -v $(pwd):/bustub bustub bash
 ```
 


### PR DESCRIPTION
If we build the docker image without specify its name `bustub`, the second instruction `docker create -t -i --name bustub -v $(pwd):/bustub bustub bash` will fail