### PR TITLE
Fix Index Key in Test

### DIFF
--- a/src/include/execution/executors/update_executor.h
+++ b/src/include/execution/executors/update_executor.h
@@ -80,7 +80,7 @@ class UpdateExecutor : public AbstractExecutor {
   const UpdatePlanNode *plan_;
   /** Metadata identifying the table that should be updated. */
   const TableMetadata *table_info_;
-  /** The child executor to obtain value from, can be nullptr. */
+  /** The child executor to obtain value from. */
   std::unique_ptr<AbstractExecutor> child_executor_;
 };
 }  // namespace bustub


### PR DESCRIPTION
This PR makes SimpleRawInsertWithIndexTest explicitly call keyFromTuple to construct index key