### PR TITLE
Remove quotes in find_program hints parameter to allow clang-format and clang-tidy to be found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ enable_testing()
 # clang-format
 find_program(CLANG_FORMAT_BIN
         NAMES clang-format clang-format-8
-        HINTS "${BUSTUB_CLANG_SEARCH_PATH}")
+        HINTS ${BUSTUB_CLANG_SEARCH_PATH})
 if ("${CLANG_FORMAT_BIN}" STREQUAL "CLANG_FORMAT_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find clang-format.")
 else()
@@ -35,7 +35,7 @@ endif()
 # clang-tidy
 find_program(CLANG_TIDY_BIN
         NAMES clang-tidy clang-tidy-8
-        HINTS "${BUSTUB_CLANG_SEARCH_PATH}")
+        HINTS ${BUSTUB_CLANG_SEARCH_PATH})
 if ("${CLANG_TIDY_BIN}" STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find clang-tidy.")
 else()


### PR DESCRIPTION
Fix #28.