### PR TITLE
Use SetUp() and TearDown() to clean up test.db and test.log

### DIFF
--- a/test/recovery/recovery_test.cpp
+++ b/test/recovery/recovery_test.cpp
@@ -40,7 +40,6 @@ class RecoveryTest : public ::testing::Test {
     remove("test.db");
     remove("test.log");
   };
-
 };
 
 // NOLINTNEXTLINE

--- a/test/recovery/recovery_test.cpp
+++ b/test/recovery/recovery_test.cpp
@@ -26,11 +26,25 @@
 
 namespace bustub {
 
-// NOLINTNEXTLINE
-TEST(RecoveryTest, DISABLED_RedoTest) {
-  remove("test.db");
-  remove("test.log");
+class RecoveryTest : public ::testing::Test {
+ protected:
+  // This function is called before every test.
+  void SetUp() override {
+    remove("test.db");
+    remove("test.log");
+  }
 
+  // This function is called after every test.
+  void TearDown() override {
+    LOG_INFO("Tearing down the system..");
+    remove("test.db");
+    remove("test.log");
+  };
+
+};
+
+// NOLINTNEXTLINE
+TEST_F(RecoveryTest, DISABLED_RedoTest) {
   BustubInstance *bustub_instance = new BustubInstance("test.db");
 
   ASSERT_FALSE(enable_logging);
@@ -116,15 +130,10 @@ TEST(RecoveryTest, DISABLED_RedoTest) {
   ASSERT_EQ(old_tuple1.GetValue(&schema, 0).CompareEquals(val1_0), CmpBool::CmpTrue);
 
   delete bustub_instance;
-  LOG_INFO("Tearing down the system..");
-  remove("test.db");
-  remove("test.log");
 }
 
 // NOLINTNEXTLINE
-TEST(RecoveryTest, DISABLED_UndoTest) {
-  remove("test.db");
-  remove("test.log");
+TEST_F(RecoveryTest, DISABLED_UndoTest) {
   BustubInstance *bustub_instance = new BustubInstance("test.db");
 
   ASSERT_FALSE(enable_logging);
@@ -200,15 +209,10 @@ TEST(RecoveryTest, DISABLED_UndoTest) {
   delete log_recovery;
 
   delete bustub_instance;
-  LOG_INFO("Tearing down the system..");
-  remove("test.db");
-  remove("test.log");
 }
 
 // NOLINTNEXTLINE
-TEST(RecoveryTest, DISABLED_CheckpointTest) {
-  remove("test.db");
-  remove("test.log");
+TEST_F(RecoveryTest, DISABLED_CheckpointTest) {
   BustubInstance *bustub_instance = new BustubInstance("test.db");
 
   EXPECT_FALSE(enable_logging);
@@ -309,9 +313,5 @@ TEST(RecoveryTest, DISABLED_CheckpointTest) {
 
   LOG_INFO("Shutdown System");
   delete bustub_instance;
-
-  LOG_INFO("Tearing down the system..");
-  remove("test.db");
-  remove("test.log");
 }
 }  // namespace bustub

--- a/test/storage/disk_manager_test.cpp
+++ b/test/storage/disk_manager_test.cpp
@@ -18,9 +18,23 @@
 
 namespace bustub {
 
+class DiskManagerTest : public ::testing::Test {
+ protected:
+  // This function is called before every test.
+  void SetUp() override {
+    remove("test.db");
+    remove("test.log");
+  }
+
+  // This function is called after every test.
+  void TearDown() override {
+    remove("test.db");
+    remove("test.log");
+  };
+};
+
 // NOLINTNEXTLINE
-TEST(DiskManagerTest, ReadWritePageTest) {
-  remove("test.db");
+TEST_F(DiskManagerTest, ReadWritePageTest) {
   char buf[PAGE_SIZE] = {0};
   char data[PAGE_SIZE] = {0};
   std::string db_file("test.db");
@@ -39,13 +53,10 @@ TEST(DiskManagerTest, ReadWritePageTest) {
   EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
 
   dm.ShutDown();
-  remove(db_file.c_str());
 }
 
 // NOLINTNEXTLINE
-TEST(DiskManagerTest, ReadWriteLogTest) {
-  remove("test.db");
-  remove("test.log");
+TEST_F(DiskManagerTest, ReadWriteLogTest) {
   char buf[16] = {0};
   char data[16] = {0};
   std::string db_file("test.db");
@@ -59,11 +70,9 @@ TEST(DiskManagerTest, ReadWriteLogTest) {
   EXPECT_EQ(std::memcmp(buf, data, sizeof(buf)), 0);
 
   dm.ShutDown();
-  remove(db_file.c_str());
-  remove("test.log");
 }
 
 // NOLINTNEXTLINE
-TEST(DiskManagerTest, ThrowBadFileTest) { EXPECT_THROW(DiskManager("dev/null\\/foo/bar/baz/test.db"), Exception); }
+TEST_F(DiskManagerTest, ThrowBadFileTest) { EXPECT_THROW(DiskManager("dev/null\\/foo/bar/baz/test.db"), Exception); }
 
 }  // namespace bustub

--- a/test/storage/disk_manager_test.cpp
+++ b/test/storage/disk_manager_test.cpp
@@ -20,6 +20,7 @@ namespace bustub {
 
 // NOLINTNEXTLINE
 TEST(DiskManagerTest, ReadWritePageTest) {
+  remove("test.db");
   char buf[PAGE_SIZE] = {0};
   char data[PAGE_SIZE] = {0};
   std::string db_file("test.db");
@@ -41,7 +42,10 @@ TEST(DiskManagerTest, ReadWritePageTest) {
   remove(db_file.c_str());
 }
 
+// NOLINTNEXTLINE
 TEST(DiskManagerTest, ReadWriteLogTest) {
+  remove("test.db");
+  remove("test.log");
   char buf[16] = {0};
   char data[16] = {0};
   std::string db_file("test.db");
@@ -56,8 +60,10 @@ TEST(DiskManagerTest, ReadWriteLogTest) {
 
   dm.ShutDown();
   remove(db_file.c_str());
+  remove("test.log");
 }
 
+// NOLINTNEXTLINE
 TEST(DiskManagerTest, ThrowBadFileTest) { EXPECT_THROW(DiskManager("dev/null\\/foo/bar/baz/test.db"), Exception); }
 
 }  // namespace bustub


### PR DESCRIPTION
- Remove test.db and test.log before test run to avoid test
  failures caused by non-empty test.db and test.log from
  other failed tests.
- Add NOLINTNEXTLINE.
- Use SetUp() and TearDown() methods in RecoveryTest 
  and DiskManagerTest.