### PR TITLE
Add const mark to replacer size method

### DIFF
--- a/src/buffer/clock_replacer.cpp
+++ b/src/buffer/clock_replacer.cpp
@@ -24,6 +24,6 @@ void ClockReplacer::Pin(frame_id_t frame_id) {}
 
 void ClockReplacer::Unpin(frame_id_t frame_id) {}
 
-size_t ClockReplacer::Size() { return 0; }
+size_t ClockReplacer::Size() const { return 0; }
 
 }  // namespace bustub

--- a/src/buffer/lru_replacer.cpp
+++ b/src/buffer/lru_replacer.cpp
@@ -24,6 +24,6 @@ void LRUReplacer::Pin(frame_id_t frame_id) {}
 
 void LRUReplacer::Unpin(frame_id_t frame_id) {}
 
-size_t LRUReplacer::Size() { return 0; }
+size_t LRUReplacer::Size() const { return 0; }
 
 }  // namespace bustub

--- a/src/include/buffer/clock_replacer.h
+++ b/src/include/buffer/clock_replacer.h
@@ -43,7 +43,7 @@ class ClockReplacer : public Replacer {
 
   void Unpin(frame_id_t frame_id) override;
 
-  size_t Size() override;
+  size_t Size() const override;
 
  private:
   // TODO(student): implement me!

--- a/src/include/buffer/lru_replacer.h
+++ b/src/include/buffer/lru_replacer.h
@@ -43,7 +43,7 @@ class LRUReplacer : public Replacer {
 
   void Unpin(frame_id_t frame_id) override;
 
-  size_t Size() override;
+  size_t Size() const override;
 
  private:
   // TODO(student): implement me!

--- a/src/include/buffer/replacer.h
+++ b/src/include/buffer/replacer.h
@@ -44,7 +44,7 @@ class Replacer {
   virtual void Unpin(frame_id_t frame_id) = 0;
 
   /** @return the number of elements in the replacer that can be victimized */
-  virtual size_t Size() = 0;
+  virtual size_t Size() const = 0;
 };
 
 }  // namespace bustub


### PR DESCRIPTION
It is supposed to be marked as const for replacer size method since it doesn't change any member variables.