### PR TITLE
issue#97, using memcmp,memcpy instead of strcmp,strcpy respectively f…

### DIFF
--- a/test/buffer/buffer_pool_manager_test.cpp
+++ b/test/buffer/buffer_pool_manager_test.cpp
@@ -45,8 +45,8 @@ TEST(BufferPoolManagerTest, DISABLED_BinaryDataTest) {
   random_binary_data[PAGE_SIZE - 1] = '\0';
 
   // Scenario: Once we have a page, we should be able to read and write content.
-  std::strncpy(page0->GetData(), random_binary_data, PAGE_SIZE);
-  EXPECT_EQ(0, std::strcmp(page0->GetData(), random_binary_data));
+  std::memcpy(page0->GetData(), random_binary_data, PAGE_SIZE);
+  EXPECT_EQ(0, std::memcmp(page0->GetData(), random_binary_data, PAGE_SIZE));
 
   // Scenario: We should be able to create new pages until we fill up the buffer pool.
   for (size_t i = 1; i < buffer_pool_size; ++i) {
@@ -70,7 +70,7 @@ TEST(BufferPoolManagerTest, DISABLED_BinaryDataTest) {
   }
   // Scenario: We should be able to fetch the data we wrote a while ago.
   page0 = bpm->FetchPage(0);
-  EXPECT_EQ(0, strcmp(page0->GetData(), random_binary_data));
+  EXPECT_EQ(0, std::memcmp(page0->GetData(), random_binary_data, PAGE_SIZE));
   EXPECT_EQ(true, bpm->UnpinPage(0, true));
 
   // Shutdown the disk manager and remove the temporary file we created.


### PR DESCRIPTION
Using memcmp, memcpy instead of strcmp, strcpy respectively for copying and testing random binary data. Resolved issue#97