### PR TITLE
Add operator= in TableIterator.

### DIFF
--- a/src/include/storage/table/table_iterator.h
+++ b/src/include/storage/table/table_iterator.h
@@ -36,6 +36,10 @@ class TableIterator {
   
   TableIterator& operator=(const TableIterator &other) {
     table_heap_ = other.table_heap_;
+    if (tuple_) {
+      delete tuple_;
+    }
+
     tuple_ = new Tuple(*other.tuple_);
     txn_ = other.txn_;
     return *this;

--- a/src/include/storage/table/table_iterator.h
+++ b/src/include/storage/table/table_iterator.h
@@ -33,6 +33,13 @@ class TableIterator {
 
   TableIterator(const TableIterator &other)
       : table_heap_(other.table_heap_), tuple_(new Tuple(*other.tuple_)), txn_(other.txn_) {}
+  
+  TableIterator& operator=(const TableIterator &other) {
+    table_heap_ = other.table_heap_;
+    tuple_ = new Tuple(*other.tuple_);
+    txn_ = other.txn_;
+    return *this;
+  }
 
   ~TableIterator() { delete tuple_; }
 


### PR DESCRIPTION
This prevents `use after free` bugs when objects of TableIterator are assigned to one another.
TableIterator's destructor deletes `Tuple`. So, assignment operator= should create a new Tuple like Copy Constructor.