### PR TITLE
unnecessary code block removed

### DIFF
--- a/src/storage/page/table_page.cpp
+++ b/src/storage/page/table_page.cpp
@@ -53,11 +53,6 @@ bool TablePage::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, Lock
     }
   }
 
-  // If there was no free slot left, and we cannot claim it from the free space, then we give up.
-  if (i == GetTupleCount() && GetFreeSpaceRemaining() < tuple.size_ + SIZE_TUPLE) {
-    return false;
-  }
-
   // Otherwise we claim available free space..
   SetFreeSpacePointer(GetFreeSpacePointer() - tuple.size_);
   memcpy(GetData() + GetFreeSpacePointer(), tuple.data_, tuple.size_);


### PR DESCRIPTION
```GetFreeSpaceRemaining() < tuple.size_ + SIZE_TUPLE``` check is already done in the beginning of the method and if it is true method returns directly hence when we come to 57th line ```GetFreeSpaceRemaining() < tuple.size_ + SIZE_TUPLE``` is false and it is impossible to get inside of the if block.