### PR TITLE
use strncmp for BinaryDataTest in BufferPoolManagerTest

### DIFF
--- a/test/buffer/buffer_pool_manager_test.cpp
+++ b/test/buffer/buffer_pool_manager_test.cpp
@@ -50,7 +50,7 @@ TEST(BufferPoolManagerTest, DISABLED_BinaryDataTest) {
 
   // Scenario: Once we have a page, we should be able to read and write content.
   std::strncpy(page0->GetData(), random_binary_data, PAGE_SIZE);
-  EXPECT_EQ(0, std::strcmp(page0->GetData(), random_binary_data));
+  EXPECT_EQ(0, std::strncmp(page0->GetData(), random_binary_data, PAGE_SIZE));
 
   // Scenario: We should be able to create new pages until we fill up the buffer pool.
   for (size_t i = 1; i < buffer_pool_size; ++i) {
@@ -74,7 +74,7 @@ TEST(BufferPoolManagerTest, DISABLED_BinaryDataTest) {
   }
   // Scenario: We should be able to fetch the data we wrote a while ago.
   page0 = bpm->FetchPage(0);
-  EXPECT_EQ(0, strcmp(page0->GetData(), random_binary_data));
+  EXPECT_EQ(0, strncmp(page0->GetData(), random_binary_data, PAGE_SIZE));
   EXPECT_EQ(true, bpm->UnpinPage(0, true));
 
   // Shutdown the disk manager and remove the temporary file we created.


### PR DESCRIPTION
For comparing all the bytes of pages, we need to use `std::strncmp` with `PAGE_SIZE` as an argument, like what we have done in [here](https://github.com/cmu-db/bustub/blob/449b85fa817005afcb1856d603b1ac480fe2ca90/test/buffer/buffer_pool_manager_test.cpp#L52).