### PR TITLE
FIX filepath properly truncated in logger

### DIFF
--- a/src/include/common/logger.h
+++ b/src/include/common/logger.h
@@ -42,7 +42,7 @@ namespace bustub {
 using cstr = const char *;
 
 static constexpr cstr PastLastSlash(cstr a, cstr b) {
-  return *a == '\0' ? b : *b == '/' ? PastLastSlash(a + 1, a + 1) : PastLastSlash(a + 1, b);
+  return *a == '\0' ? b : *a == '/' ? PastLastSlash(a + 1, a + 1) : PastLastSlash(a + 1, b);
 }
 
 static constexpr cstr PastLastSlash(cstr a) { return PastLastSlash(a, a); }


### PR DESCRIPTION
Hi, sorry to bother you guys, there is this very tiny small typo in logger.h that cause `LOG_XXX` to print full filepath instead of just filename.

By the way, thanks for making educational material publicly available, this course is awesome.