### PR TITLE
fix: executor_test assertion for SimpleUpdateTest

### DIFF
--- a/test/execution/executor_test.cpp
+++ b/test/execution/executor_test.cpp
@@ -312,7 +312,7 @@ TEST_F(ExecutorTest, DISABLED_SimpleUpdateTest) {
   GetExecutionEngine()->Execute(update_plan.get(), &result_set, GetTxn(), GetExecutorContext());
 
   // UpdateExecutor should not modify the result set
-  ASSERT_EQ(result_set.size(), 0);
+  ASSERT_EQ(result_set.size(), TEST3_SIZE);
   result_set.clear();
 
   // Execute another sequential scan; no tuples should be present in the table


### PR DESCRIPTION
https://github.com/cmu-db/bustub/blob/9b0da5ebe0985de726ee299b7bec60dc56f1086a/test/execution/executor_test.cpp#L314-L315

The UpdateExecutor really shouldn't modify the result set, but I think the result set of size is TEST3_SIZE.