### PR TITLE
Fix initialize instance_index_ in BPI

### DIFF
--- a/src/buffer/buffer_pool_manager_instance.cpp
+++ b/src/buffer/buffer_pool_manager_instance.cpp
@@ -24,6 +24,7 @@ BufferPoolManagerInstance::BufferPoolManagerInstance(size_t pool_size, uint32_t 
                                                      DiskManager *disk_manager, LogManager *log_manager)
     : pool_size_(pool_size),
       num_instances_(num_instances),
+      instance_index_(instance_index),
       next_page_id_(instance_index),
       disk_manager_(disk_manager),
       log_manager_(log_manager) {


### PR DESCRIPTION
In `BufferPoolManagerInstance::ValidatePageId`, the `page_id` mod `num_instances` with `the instance_index` is assert to be equal, but the `instance_index` is not assigned an initial value in **BPI**, which causes its value to always be 0.
