### PR TITLE
Move IndexIterator dtor default to header file to fix a clang-tidy issue

### DIFF
--- a/src/include/storage/index/index_iterator.h
+++ b/src/include/storage/index/index_iterator.h
@@ -24,7 +24,7 @@ class IndexIterator {
  public:
   // you may define your own constructor based on your member variables
   IndexIterator();
-  ~IndexIterator();
+  ~IndexIterator() = default;
 
   bool isEnd();
 

--- a/src/storage/index/index_iterator.cpp
+++ b/src/storage/index/index_iterator.cpp
@@ -15,9 +15,6 @@ INDEX_TEMPLATE_ARGUMENTS
 INDEXITERATOR_TYPE::IndexIterator() = default;
 
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE::~IndexIterator() = default;
-
-INDEX_TEMPLATE_ARGUMENTS
 bool INDEXITERATOR_TYPE::isEnd() { throw std::runtime_error("unimplemented"); }
 
 INDEX_TEMPLATE_ARGUMENTS


### PR DESCRIPTION
Upon running `make check-clang-tidy`, I noticed that the `performance-trivially-destructible` was failing:

```
/home/spraza/code/bustub/src/include/storage/index/index_iterator.h:27:3: error: class 'IndexIterator' can be made trivi
ally destructible by defaulting the destructor on its first declaration [performance-trivially-destructible,-warnings-as
-errors]                                                                                                                
  ~IndexIterator();                                         
  ^                                                                                                                     
                   = default                                
/home/spraza/code/bustub/src/storage/index/index_iterator.cpp:18:21: note: destructor definition is here                
INDEXITERATOR_TYPE::~IndexIterator() = default;                                                                         
                    ^                                                                                                   
 Checking: /home/spraza/code/bustub/test/primer/starter_test.cppThe files that failed were:                             
[u'/home/spraza/code/bustub/src/storage/index/index_iterator.cpp']
Note that a failing .h file will fail all the .cpp files that include it.                                               
                                                                                                                        
                                                            
make[3]: *** [CMakeFiles/check-clang-tidy.dir/build.make:57: CMakeFiles/check-clang-tidy] Error 1                       
make[2]: *** [CMakeFiles/Makefile2:206: CMakeFiles/check-clang-tidy.dir/all] Error 2                                    
make[1]: *** [CMakeFiles/Makefile2:213: CMakeFiles/check-clang-tidy.dir/rule] Error 2
make: *** [Makefile:175: check-clang-tidy] Error 2                                                  
```

So I moved the dtor default to the header file as `clang-tidy` suggested. 

If you're interested:

```
$ clang-tidy --version
LLVM (http://llvm.org/):
  LLVM version 10.0.0
  
  Optimized build.
  Default target: x86_64-pc-linux-gnu
  Host CPU: znver2
```