### PR TITLE
Fix signature for checkpoint 2

### DIFF
--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -54,7 +54,8 @@ class BPlusTreeInternalPage : public BPlusTreePage {
   void MoveHalfTo(BPlusTreeInternalPage *recipient, BufferPoolManager *buffer_pool_manager);
   void MoveFirstToEndOf(BPlusTreeInternalPage *recipient, const KeyType &middle_key,
                         BufferPoolManager *buffer_pool_manager);
-  void MoveLastToFrontOf(BPlusTreeInternalPage *recipient, BufferPoolManager *buffer_pool_manager);
+  void MoveLastToFrontOf(BPlusTreeInternalPage *recipient, const KeyType &middle_key,
+                         BufferPoolManager *buffer_pool_manager);
 
  private:
   void CopyNFrom(MappingType *items, int size, BufferPoolManager *buffer_pool_manager);

--- a/src/storage/page/b_plus_tree_internal_page.cpp
+++ b/src/storage/page/b_plus_tree_internal_page.cpp
@@ -162,12 +162,12 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::CopyLastFrom(const MappingType &pair, Buffe
 
 /*
  * Remove the last key & value pair from this page to head of "recipient" page.
- *
+ * You will also need the separating key (from the parent) to override your recipient's previous first dummy key.
  * You also need to use BufferPoolManager to persist changes to the parent page id for those
  * pages that are moved to the recipient
  */
 INDEX_TEMPLATE_ARGUMENTS
-void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveLastToFrontOf(BPlusTreeInternalPage *recipient,
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveLastToFrontOf(BPlusTreeInternalPage *recipient, const KeyType &middle_key,
                                                        BufferPoolManager *buffer_pool_manager) {}
 
 /* Append an entry at the beginning.

--- a/src/storage/page/b_plus_tree_internal_page.cpp
+++ b/src/storage/page/b_plus_tree_internal_page.cpp
@@ -162,9 +162,10 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::CopyLastFrom(const MappingType &pair, Buffe
 
 /*
  * Remove the last key & value pair from this page to head of "recipient" page.
- * You will also need the separating key (from the parent) to override your recipient's previous first dummy key.
- * You also need to use BufferPoolManager to persist changes to the parent page id for those
- * pages that are moved to the recipient
+ * You need to handle the original dummy key properly, e.g. updating recipient’s array to position the middle_key at the
+ * right place.
+ * You also need to use BufferPoolManager to persist changes to the parent page id for those pages that are
+ * moved to the recipient
  */
 INDEX_TEMPLATE_ARGUMENTS
 void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveLastToFrontOf(BPlusTreeInternalPage *recipient, const KeyType &middle_key,


### PR DESCRIPTION
`MoveLastToFrontOf` will also need the separating key from the parent. 