### PR TITLE
Changing compliance for zero-length arrays

### DIFF
--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -62,6 +62,6 @@ class BPlusTreeInternalPage : public BPlusTreePage {
   void CopyLastFrom(const MappingType &pair, BufferPoolManager *buffer_pool_manager);
   void CopyFirstFrom(const MappingType &pair, BufferPoolManager *buffer_pool_manager);
   // Flexible array member for page data.
-  MappingType array[1];
+  MappingType array_[1];
 };
 }  // namespace bustub

--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -61,6 +61,7 @@ class BPlusTreeInternalPage : public BPlusTreePage {
   void CopyNFrom(MappingType *items, int size, BufferPoolManager *buffer_pool_manager);
   void CopyLastFrom(const MappingType &pair, BufferPoolManager *buffer_pool_manager);
   void CopyFirstFrom(const MappingType &pair, BufferPoolManager *buffer_pool_manager);
+  // Flexible array member for page data.
   MappingType array[1];
 };
 }  // namespace bustub

--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -61,6 +61,6 @@ class BPlusTreeInternalPage : public BPlusTreePage {
   void CopyNFrom(MappingType *items, int size, BufferPoolManager *buffer_pool_manager);
   void CopyLastFrom(const MappingType &pair, BufferPoolManager *buffer_pool_manager);
   void CopyFirstFrom(const MappingType &pair, BufferPoolManager *buffer_pool_manager);
-  MappingType array_[0];
+  MappingType array[1];
 };
 }  // namespace bustub

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -68,6 +68,6 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   void CopyLastFrom(const MappingType &item);
   void CopyFirstFrom(const MappingType &item);
   page_id_t next_page_id_;
-  MappingType array_[0];
+  MappingType array[1];
 };
 }  // namespace bustub

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -69,6 +69,6 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   void CopyFirstFrom(const MappingType &item);
   page_id_t next_page_id_;
   // Flexible array member for page data.
-  MappingType array[1];
+  MappingType array_[1];
 };
 }  // namespace bustub

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -68,6 +68,7 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   void CopyLastFrom(const MappingType &item);
   void CopyFirstFrom(const MappingType &item);
   page_id_t next_page_id_;
+  // Flexible array member for page data.
   MappingType array[1];
 };
 }  // namespace bustub

--- a/src/include/storage/page/hash_table_block_page.h
+++ b/src/include/storage/page/hash_table_block_page.h
@@ -143,7 +143,7 @@ class HashTableBlockPage {
 
   // 0 if tombstone/brand new (never occupied), 1 otherwise.
   std::atomic_char readable_[(BLOCK_ARRAY_SIZE - 1) / 8 + 1];
-  MappingType array_[0];
+  MappingType array_[1];
 };
 
 }  // namespace bustub

--- a/src/include/storage/page/hash_table_block_page.h
+++ b/src/include/storage/page/hash_table_block_page.h
@@ -143,6 +143,7 @@ class HashTableBlockPage {
 
   // 0 if tombstone/brand new (never occupied), 1 otherwise.
   std::atomic_char readable_[(BLOCK_ARRAY_SIZE - 1) / 8 + 1];
+  // Flexible array member for page data.
   MappingType array_[1];
 };
 

--- a/src/include/storage/page/hash_table_bucket_page.h
+++ b/src/include/storage/page/hash_table_bucket_page.h
@@ -142,7 +142,7 @@ class HashTableBucketPage {
   char occupied_[(BUCKET_ARRAY_SIZE - 1) / 8 + 1];
   // 0 if tombstone/brand new (never occupied), 1 otherwise.
   char readable_[(BUCKET_ARRAY_SIZE - 1) / 8 + 1];
-  MappingType array_[0];
+  MappingType array_[1];
 };
 
 }  // namespace bustub

--- a/src/include/storage/page/hash_table_header_page.h
+++ b/src/include/storage/page/hash_table_header_page.h
@@ -94,6 +94,7 @@ class HashTableHeaderPage {
   __attribute__((unused)) size_t size_;
   __attribute__((unused)) page_id_t page_id_;
   __attribute__((unused)) size_t next_ind_;
+  // Flexible array member for page data.
   __attribute__((unused)) page_id_t block_page_ids_[1];
 };
 

--- a/src/include/storage/page/hash_table_header_page.h
+++ b/src/include/storage/page/hash_table_header_page.h
@@ -94,7 +94,7 @@ class HashTableHeaderPage {
   __attribute__((unused)) size_t size_;
   __attribute__((unused)) page_id_t page_id_;
   __attribute__((unused)) size_t next_ind_;
-  __attribute__((unused)) page_id_t block_page_ids_[0];
+  __attribute__((unused)) page_id_t block_page_ids_[1];
 };
 
 }  // namespace bustub


### PR DESCRIPTION
C++ does not support flexible array members. [Here's a good source](http://david.tribble.com/text/cdiffs.htm#C99-fam).

This is only supported by compiler convention.

If you want to abuse C99 things where the C++ compiler plays nice, remove the number altogether i.e. `MappingType array[];`.

Seeing as how this type is always instantiate via a reinterpret cast, this should not be a performance or correctness issue.

The issue with this being undefined behavior is that it may not exist, or may go away if a compiler optimization level deems it to be a candidate for "no-unique-address" behavior.