### PR TITLE
Fix conversion loss when checking BIGINT bounds in decimal_type.cpp

### DIFF
--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -298,7 +298,8 @@ Value DecimalType::CastAs(const Value &val, const TypeId type_id) const {
       if (val.IsNull()) {
         return Value(type_id, BUSTUB_INT64_NULL);
       }
-      if (val.GetAs<double>() > BUSTUB_INT64_MAX || val.GetAs<double>() < BUSTUB_INT64_MIN) {
+      if (val.GetAs<double>() >= static_cast<double>(BUSTUB_INT64_MAX) ||
+          val.GetAs<double>() < static_cast<double>(BUSTUB_INT64_MIN)) {
         throw Exception(ExceptionType::OUT_OF_RANGE, "Numeric value out of range.");
       }
       return Value(type_id, static_cast<int64_t>(val.GetAs<double>()));


### PR DESCRIPTION
BUSTUB_INT64_MAX
conversion from 'const int64_t' (aka 'const long') to 'double' changes value from 9223372036854775807 to 9223372036854775808

BUSTUB_INT64_MIN
conversion from 'const int64_t' (aka 'const long') to 'double' changes value from -9223372036854775807 to -9223372036854775808

value  >= static_cast<double>(BUSTUB_INT64_MAX) || value < static_cast<double>(BUSTUB_INT64_MIN)

so the value at this range will throw OUT_OF_RANGE exception
 
