### PR TITLE
Extendible hashing refinements (not required for Project 2 2021)

### DIFF
--- a/src/container/hash/extendible_hash_table.cpp
+++ b/src/container/hash/extendible_hash_table.cpp
@@ -45,12 +45,12 @@ uint32_t HASH_TABLE_TYPE::Hash(KeyType key) {
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-inline uint32_t HASH_TABLE_TYPE::KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page) {
+uint32_t HASH_TABLE_TYPE::KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page) {
   return 0;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-inline uint32_t HASH_TABLE_TYPE::KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page) {
+page_id_t HASH_TABLE_TYPE::KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page) {
   return 0;
 }
 

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -110,7 +110,7 @@ class ExtendibleHashTable {
    * @param dir_page to use for lookup of global depth
    * @return the directory index
    */
-  inline uint32_t KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page);
+  uint32_t KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page);
 
   /**
    * Get the bucket page_id corresponding to a key.
@@ -119,7 +119,7 @@ class ExtendibleHashTable {
    * @param dir_page a pointer to the hash table's directory page
    * @return the bucket page_id corresponding to the input key
    */
-  inline uint32_t KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page);
+  page_id_t KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page);
 
   /**
    * Fetches the directory page from the buffer pool manager.

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -137,7 +137,9 @@ class ExtendibleHashTable {
   HASH_TABLE_BUCKET_TYPE *FetchBucketPage(page_id_t bucket_page_id);
 
   /**
-   * Performs insertion with an optional bucket splitting.
+   * Performs insertion with an optional bucket splitting.  If the 
+   * page is still full after the split, then recursively split.
+   * This is exceedingly rare, but possible.
    *
    * @param transaction a pointer to the current transaction
    * @param key the key to insert
@@ -154,6 +156,8 @@ class ExtendibleHashTable {
    * 1. The bucket is no longer empty.
    * 2. The bucket has local depth 0.
    * 3. The bucket's local depth doesn't match its split image's local depth.
+   * 
+   * Note: we do not merge recursively.
    *
    * @param transaction a pointer to the current transaction
    * @param key the key that was removed

--- a/src/include/storage/page/hash_table_bucket_page.h
+++ b/src/include/storage/page/hash_table_bucket_page.h
@@ -50,6 +50,7 @@ class HashTableBucketPage {
   /**
    * Attempts to insert a key and value in the bucket.  Uses the occupied_
    * and readable_ arrays to keep track of each slot's availability.
+   * Bucket insertion must always take the first available slot.
    *
    * @param key key to insert
    * @param value value to insert
@@ -138,10 +139,11 @@ class HashTableBucketPage {
   void PrintBucket();
 
  private:
-  //  For more on BUCKET_ARRAY_SIZE see storage/page/hash_table_page_defs.h
+  // For more on BUCKET_ARRAY_SIZE see storage/page/hash_table_page_defs.h
   char occupied_[(BUCKET_ARRAY_SIZE - 1) / 8 + 1];
   // 0 if tombstone/brand new (never occupied), 1 otherwise.
   char readable_[(BUCKET_ARRAY_SIZE - 1) / 8 + 1];
+  // Do not add any members below array_, as they will overlap.
   MappingType array_[0];
 };
 


### PR DESCRIPTION
- updated return type from uint32_t to page_id_t in an extendible hashing helper.  updated a comment to clarify behavior for bucket insertions
- added comments clarifying hash index SplitInsert and Merge behavior

DO NOT PUSH PROJECT SOLUTIONS PUBLICLY.

And especially do NOT open pull requests with project solutions!

Please be considerate of this free educational resource.
