### PR TITLE
Apply clang-tidy modernize-use-trailing-return-type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,6 @@ Checks:     '
             -modernize-avoid-c-arrays,
             -modernize-use-nodiscard,
             -modernize-use-auto,
-            -modernize-use-trailing-return-type,
             -modernize-use-default-member-init,
             -modernize-return-braced-init-list,
             -readability-convert-member-functions-to-static,

--- a/build_support/run_clang_tidy.py
+++ b/build_support/run_clang_tidy.py
@@ -105,7 +105,6 @@ def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
     if config:
         start.append('-config=' + config)
     start.append(f)
-    start.append("-fix")
     return start
 
 def merge_replacement_files(tmpdir, mergefile):
@@ -272,7 +271,6 @@ def main():
     if max_task == 0:
         max_task = multiprocessing.cpu_count()
 
-    max_task = 1
     tmpdir = None
     if args.fix or args.export_fixes:
         check_clang_apply_replacements_binary(args)

--- a/build_support/run_clang_tidy.py
+++ b/build_support/run_clang_tidy.py
@@ -105,6 +105,7 @@ def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
     if config:
         start.append('-config=' + config)
     start.append(f)
+    start.append("-fix")
     return start
 
 def merge_replacement_files(tmpdir, mergefile):
@@ -271,6 +272,7 @@ def main():
     if max_task == 0:
         max_task = multiprocessing.cpu_count()
 
+    max_task = 1
     tmpdir = None
     if args.fix or args.export_fixes:
         check_clang_apply_replacements_binary(args)

--- a/src/buffer/buffer_pool_manager_instance.cpp
+++ b/src/buffer/buffer_pool_manager_instance.cpp
@@ -47,7 +47,7 @@ BufferPoolManagerInstance::~BufferPoolManagerInstance() {
   delete replacer_;
 }
 
-bool BufferPoolManagerInstance::FlushPgImp(page_id_t page_id) {
+auto BufferPoolManagerInstance::FlushPgImp(page_id_t page_id) -> bool {
   // Make sure you call DiskManager::WritePage!
   return false;
 }
@@ -56,7 +56,7 @@ void BufferPoolManagerInstance::FlushAllPgsImp() {
   // You can do it!
 }
 
-Page *BufferPoolManagerInstance::NewPgImp(page_id_t *page_id) {
+auto BufferPoolManagerInstance::NewPgImp(page_id_t *page_id) -> Page * {
   // 0.   Make sure you call AllocatePage!
   // 1.   If all the pages in the buffer pool are pinned, return nullptr.
   // 2.   Pick a victim page P from either the free list or the replacer. Always pick from the free list first.
@@ -65,7 +65,7 @@ Page *BufferPoolManagerInstance::NewPgImp(page_id_t *page_id) {
   return nullptr;
 }
 
-Page *BufferPoolManagerInstance::FetchPgImp(page_id_t page_id) {
+auto BufferPoolManagerInstance::FetchPgImp(page_id_t page_id) -> Page * {
   // 1.     Search the page table for the requested page (P).
   // 1.1    If P exists, pin it and return it immediately.
   // 1.2    If P does not exist, find a replacement page (R) from either the free list or the replacer.
@@ -76,7 +76,7 @@ Page *BufferPoolManagerInstance::FetchPgImp(page_id_t page_id) {
   return nullptr;
 }
 
-bool BufferPoolManagerInstance::DeletePgImp(page_id_t page_id) {
+auto BufferPoolManagerInstance::DeletePgImp(page_id_t page_id) -> bool {
   // 0.   Make sure you call DeallocatePage!
   // 1.   Search the page table for the requested page (P).
   // 1.   If P does not exist, return true.
@@ -85,9 +85,9 @@ bool BufferPoolManagerInstance::DeletePgImp(page_id_t page_id) {
   return false;
 }
 
-bool BufferPoolManagerInstance::UnpinPgImp(page_id_t page_id, bool is_dirty) { return false; }
+auto BufferPoolManagerInstance::UnpinPgImp(page_id_t page_id, bool is_dirty) -> bool { return false; }
 
-page_id_t BufferPoolManagerInstance::AllocatePage() {
+auto BufferPoolManagerInstance::AllocatePage() -> page_id_t {
   const page_id_t next_page_id = next_page_id_;
   next_page_id_ += num_instances_;
   ValidatePageId(next_page_id);

--- a/src/buffer/clock_replacer.cpp
+++ b/src/buffer/clock_replacer.cpp
@@ -18,12 +18,12 @@ ClockReplacer::ClockReplacer(size_t num_pages) {}
 
 ClockReplacer::~ClockReplacer() = default;
 
-bool ClockReplacer::Victim(frame_id_t *frame_id) { return false; }
+auto ClockReplacer::Victim(frame_id_t *frame_id) -> bool { return false; }
 
 void ClockReplacer::Pin(frame_id_t frame_id) {}
 
 void ClockReplacer::Unpin(frame_id_t frame_id) {}
 
-size_t ClockReplacer::Size() { return 0; }
+auto ClockReplacer::Size() -> size_t { return 0; }
 
 }  // namespace bustub

--- a/src/buffer/lru_replacer.cpp
+++ b/src/buffer/lru_replacer.cpp
@@ -18,12 +18,12 @@ LRUReplacer::LRUReplacer(size_t num_pages) {}
 
 LRUReplacer::~LRUReplacer() = default;
 
-bool LRUReplacer::Victim(frame_id_t *frame_id) { return false; }
+auto LRUReplacer::Victim(frame_id_t *frame_id) -> bool { return false; }
 
 void LRUReplacer::Pin(frame_id_t frame_id) {}
 
 void LRUReplacer::Unpin(frame_id_t frame_id) {}
 
-size_t LRUReplacer::Size() { return 0; }
+auto LRUReplacer::Size() -> size_t { return 0; }
 
 }  // namespace bustub

--- a/src/buffer/parallel_buffer_pool_manager.cpp
+++ b/src/buffer/parallel_buffer_pool_manager.cpp
@@ -22,32 +22,32 @@ ParallelBufferPoolManager::ParallelBufferPoolManager(size_t num_instances, size_
 // Update constructor to destruct all BufferPoolManagerInstances and deallocate any associated memory
 ParallelBufferPoolManager::~ParallelBufferPoolManager() = default;
 
-size_t ParallelBufferPoolManager::GetPoolSize() {
+auto ParallelBufferPoolManager::GetPoolSize() -> size_t {
   // Get size of all BufferPoolManagerInstances
   return 0;
 }
 
-BufferPoolManager *ParallelBufferPoolManager::GetBufferPoolManager(page_id_t page_id) {
+auto ParallelBufferPoolManager::GetBufferPoolManager(page_id_t page_id) -> BufferPoolManager * {
   // Get BufferPoolManager responsible for handling given page id. You can use this method in your other methods.
   return nullptr;
 }
 
-Page *ParallelBufferPoolManager::FetchPgImp(page_id_t page_id) {
+auto ParallelBufferPoolManager::FetchPgImp(page_id_t page_id) -> Page * {
   // Fetch page for page_id from responsible BufferPoolManagerInstance
   return nullptr;
 }
 
-bool ParallelBufferPoolManager::UnpinPgImp(page_id_t page_id, bool is_dirty) {
+auto ParallelBufferPoolManager::UnpinPgImp(page_id_t page_id, bool is_dirty) -> bool {
   // Unpin page_id from responsible BufferPoolManagerInstance
   return false;
 }
 
-bool ParallelBufferPoolManager::FlushPgImp(page_id_t page_id) {
+auto ParallelBufferPoolManager::FlushPgImp(page_id_t page_id) -> bool {
   // Flush page_id from responsible BufferPoolManagerInstance
   return false;
 }
 
-Page *ParallelBufferPoolManager::NewPgImp(page_id_t *page_id) {
+auto ParallelBufferPoolManager::NewPgImp(page_id_t *page_id) -> Page * {
   // create new page. We will request page allocation in a round robin manner from the underlying
   // BufferPoolManagerInstances
   // 1.   From a starting index of the BPMIs, call NewPageImpl until either 1) success and return 2) looped around to
@@ -57,7 +57,7 @@ Page *ParallelBufferPoolManager::NewPgImp(page_id_t *page_id) {
   return nullptr;
 }
 
-bool ParallelBufferPoolManager::DeletePgImp(page_id_t page_id) {
+auto ParallelBufferPoolManager::DeletePgImp(page_id_t page_id) -> bool {
   // Delete page_id from responsible BufferPoolManagerInstance
   return false;
 }

--- a/src/catalog/column.cpp
+++ b/src/catalog/column.cpp
@@ -17,7 +17,7 @@
 
 namespace bustub {
 
-std::string Column::ToString() const {
+auto Column::ToString() const -> std::string {
   std::ostringstream os;
 
   os << "Column[" << column_name_ << ", " << Type::TypeIdToString(column_type_) << ", "

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -38,7 +38,7 @@ Schema::Schema(const std::vector<Column> &columns) : tuple_is_inlined_(true) {
   length_ = curr_offset;
 }
 
-std::string Schema::ToString() const {
+auto Schema::ToString() const -> std::string {
   std::ostringstream os;
 
   os << "Schema["

--- a/src/catalog/table_generator.cpp
+++ b/src/catalog/table_generator.cpp
@@ -7,7 +7,7 @@
 namespace bustub {
 
 template <typename CppType>
-std::vector<Value> TableGenerator::GenNumericValues(ColumnInsertMeta *col_meta, uint32_t count) {
+auto TableGenerator::GenNumericValues(ColumnInsertMeta *col_meta, uint32_t count) -> std::vector<Value> {
   std::vector<Value> values{};
   values.reserve(count);
 
@@ -43,7 +43,7 @@ std::vector<Value> TableGenerator::GenNumericValues(ColumnInsertMeta *col_meta, 
   return values;
 }
 
-std::vector<Value> TableGenerator::MakeValues(ColumnInsertMeta *col_meta, uint32_t count) {
+auto TableGenerator::MakeValues(ColumnInsertMeta *col_meta, uint32_t count) -> std::vector<Value> {
   std::vector<Value> values;
   switch (col_meta->type_) {
     case TypeId::TINYINT:

--- a/src/common/util/string_util.cpp
+++ b/src/common/util/string_util.cpp
@@ -23,7 +23,7 @@
 
 namespace bustub {
 
-bool StringUtil::Contains(const std::string &haystack, const std::string &needle) {
+auto StringUtil::Contains(const std::string &haystack, const std::string &needle) -> bool {
   return (haystack.find(needle) != std::string::npos);
 }
 
@@ -32,13 +32,13 @@ void StringUtil::RTrim(std::string *str) {
   str->erase(std::find_if(str->rbegin(), str->rend(), [](int ch) { return std::isspace(ch) == 0; }).base(), str->end());
 }
 
-std::string StringUtil::Indent(int num_indent) { return std::string(num_indent, ' '); }
+auto StringUtil::Indent(int num_indent) -> std::string { return std::string(num_indent, ' '); }
 
-bool StringUtil::StartsWith(const std::string &str, const std::string &prefix) {
+auto StringUtil::StartsWith(const std::string &str, const std::string &prefix) -> bool {
   return std::equal(prefix.begin(), prefix.end(), str.begin());
 }
 
-bool StringUtil::EndsWith(const std::string &str, const std::string &suffix) {
+auto StringUtil::EndsWith(const std::string &str, const std::string &suffix) -> bool {
   // http://stackoverflow.com/a/2072890
   if (suffix.size() > str.size()) {
     return false;
@@ -46,7 +46,7 @@ bool StringUtil::EndsWith(const std::string &str, const std::string &suffix) {
   return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
 }
 
-std::string StringUtil::Repeat(const std::string &str, const std::size_t n) {
+auto StringUtil::Repeat(const std::string &str, const std::size_t n) -> std::string {
   std::ostringstream os;
   if (n == 0 || str.empty()) {
     return (os.str());
@@ -57,7 +57,7 @@ std::string StringUtil::Repeat(const std::string &str, const std::size_t n) {
   return (os.str());
 }
 
-std::vector<std::string> StringUtil::Split(const std::string &str, char delimiter) {
+auto StringUtil::Split(const std::string &str, char delimiter) -> std::vector<std::string> {
   std::stringstream ss(str);
   std::vector<std::string> lines;
   std::string temp;
@@ -67,7 +67,7 @@ std::vector<std::string> StringUtil::Split(const std::string &str, char delimite
   return (lines);
 }
 
-std::string StringUtil::Join(const std::vector<std::string> &input, const std::string &separator) {
+auto StringUtil::Join(const std::vector<std::string> &input, const std::string &separator) -> std::string {
   std::string result;
 
   // If the input isn't empty, append the first element. We do this so we don't need to introduce an if into the loop.
@@ -83,7 +83,7 @@ std::string StringUtil::Join(const std::vector<std::string> &input, const std::s
   return result;
 }
 
-std::string StringUtil::Prefix(const std::string &str, const std::string &prefix) {
+auto StringUtil::Prefix(const std::string &str, const std::string &prefix) -> std::string {
   std::vector<std::string> lines = StringUtil::Split(str, '\n');
 
   if (lines.empty()) {
@@ -100,7 +100,7 @@ std::string StringUtil::Prefix(const std::string &str, const std::string &prefix
   return (os.str());
 }
 
-std::string StringUtil::FormatSize(uint64_t bytes) {
+auto StringUtil::FormatSize(uint64_t bytes) -> std::string {
   // http://ubuntuforums.org/showpost.php?p=10215516&postcount=5
   double base = 1024;
   double kb = base;
@@ -121,7 +121,7 @@ std::string StringUtil::FormatSize(uint64_t bytes) {
   return (os.str());
 }
 
-std::string StringUtil::Bold(const std::string &str) {
+auto StringUtil::Bold(const std::string &str) -> std::string {
   std::string set_plain_text = "\033[0;0m";
   std::string set_bold_text = "\033[0;1m";
 
@@ -130,13 +130,13 @@ std::string StringUtil::Bold(const std::string &str) {
   return (os.str());
 }
 
-std::string StringUtil::Upper(const std::string &str) {
+auto StringUtil::Upper(const std::string &str) -> std::string {
   std::string copy(str);
   std::transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::toupper(c); });
   return (copy);
 }
 
-std::string StringUtil::Lower(const std::string &str) {
+auto StringUtil::Lower(const std::string &str) -> std::string {
   std::string copy(str);
   std::transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::tolower(c); });
   return (copy);
@@ -168,7 +168,7 @@ std::string StringUtil::Format(std::string fmt_str, ...) {
   return std::string(formatted.get());
 }
 
-std::vector<std::string> StringUtil::Split(const std::string &input, const std::string &split) {
+auto StringUtil::Split(const std::string &input, const std::string &split) -> std::vector<std::string> {
   std::vector<std::string> splits;
 
   size_t last = 0;
@@ -190,7 +190,7 @@ std::vector<std::string> StringUtil::Split(const std::string &input, const std::
   return splits;
 }
 
-std::string StringUtil::Strip(const std::string &str, char c) {
+auto StringUtil::Strip(const std::string &str, char c) -> std::string {
   // There's a copy here which is wasteful, so don't use this in performance-critical code!
   std::string tmp = str;
   tmp.erase(std::remove(tmp.begin(), tmp.end(), c), tmp.end());

--- a/src/concurrency/lock_manager.cpp
+++ b/src/concurrency/lock_manager.cpp
@@ -17,23 +17,23 @@
 
 namespace bustub {
 
-bool LockManager::LockShared(Transaction *txn, const RID &rid) {
+auto LockManager::LockShared(Transaction *txn, const RID &rid) -> bool {
   txn->GetSharedLockSet()->emplace(rid);
   return true;
 }
 
-bool LockManager::LockExclusive(Transaction *txn, const RID &rid) {
+auto LockManager::LockExclusive(Transaction *txn, const RID &rid) -> bool {
   txn->GetExclusiveLockSet()->emplace(rid);
   return true;
 }
 
-bool LockManager::LockUpgrade(Transaction *txn, const RID &rid) {
+auto LockManager::LockUpgrade(Transaction *txn, const RID &rid) -> bool {
   txn->GetSharedLockSet()->erase(rid);
   txn->GetExclusiveLockSet()->emplace(rid);
   return true;
 }
 
-bool LockManager::Unlock(Transaction *txn, const RID &rid) {
+auto LockManager::Unlock(Transaction *txn, const RID &rid) -> bool {
   txn->GetSharedLockSet()->erase(rid);
   txn->GetExclusiveLockSet()->erase(rid);
   return true;

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -23,7 +23,7 @@ namespace bustub {
 std::unordered_map<txn_id_t, Transaction *> TransactionManager::txn_map = {};
 std::shared_mutex TransactionManager::txn_map_mutex = {};
 
-Transaction *TransactionManager::Begin(Transaction *txn, IsolationLevel isolation_level) {
+auto TransactionManager::Begin(Transaction *txn, IsolationLevel isolation_level) -> Transaction * {
   // Acquire the global transaction latch in shared mode.
   global_txn_latch_.RLock();
 

--- a/src/container/hash/extendible_hash_table.cpp
+++ b/src/container/hash/extendible_hash_table.cpp
@@ -40,27 +40,27 @@ HASH_TABLE_TYPE::ExtendibleHashTable(const std::string &name, BufferPoolManager 
  * @return the downcasted 32-bit hash
  */
 template <typename KeyType, typename ValueType, typename KeyComparator>
-uint32_t HASH_TABLE_TYPE::Hash(KeyType key) {
+auto HASH_TABLE_TYPE::Hash(KeyType key) -> uint32_t {
   return static_cast<uint32_t>(hash_fn_.GetHash(key));
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-inline uint32_t HASH_TABLE_TYPE::KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page) {
+inline auto HASH_TABLE_TYPE::KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page) -> uint32_t {
   return 0;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-inline uint32_t HASH_TABLE_TYPE::KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page) {
+inline auto HASH_TABLE_TYPE::KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page) -> uint32_t {
   return 0;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-HashTableDirectoryPage *HASH_TABLE_TYPE::FetchDirectoryPage() {
+auto HASH_TABLE_TYPE::FetchDirectoryPage() -> HashTableDirectoryPage * {
   return nullptr;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-HASH_TABLE_BUCKET_TYPE *HASH_TABLE_TYPE::FetchBucketPage(page_id_t bucket_page_id) {
+auto HASH_TABLE_TYPE::FetchBucketPage(page_id_t bucket_page_id) -> HASH_TABLE_BUCKET_TYPE * {
   return nullptr;
 }
 
@@ -68,7 +68,7 @@ HASH_TABLE_BUCKET_TYPE *HASH_TABLE_TYPE::FetchBucketPage(page_id_t bucket_page_i
  * SEARCH
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) {
+auto HASH_TABLE_TYPE::GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) -> bool {
   return false;
 }
 
@@ -76,12 +76,12 @@ bool HASH_TABLE_TYPE::GetValue(Transaction *transaction, const KeyType &key, std
  * INSERTION
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::Insert(Transaction *transaction, const KeyType &key, const ValueType &value) {
+auto HASH_TABLE_TYPE::Insert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool {
   return false;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::SplitInsert(Transaction *transaction, const KeyType &key, const ValueType &value) {
+auto HASH_TABLE_TYPE::SplitInsert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool {
   return false;
 }
 
@@ -89,7 +89,7 @@ bool HASH_TABLE_TYPE::SplitInsert(Transaction *transaction, const KeyType &key, 
  * REMOVE
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::Remove(Transaction *transaction, const KeyType &key, const ValueType &value) {
+auto HASH_TABLE_TYPE::Remove(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool {
   return false;
 }
 
@@ -103,7 +103,7 @@ void HASH_TABLE_TYPE::Merge(Transaction *transaction, const KeyType &key, const 
  * GETGLOBALDEPTH - DO NOT TOUCH
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-uint32_t HASH_TABLE_TYPE::GetGlobalDepth() {
+auto HASH_TABLE_TYPE::GetGlobalDepth() -> uint32_t {
   table_latch_.RLock();
   HashTableDirectoryPage *dir_page = FetchDirectoryPage();
   uint32_t global_depth = dir_page->GetGlobalDepth();

--- a/src/container/hash/linear_probe_hash_table.cpp
+++ b/src/container/hash/linear_probe_hash_table.cpp
@@ -32,14 +32,14 @@ HASH_TABLE_TYPE::LinearProbeHashTable(const std::string &name, BufferPoolManager
  * SEARCH
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) {
+auto HASH_TABLE_TYPE::GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) -> bool {
   return false;
 }
 /*****************************************************************************
  * INSERTION
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::Insert(Transaction *transaction, const KeyType &key, const ValueType &value) {
+auto HASH_TABLE_TYPE::Insert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool {
   return false;
 }
 
@@ -47,7 +47,7 @@ bool HASH_TABLE_TYPE::Insert(Transaction *transaction, const KeyType &key, const
  * REMOVE
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_TYPE::Remove(Transaction *transaction, const KeyType &key, const ValueType &value) {
+auto HASH_TABLE_TYPE::Remove(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool {
   return false;
 }
 
@@ -61,7 +61,7 @@ void HASH_TABLE_TYPE::Resize(size_t initial_size) {}
  * GETSIZE
  *****************************************************************************/
 template <typename KeyType, typename ValueType, typename KeyComparator>
-size_t HASH_TABLE_TYPE::GetSize() {
+auto HASH_TABLE_TYPE::GetSize() -> size_t {
   return 0;
 }
 

--- a/src/execution/aggregation_executor.cpp
+++ b/src/execution/aggregation_executor.cpp
@@ -22,8 +22,8 @@ AggregationExecutor::AggregationExecutor(ExecutorContext *exec_ctx, const Aggreg
 
 void AggregationExecutor::Init() {}
 
-bool AggregationExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto AggregationExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
-const AbstractExecutor *AggregationExecutor::GetChildExecutor() const { return child_.get(); }
+auto AggregationExecutor::GetChildExecutor() const -> const AbstractExecutor * { return child_.get(); }
 
 }  // namespace bustub

--- a/src/execution/delete_executor.cpp
+++ b/src/execution/delete_executor.cpp
@@ -22,6 +22,6 @@ DeleteExecutor::DeleteExecutor(ExecutorContext *exec_ctx, const DeletePlanNode *
 
 void DeleteExecutor::Init() {}
 
-bool DeleteExecutor::Next([[maybe_unused]] Tuple *tuple, RID *rid) { return false; }
+auto DeleteExecutor::Next([[maybe_unused]] Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/distinct_executor.cpp
+++ b/src/execution/distinct_executor.cpp
@@ -20,6 +20,6 @@ DistinctExecutor::DistinctExecutor(ExecutorContext *exec_ctx, const DistinctPlan
 
 void DistinctExecutor::Init() {}
 
-bool DistinctExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto DistinctExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/executor_factory.cpp
+++ b/src/execution/executor_factory.cpp
@@ -31,8 +31,8 @@
 
 namespace bustub {
 
-std::unique_ptr<AbstractExecutor> ExecutorFactory::CreateExecutor(ExecutorContext *exec_ctx,
-                                                                  const AbstractPlanNode *plan) {
+auto ExecutorFactory::CreateExecutor(ExecutorContext *exec_ctx,
+                                                                  const AbstractPlanNode *plan) -> std::unique_ptr<AbstractExecutor> {
   switch (plan->GetType()) {
     // Create a new sequential scan executor
     case PlanType::SeqScan: {

--- a/src/execution/hash_join_executor.cpp
+++ b/src/execution/hash_join_executor.cpp
@@ -21,6 +21,6 @@ HashJoinExecutor::HashJoinExecutor(ExecutorContext *exec_ctx, const HashJoinPlan
 
 void HashJoinExecutor::Init() {}
 
-bool HashJoinExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto HashJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/index_scan_executor.cpp
+++ b/src/execution/index_scan_executor.cpp
@@ -17,6 +17,6 @@ IndexScanExecutor::IndexScanExecutor(ExecutorContext *exec_ctx, const IndexScanP
 
 void IndexScanExecutor::Init() {}
 
-bool IndexScanExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto IndexScanExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/insert_executor.cpp
+++ b/src/execution/insert_executor.cpp
@@ -22,6 +22,6 @@ InsertExecutor::InsertExecutor(ExecutorContext *exec_ctx, const InsertPlanNode *
 
 void InsertExecutor::Init() {}
 
-bool InsertExecutor::Next([[maybe_unused]] Tuple *tuple, RID *rid) { return false; }
+auto InsertExecutor::Next([[maybe_unused]] Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/limit_executor.cpp
+++ b/src/execution/limit_executor.cpp
@@ -20,6 +20,6 @@ LimitExecutor::LimitExecutor(ExecutorContext *exec_ctx, const LimitPlanNode *pla
 
 void LimitExecutor::Init() {}
 
-bool LimitExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto LimitExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/nested_index_join_executor.cpp
+++ b/src/execution/nested_index_join_executor.cpp
@@ -20,6 +20,6 @@ NestIndexJoinExecutor::NestIndexJoinExecutor(ExecutorContext *exec_ctx, const Ne
 
 void NestIndexJoinExecutor::Init() {}
 
-bool NestIndexJoinExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto NestIndexJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/nested_loop_join_executor.cpp
+++ b/src/execution/nested_loop_join_executor.cpp
@@ -21,6 +21,6 @@ NestedLoopJoinExecutor::NestedLoopJoinExecutor(ExecutorContext *exec_ctx, const 
 
 void NestedLoopJoinExecutor::Init() {}
 
-bool NestedLoopJoinExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto NestedLoopJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/seq_scan_executor.cpp
+++ b/src/execution/seq_scan_executor.cpp
@@ -18,6 +18,6 @@ SeqScanExecutor::SeqScanExecutor(ExecutorContext *exec_ctx, const SeqScanPlanNod
 
 void SeqScanExecutor::Init() {}
 
-bool SeqScanExecutor::Next(Tuple *tuple, RID *rid) { return false; }
+auto SeqScanExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
 }  // namespace bustub

--- a/src/execution/update_executor.cpp
+++ b/src/execution/update_executor.cpp
@@ -21,9 +21,9 @@ UpdateExecutor::UpdateExecutor(ExecutorContext *exec_ctx, const UpdatePlanNode *
 
 void UpdateExecutor::Init() {}
 
-bool UpdateExecutor::Next([[maybe_unused]] Tuple *tuple, RID *rid) { return false; }
+auto UpdateExecutor::Next([[maybe_unused]] Tuple *tuple, RID *rid) -> bool { return false; }
 
-Tuple UpdateExecutor::GenerateUpdatedTuple(const Tuple &src_tuple) {
+auto UpdateExecutor::GenerateUpdatedTuple(const Tuple &src_tuple) -> Tuple {
   const auto &update_attrs = plan_->GetUpdateAttr();
   Schema schema = table_info_->schema_;
   uint32_t col_count = schema.GetColumnCount();

--- a/src/include/buffer/buffer_pool_manager.h
+++ b/src/include/buffer/buffer_pool_manager.h
@@ -38,7 +38,7 @@ class BufferPoolManager {
   virtual ~BufferPoolManager() = default;
 
   /** Grading function. Do not modify! */
-  Page *FetchPage(page_id_t page_id, bufferpool_callback_fn callback = nullptr) {
+  auto FetchPage(page_id_t page_id, bufferpool_callback_fn callback = nullptr) -> Page * {
     GradingCallback(callback, CallbackType::BEFORE, page_id);
     auto *result = FetchPgImp(page_id);
     GradingCallback(callback, CallbackType::AFTER, page_id);
@@ -46,7 +46,7 @@ class BufferPoolManager {
   }
 
   /** Grading function. Do not modify! */
-  bool UnpinPage(page_id_t page_id, bool is_dirty, bufferpool_callback_fn callback = nullptr) {
+  auto UnpinPage(page_id_t page_id, bool is_dirty, bufferpool_callback_fn callback = nullptr) -> bool {
     GradingCallback(callback, CallbackType::BEFORE, page_id);
     auto result = UnpinPgImp(page_id, is_dirty);
     GradingCallback(callback, CallbackType::AFTER, page_id);
@@ -54,7 +54,7 @@ class BufferPoolManager {
   }
 
   /** Grading function. Do not modify! */
-  bool FlushPage(page_id_t page_id, bufferpool_callback_fn callback = nullptr) {
+  auto FlushPage(page_id_t page_id, bufferpool_callback_fn callback = nullptr) -> bool {
     GradingCallback(callback, CallbackType::BEFORE, page_id);
     auto result = FlushPgImp(page_id);
     GradingCallback(callback, CallbackType::AFTER, page_id);
@@ -62,7 +62,7 @@ class BufferPoolManager {
   }
 
   /** Grading function. Do not modify! */
-  Page *NewPage(page_id_t *page_id, bufferpool_callback_fn callback = nullptr) {
+  auto NewPage(page_id_t *page_id, bufferpool_callback_fn callback = nullptr) -> Page * {
     GradingCallback(callback, CallbackType::BEFORE, INVALID_PAGE_ID);
     auto *result = NewPgImp(page_id);
     GradingCallback(callback, CallbackType::AFTER, *page_id);
@@ -70,7 +70,7 @@ class BufferPoolManager {
   }
 
   /** Grading function. Do not modify! */
-  bool DeletePage(page_id_t page_id, bufferpool_callback_fn callback = nullptr) {
+  auto DeletePage(page_id_t page_id, bufferpool_callback_fn callback = nullptr) -> bool {
     GradingCallback(callback, CallbackType::BEFORE, page_id);
     auto result = DeletePgImp(page_id);
     GradingCallback(callback, CallbackType::AFTER, page_id);
@@ -85,7 +85,7 @@ class BufferPoolManager {
   }
 
   /** @return size of the buffer pool */
-  virtual size_t GetPoolSize() = 0;
+  virtual auto GetPoolSize() -> size_t = 0;
 
  protected:
   /**
@@ -106,7 +106,7 @@ class BufferPoolManager {
    * @param page_id id of page to be fetched
    * @return the requested page
    */
-  virtual Page *FetchPgImp(page_id_t page_id) = 0;
+  virtual auto FetchPgImp(page_id_t page_id) -> Page * = 0;
 
   /**
    * Unpin the target page from the buffer pool.
@@ -114,28 +114,28 @@ class BufferPoolManager {
    * @param is_dirty true if the page should be marked as dirty, false otherwise
    * @return false if the page pin count is <= 0 before this call, true otherwise
    */
-  virtual bool UnpinPgImp(page_id_t page_id, bool is_dirty) = 0;
+  virtual auto UnpinPgImp(page_id_t page_id, bool is_dirty) -> bool = 0;
 
   /**
    * Flushes the target page to disk.
    * @param page_id id of page to be flushed, cannot be INVALID_PAGE_ID
    * @return false if the page could not be found in the page table, true otherwise
    */
-  virtual bool FlushPgImp(page_id_t page_id) = 0;
+  virtual auto FlushPgImp(page_id_t page_id) -> bool = 0;
 
   /**
    * Creates a new page in the buffer pool.
    * @param[out] page_id id of created page
    * @return nullptr if no new pages could be created, otherwise pointer to new page
    */
-  virtual Page *NewPgImp(page_id_t *page_id) = 0;
+  virtual auto NewPgImp(page_id_t *page_id) -> Page * = 0;
 
   /**
    * Deletes a page from the buffer pool.
    * @param page_id id of page to be deleted
    * @return false if the page exists but could not be deleted, true if the page didn't exist or deletion succeeded
    */
-  virtual bool DeletePgImp(page_id_t page_id) = 0;
+  virtual auto DeletePgImp(page_id_t page_id) -> bool = 0;
 
   /**
    * Flushes all the pages in the buffer pool to disk.

--- a/src/include/buffer/buffer_pool_manager_instance.h
+++ b/src/include/buffer/buffer_pool_manager_instance.h
@@ -53,10 +53,10 @@ class BufferPoolManagerInstance : public BufferPoolManager {
   ~BufferPoolManagerInstance() override;
 
   /** @return size of the buffer pool */
-  size_t GetPoolSize() override { return pool_size_; }
+  auto GetPoolSize() -> size_t override { return pool_size_; }
 
   /** @return pointer to all the pages in the buffer pool */
-  Page *GetPages() { return pages_; }
+  auto GetPages() -> Page * { return pages_; }
 
  protected:
   /**
@@ -64,7 +64,7 @@ class BufferPoolManagerInstance : public BufferPoolManager {
    * @param page_id id of page to be fetched
    * @return the requested page
    */
-  Page *FetchPgImp(page_id_t page_id) override;
+  auto FetchPgImp(page_id_t page_id) -> Page * override;
 
   /**
    * Unpin the target page from the buffer pool.
@@ -72,28 +72,28 @@ class BufferPoolManagerInstance : public BufferPoolManager {
    * @param is_dirty true if the page should be marked as dirty, false otherwise
    * @return false if the page pin count is <= 0 before this call, true otherwise
    */
-  bool UnpinPgImp(page_id_t page_id, bool is_dirty) override;
+  auto UnpinPgImp(page_id_t page_id, bool is_dirty) -> bool override;
 
   /**
    * Flushes the target page to disk.
    * @param page_id id of page to be flushed, cannot be INVALID_PAGE_ID
    * @return false if the page could not be found in the page table, true otherwise
    */
-  bool FlushPgImp(page_id_t page_id) override;
+  auto FlushPgImp(page_id_t page_id) -> bool override;
 
   /**
    * Creates a new page in the buffer pool.
    * @param[out] page_id id of created page
    * @return nullptr if no new pages could be created, otherwise pointer to new page
    */
-  Page *NewPgImp(page_id_t *page_id) override;
+  auto NewPgImp(page_id_t *page_id) -> Page * override;
 
   /**
    * Deletes a page from the buffer pool.
    * @param page_id id of page to be deleted
    * @return false if the page exists but could not be deleted, true if the page didn't exist or deletion succeeded
    */
-  bool DeletePgImp(page_id_t page_id) override;
+  auto DeletePgImp(page_id_t page_id) -> bool override;
 
   /**
    * Flushes all the pages in the buffer pool to disk.
@@ -104,7 +104,7 @@ class BufferPoolManagerInstance : public BufferPoolManager {
    * Allocate a page on disk.∂
    * @return the id of the allocated page
    */
-  page_id_t AllocatePage();
+  auto AllocatePage() -> page_id_t;
 
   /**
    * Deallocate a page on disk.

--- a/src/include/buffer/clock_replacer.h
+++ b/src/include/buffer/clock_replacer.h
@@ -37,13 +37,13 @@ class ClockReplacer : public Replacer {
    */
   ~ClockReplacer() override;
 
-  bool Victim(frame_id_t *frame_id) override;
+  auto Victim(frame_id_t *frame_id) -> bool override;
 
   void Pin(frame_id_t frame_id) override;
 
   void Unpin(frame_id_t frame_id) override;
 
-  size_t Size() override;
+  auto Size() -> size_t override;
 
  private:
   // TODO(student): implement me!

--- a/src/include/buffer/lru_replacer.h
+++ b/src/include/buffer/lru_replacer.h
@@ -37,13 +37,13 @@ class LRUReplacer : public Replacer {
    */
   ~LRUReplacer() override;
 
-  bool Victim(frame_id_t *frame_id) override;
+  auto Victim(frame_id_t *frame_id) -> bool override;
 
   void Pin(frame_id_t frame_id) override;
 
   void Unpin(frame_id_t frame_id) override;
 
-  size_t Size() override;
+  auto Size() -> size_t override;
 
  private:
   // TODO(student): implement me!

--- a/src/include/buffer/parallel_buffer_pool_manager.h
+++ b/src/include/buffer/parallel_buffer_pool_manager.h
@@ -37,21 +37,21 @@ class ParallelBufferPoolManager : public BufferPoolManager {
   ~ParallelBufferPoolManager() override;
 
   /** @return size of the buffer pool */
-  size_t GetPoolSize() override;
+  auto GetPoolSize() -> size_t override;
 
  protected:
   /**
    * @param page_id id of page
    * @return pointer to the BufferPoolManager responsible for handling given page id
    */
-  BufferPoolManager *GetBufferPoolManager(page_id_t page_id);
+  auto GetBufferPoolManager(page_id_t page_id) -> BufferPoolManager *;
 
   /**
    * Fetch the requested page from the buffer pool.
    * @param page_id id of page to be fetched
    * @return the requested page
    */
-  Page *FetchPgImp(page_id_t page_id) override;
+  auto FetchPgImp(page_id_t page_id) -> Page * override;
 
   /**
    * Unpin the target page from the buffer pool.
@@ -59,28 +59,28 @@ class ParallelBufferPoolManager : public BufferPoolManager {
    * @param is_dirty true if the page should be marked as dirty, false otherwise
    * @return false if the page pin count is <= 0 before this call, true otherwise
    */
-  bool UnpinPgImp(page_id_t page_id, bool is_dirty) override;
+  auto UnpinPgImp(page_id_t page_id, bool is_dirty) -> bool override;
 
   /**
    * Flushes the target page to disk.
    * @param page_id id of page to be flushed, cannot be INVALID_PAGE_ID
    * @return false if the page could not be found in the page table, true otherwise
    */
-  bool FlushPgImp(page_id_t page_id) override;
+  auto FlushPgImp(page_id_t page_id) -> bool override;
 
   /**
    * Creates a new page in the buffer pool.
    * @param[out] page_id id of created page
    * @return nullptr if no new pages could be created, otherwise pointer to new page
    */
-  Page *NewPgImp(page_id_t *page_id) override;
+  auto NewPgImp(page_id_t *page_id) -> Page * override;
 
   /**
    * Deletes a page from the buffer pool.
    * @param page_id id of page to be deleted
    * @return false if the page exists but could not be deleted, true if the page didn't exist or deletion succeeded
    */
-  bool DeletePgImp(page_id_t page_id) override;
+  auto DeletePgImp(page_id_t page_id) -> bool override;
 
   /**
    * Flushes all the pages in the buffer pool to disk.

--- a/src/include/buffer/replacer.h
+++ b/src/include/buffer/replacer.h
@@ -29,7 +29,7 @@ class Replacer {
    * @param[out] frame_id id of frame that was removed, nullptr if no victim was found
    * @return true if a victim frame was found, false otherwise
    */
-  virtual bool Victim(frame_id_t *frame_id) = 0;
+  virtual auto Victim(frame_id_t *frame_id) -> bool = 0;
 
   /**
    * Pins a frame, indicating that it should not be victimized until it is unpinned.
@@ -44,7 +44,7 @@ class Replacer {
   virtual void Unpin(frame_id_t frame_id) = 0;
 
   /** @return the number of elements in the replacer that can be victimized */
-  virtual size_t Size() = 0;
+  virtual auto Size() -> size_t = 0;
 };
 
 }  // namespace bustub

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -121,7 +121,7 @@ class Catalog {
    * @param schema The schema of the new table
    * @return A (non-owning) pointer to the metadata for the table
    */
-  TableInfo *CreateTable(Transaction *txn, const std::string &table_name, const Schema &schema) {
+  auto CreateTable(Transaction *txn, const std::string &table_name, const Schema &schema) -> TableInfo * {
     if (table_names_.count(table_name) != 0) {
       return NULL_TABLE_INFO;
     }
@@ -149,7 +149,7 @@ class Catalog {
    * @param table_name The name of the table
    * @return A (non-owning) pointer to the metadata for the table
    */
-  TableInfo *GetTable(const std::string &table_name) {
+  auto GetTable(const std::string &table_name) -> TableInfo * {
     auto table_oid = table_names_.find(table_name);
     if (table_oid == table_names_.end()) {
       // Table not found
@@ -167,7 +167,7 @@ class Catalog {
    * @param table_oid The OID of the table to query
    * @return A (non-owning) pointer to the metadata for the table
    */
-  TableInfo *GetTable(table_oid_t table_oid) {
+  auto GetTable(table_oid_t table_oid) -> TableInfo * {
     auto meta = tables_.find(table_oid);
     if (meta == tables_.end()) {
       return NULL_TABLE_INFO;
@@ -189,9 +189,9 @@ class Catalog {
    * @return A (non-owning) pointer to the metadata of the new table
    */
   template <class KeyType, class ValueType, class KeyComparator>
-  IndexInfo *CreateIndex(Transaction *txn, const std::string &index_name, const std::string &table_name,
+  auto CreateIndex(Transaction *txn, const std::string &index_name, const std::string &table_name,
                          const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs,
-                         std::size_t keysize, HashFunction<KeyType> hash_function) {
+                         std::size_t keysize, HashFunction<KeyType> hash_function) -> IndexInfo * {
     // Reject the creation request for nonexistent table
     if (table_names_.find(table_name) == table_names_.end()) {
       return NULL_INDEX_INFO;
@@ -245,7 +245,7 @@ class Catalog {
    * @param table_name The name of the table on which to perform query
    * @return A (non-owning) pointer to the metadata for the index
    */
-  IndexInfo *GetIndex(const std::string &index_name, const std::string &table_name) {
+  auto GetIndex(const std::string &index_name, const std::string &table_name) -> IndexInfo * {
     auto table = index_names_.find(table_name);
     if (table == index_names_.end()) {
       BUSTUB_ASSERT((table_names_.find(table_name) == table_names_.end()), "Broken Invariant");
@@ -271,7 +271,7 @@ class Catalog {
    * @param table_oid The OID of the table on which to perform query
    * @return A (non-owning) pointer to the metadata for the index
    */
-  IndexInfo *GetIndex(const std::string &index_name, const table_oid_t table_oid) {
+  auto GetIndex(const std::string &index_name, const table_oid_t table_oid) -> IndexInfo * {
     // Locate the table metadata for the specified table OID
     auto table_meta = tables_.find(table_oid);
     if (table_meta == tables_.end()) {
@@ -287,7 +287,7 @@ class Catalog {
    * @param index_oid The OID of the index for which to query
    * @return A (non-owning) pointer to the metadata for the index
    */
-  IndexInfo *GetIndex(index_oid_t index_oid) {
+  auto GetIndex(index_oid_t index_oid) -> IndexInfo * {
     auto index = indexes_.find(index_oid);
     if (index == indexes_.end()) {
       return NULL_INDEX_INFO;
@@ -302,7 +302,7 @@ class Catalog {
    * @return A vector of IndexInfo* for each index on the given table, empty vector
    * in the event that the table exists but no indexes have been created for it
    */
-  std::vector<IndexInfo *> GetTableIndexes(const std::string &table_name) {
+  auto GetTableIndexes(const std::string &table_name) -> std::vector<IndexInfo *> {
     // Ensure the table exists
     if (table_names_.find(table_name) == table_names_.end()) {
       return std::vector<IndexInfo *>{};

--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -51,10 +51,10 @@ class Column {
   }
 
   /** @return column name */
-  std::string GetName() const { return column_name_; }
+  auto GetName() const -> std::string { return column_name_; }
 
   /** @return column length */
-  uint32_t GetLength() const {
+  auto GetLength() const -> uint32_t {
     if (IsInlined()) {
       return fixed_length_;
     }
@@ -62,25 +62,25 @@ class Column {
   }
 
   /** @return column fixed length */
-  uint32_t GetFixedLength() const { return fixed_length_; }
+  auto GetFixedLength() const -> uint32_t { return fixed_length_; }
 
   /** @return column variable length */
-  uint32_t GetVariableLength() const { return variable_length_; }
+  auto GetVariableLength() const -> uint32_t { return variable_length_; }
 
   /** @return column's offset in the tuple */
-  uint32_t GetOffset() const { return column_offset_; }
+  auto GetOffset() const -> uint32_t { return column_offset_; }
 
   /** @return column type */
-  TypeId GetType() const { return column_type_; }
+  auto GetType() const -> TypeId { return column_type_; }
 
   /** @return true if column is inlined, false otherwise */
-  bool IsInlined() const { return column_type_ != TypeId::VARCHAR; }
+  auto IsInlined() const -> bool { return column_type_ != TypeId::VARCHAR; }
 
   /** @return a string representation of this column */
-  std::string ToString() const;
+  auto ToString() const -> std::string;
 
   /** @return the expression used to create this column */
-  const AbstractExpression *GetExpr() const { return expr_; }
+  auto GetExpr() const -> const AbstractExpression * { return expr_; }
 
  private:
   /**
@@ -88,7 +88,7 @@ class Column {
    * @param type type whose size is to be determined
    * @return size in bytes
    */
-  static uint8_t TypeSize(TypeId type) {
+  static auto TypeSize(TypeId type) -> uint8_t {
     switch (type) {
       case TypeId::BOOLEAN:
         return 1;

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -29,7 +29,7 @@ class Schema {
    */
   explicit Schema(const std::vector<Column> &columns);
 
-  static Schema *CopySchema(const Schema *from, const std::vector<uint32_t> &attrs) {
+  static auto CopySchema(const Schema *from, const std::vector<uint32_t> &attrs) -> Schema * {
     std::vector<Column> cols;
     cols.reserve(attrs.size());
     for (const auto i : attrs) {
@@ -39,14 +39,14 @@ class Schema {
   }
 
   /** @return all the columns in the schema */
-  const std::vector<Column> &GetColumns() const { return columns_; }
+  auto GetColumns() const -> const std::vector<Column> & { return columns_; }
 
   /**
    * Returns a specific column from the schema.
    * @param col_idx index of requested column
    * @return requested column
    */
-  const Column &GetColumn(const uint32_t col_idx) const { return columns_[col_idx]; }
+  auto GetColumn(const uint32_t col_idx) const -> const Column & { return columns_[col_idx]; }
 
   /**
    * Looks up and returns the index of the first column in the schema with the specified name.
@@ -54,7 +54,7 @@ class Schema {
    * @param col_name name of column to look for
    * @return the index of a column with the given name, throws an exception if it does not exist
    */
-  uint32_t GetColIdx(const std::string &col_name) const {
+  auto GetColIdx(const std::string &col_name) const -> uint32_t {
     for (uint32_t i = 0; i < columns_.size(); ++i) {
       if (columns_[i].GetName() == col_name) {
         return i;
@@ -64,22 +64,22 @@ class Schema {
   }
 
   /** @return the indices of non-inlined columns */
-  const std::vector<uint32_t> &GetUnlinedColumns() const { return uninlined_columns_; }
+  auto GetUnlinedColumns() const -> const std::vector<uint32_t> & { return uninlined_columns_; }
 
   /** @return the number of columns in the schema for the tuple */
-  uint32_t GetColumnCount() const { return static_cast<uint32_t>(columns_.size()); }
+  auto GetColumnCount() const -> uint32_t { return static_cast<uint32_t>(columns_.size()); }
 
   /** @return the number of non-inlined columns */
-  uint32_t GetUnlinedColumnCount() const { return static_cast<uint32_t>(uninlined_columns_.size()); }
+  auto GetUnlinedColumnCount() const -> uint32_t { return static_cast<uint32_t>(uninlined_columns_.size()); }
 
   /** @return the number of bytes used by one tuple */
-  inline uint32_t GetLength() const { return length_; }
+  inline auto GetLength() const -> uint32_t { return length_; }
 
   /** @return true if all columns are inlined, false otherwise */
-  inline bool IsInlined() const { return tuple_is_inlined_; }
+  inline auto IsInlined() const -> bool { return tuple_is_inlined_; }
 
   /** @return string representation of this schema */
-  std::string ToString() const;
+  auto ToString() const -> std::string;
 
  private:
   /** Fixed-length column size, i.e. the number of bytes used by one tuple. */

--- a/src/include/catalog/table_generator.h
+++ b/src/include/catalog/table_generator.h
@@ -103,10 +103,10 @@ class TableGenerator {
 
   void FillTable(TableInfo *info, TableInsertMeta *table_meta);
 
-  std::vector<Value> MakeValues(ColumnInsertMeta *col_meta, uint32_t count);
+  auto MakeValues(ColumnInsertMeta *col_meta, uint32_t count) -> std::vector<Value>;
 
   template <typename CppType>
-  std::vector<Value> GenNumericValues(ColumnInsertMeta *col_meta, uint32_t count);
+  auto GenNumericValues(ColumnInsertMeta *col_meta, uint32_t count) -> std::vector<Value>;
 
  private:
   ExecutorContext *exec_ctx_;

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -73,10 +73,10 @@ class Exception : public std::runtime_error {
   }
 
   /** @return The type of the exception */
-  ExceptionType GetType() const { return type_; }
+  auto GetType() const -> ExceptionType { return type_; }
 
   /** @return A human-readable string for the specified exception type */
-  static std::string ExceptionTypeToString(ExceptionType type) {
+  static auto ExceptionTypeToString(ExceptionType type) -> std::string {
     switch (type) {
       case ExceptionType::INVALID:
         return "Invalid";

--- a/src/include/common/logger.h
+++ b/src/include/common/logger.h
@@ -41,11 +41,11 @@ namespace bustub {
 // https://blog.galowicz.de/2016/02/20/short_file_macro/
 using cstr = const char *;
 
-static constexpr cstr PastLastSlash(cstr a, cstr b) {
+static constexpr auto PastLastSlash(cstr a, cstr b) -> cstr {
   return *a == '\0' ? b : *b == '/' ? PastLastSlash(a + 1, a + 1) : PastLastSlash(a + 1, b);
 }
 
-static constexpr cstr PastLastSlash(cstr a) { return PastLastSlash(a, a); }
+static constexpr auto PastLastSlash(cstr a) -> cstr { return PastLastSlash(a, a); }
 
 #define __SHORT_FILE__                            \
   ({                                              \

--- a/src/include/common/rid.h
+++ b/src/include/common/rid.h
@@ -34,18 +34,18 @@ class RID {
 
   explicit RID(int64_t rid) : page_id_(static_cast<page_id_t>(rid >> 32)), slot_num_(static_cast<uint32_t>(rid)) {}
 
-  inline int64_t Get() const { return (static_cast<int64_t>(page_id_)) << 32 | slot_num_; }
+  inline auto Get() const -> int64_t { return (static_cast<int64_t>(page_id_)) << 32 | slot_num_; }
 
-  inline page_id_t GetPageId() const { return page_id_; }
+  inline auto GetPageId() const -> page_id_t { return page_id_; }
 
-  inline uint32_t GetSlotNum() const { return slot_num_; }
+  inline auto GetSlotNum() const -> uint32_t { return slot_num_; }
 
   inline void Set(page_id_t page_id, uint32_t slot_num) {
     page_id_ = page_id;
     slot_num_ = slot_num;
   }
 
-  inline std::string ToString() const {
+  inline auto ToString() const -> std::string {
     std::stringstream os;
     os << "page_id: " << page_id_;
     os << " slot_num: " << slot_num_ << "\n";
@@ -53,12 +53,12 @@ class RID {
     return os.str();
   }
 
-  friend std::ostream &operator<<(std::ostream &os, const RID &rid) {
+  friend auto operator<<(std::ostream &os, const RID &rid) -> std::ostream & {
     os << rid.ToString();
     return os;
   }
 
-  bool operator==(const RID &other) const { return page_id_ == other.page_id_ && slot_num_ == other.slot_num_; }
+  auto operator==(const RID &other) const -> bool { return page_id_ == other.page_id_ && slot_num_ == other.slot_num_; }
 
  private:
   page_id_t page_id_{INVALID_PAGE_ID};
@@ -70,6 +70,6 @@ class RID {
 namespace std {
 template <>
 struct hash<bustub::RID> {
-  size_t operator()(const bustub::RID &obj) const { return hash<int64_t>()(obj.Get()); }
+  auto operator()(const bustub::RID &obj) const -> size_t { return hash<int64_t>()(obj.Get()); }
 };
 }  // namespace std

--- a/src/include/common/util/hash_util.h
+++ b/src/include/common/util/hash_util.h
@@ -29,7 +29,7 @@ class HashUtil {
   static const hash_t PRIME_FACTOR = 10000019;
 
  public:
-  static inline hash_t HashBytes(const char *bytes, size_t length) {
+  static inline auto HashBytes(const char *bytes, size_t length) -> hash_t {
     // https://github.com/greenplum-db/gpos/blob/b53c1acd6285de94044ff91fbee91589543feba1/libgpos/src/utils.cpp#L126
     hash_t hash = length;
     for (size_t i = 0; i < length; ++i) {
@@ -38,27 +38,27 @@ class HashUtil {
     return hash;
   }
 
-  static inline hash_t CombineHashes(hash_t l, hash_t r) {
+  static inline auto CombineHashes(hash_t l, hash_t r) -> hash_t {
     hash_t both[2] = {};
     both[0] = l;
     both[1] = r;
     return HashBytes(reinterpret_cast<char *>(both), sizeof(hash_t) * 2);
   }
 
-  static inline hash_t SumHashes(hash_t l, hash_t r) { return (l % PRIME_FACTOR + r % PRIME_FACTOR) % PRIME_FACTOR; }
+  static inline auto SumHashes(hash_t l, hash_t r) -> hash_t { return (l % PRIME_FACTOR + r % PRIME_FACTOR) % PRIME_FACTOR; }
 
   template <typename T>
-  static inline hash_t Hash(const T *ptr) {
+  static inline auto Hash(const T *ptr) -> hash_t {
     return HashBytes(reinterpret_cast<const char *>(ptr), sizeof(T));
   }
 
   template <typename T>
-  static inline hash_t HashPtr(const T *ptr) {
+  static inline auto HashPtr(const T *ptr) -> hash_t {
     return HashBytes(reinterpret_cast<const char *>(&ptr), sizeof(void *));
   }
 
   /** @return the hash of the value */
-  static inline hash_t HashValue(const Value *val) {
+  static inline auto HashValue(const Value *val) -> hash_t {
     switch (val->GetTypeId()) {
       case TypeId::TINYINT: {
         auto raw = static_cast<int64_t>(val->GetAs<int8_t>());

--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -23,43 +23,43 @@ namespace bustub {
 class StringUtil {
  public:
   /** @return true if haystack contains needle, false otherwise */
-  static bool Contains(const std::string &haystack, const std::string &needle);
+  static auto Contains(const std::string &haystack, const std::string &needle) -> bool;
 
   /** @return true if target string starts with given prefix, false otherwise */
-  static bool StartsWith(const std::string &str, const std::string &prefix);
+  static auto StartsWith(const std::string &str, const std::string &prefix) -> bool;
 
   /** @return true if target string ends with the given suffix, false otherwise */
-  static bool EndsWith(const std::string &str, const std::string &suffix);
+  static auto EndsWith(const std::string &str, const std::string &suffix) -> bool;
 
   /** @return str repeated n times */
-  static std::string Repeat(const std::string &str, std::size_t n);
+  static auto Repeat(const std::string &str, std::size_t n) -> std::string;
 
   /** @return input string split based on the delimiter */
-  static std::vector<std::string> Split(const std::string &str, char delimiter);
+  static auto Split(const std::string &str, char delimiter) -> std::vector<std::string>;
 
   /** @return concatenation of all input strings, separated by the separator */
-  static std::string Join(const std::vector<std::string> &input, const std::string &separator);
+  static auto Join(const std::vector<std::string> &input, const std::string &separator) -> std::string;
 
   /** @return prefix prepended to the beginning of each line in str */
-  static std::string Prefix(const std::string &str, const std::string &prefix);
+  static auto Prefix(const std::string &str, const std::string &prefix) -> std::string;
 
   /** @return bytes formatted into the appropriate kilobyte, megabyte or gigabyte representation */
-  static std::string FormatSize(uint64_t bytes);
+  static auto FormatSize(uint64_t bytes) -> std::string;
 
   /** @return string wrapped with control characters to appear bold in the console */
-  static std::string Bold(const std::string &str);
+  static auto Bold(const std::string &str) -> std::string;
 
   /** @return uppercase version of the string */
-  static std::string Upper(const std::string &str);
+  static auto Upper(const std::string &str) -> std::string;
 
   /** @return lowercase version of the string */
-  static std::string Lower(const std::string &str);
+  static auto Lower(const std::string &str) -> std::string;
 
   /** @return string formatted with printf semantics */
-  static std::string Format(std::string fmt_str, ...);
+  static auto Format(std::string fmt_str, ...) -> std::string;
 
   /** @return input string split based on the split string */
-  static std::vector<std::string> Split(const std::string &input, const std::string &split);
+  static auto Split(const std::string &input, const std::string &split) -> std::vector<std::string>;
 
   /**
    * Removes the whitespace characters from the right side of the string.
@@ -68,7 +68,7 @@ class StringUtil {
   static void RTrim(std::string *str);
 
   /** @return indented string */
-  static std::string Indent(int num_indent);
+  static auto Indent(int num_indent) -> std::string;
 
   /**
    * Return a new string that has stripped all occurrences of the provided character from the provided string.
@@ -79,7 +79,7 @@ class StringUtil {
    * @param c character to be removed
    * @return a new string with no occurrences of the provided character
    */
-  static std::string Strip(const std::string &str, char c);
+  static auto Strip(const std::string &str, char c) -> std::string;
 };
 
 }  // namespace bustub

--- a/src/include/concurrency/lock_manager.h
+++ b/src/include/concurrency/lock_manager.h
@@ -76,7 +76,7 @@ class LockManager {
    * @param rid the RID to be locked in shared mode
    * @return true if the lock is granted, false otherwise
    */
-  bool LockShared(Transaction *txn, const RID &rid);
+  auto LockShared(Transaction *txn, const RID &rid) -> bool;
 
   /**
    * Acquire a lock on RID in exclusive mode. See [LOCK_NOTE] in header file.
@@ -84,7 +84,7 @@ class LockManager {
    * @param rid the RID to be locked in exclusive mode
    * @return true if the lock is granted, false otherwise
    */
-  bool LockExclusive(Transaction *txn, const RID &rid);
+  auto LockExclusive(Transaction *txn, const RID &rid) -> bool;
 
   /**
    * Upgrade a lock from a shared lock to an exclusive lock.
@@ -93,7 +93,7 @@ class LockManager {
    * requesting transaction
    * @return true if the upgrade is successful, false otherwise
    */
-  bool LockUpgrade(Transaction *txn, const RID &rid);
+  auto LockUpgrade(Transaction *txn, const RID &rid) -> bool;
 
   /**
    * Release the lock held by the transaction.
@@ -102,7 +102,7 @@ class LockManager {
    * @param rid the RID that is locked by the transaction
    * @return true if the unlock is successful, false otherwise
    */
-  bool Unlock(Transaction *txn, const RID &rid);
+  auto Unlock(Transaction *txn, const RID &rid) -> bool;
 
  private:
   std::mutex latch_;

--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -126,9 +126,9 @@ class TransactionAbortException : public std::exception {
  public:
   explicit TransactionAbortException(txn_id_t txn_id, AbortReason abort_reason)
       : txn_id_(txn_id), abort_reason_(abort_reason) {}
-  txn_id_t GetTransactionId() { return txn_id_; }
-  AbortReason GetAbortReason() { return abort_reason_; }
-  std::string GetInfo() {
+  auto GetTransactionId() -> txn_id_t { return txn_id_; }
+  auto GetAbortReason() -> AbortReason { return abort_reason_; }
+  auto GetInfo() -> std::string {
     switch (abort_reason_) {
       case AbortReason::LOCK_ON_SHRINKING:
         return "Transaction " + std::to_string(txn_id_) +
@@ -174,22 +174,22 @@ class Transaction {
   DISALLOW_COPY(Transaction);
 
   /** @return the id of the thread running the transaction */
-  inline std::thread::id GetThreadId() const { return thread_id_; }
+  inline auto GetThreadId() const -> std::thread::id { return thread_id_; }
 
   /** @return the id of this transaction */
-  inline txn_id_t GetTransactionId() const { return txn_id_; }
+  inline auto GetTransactionId() const -> txn_id_t { return txn_id_; }
 
   /** @return the isolation level of this transaction */
-  inline IsolationLevel GetIsolationLevel() const { return isolation_level_; }
+  inline auto GetIsolationLevel() const -> IsolationLevel { return isolation_level_; }
 
   /** @return the list of table write records of this transaction */
-  inline std::shared_ptr<std::deque<TableWriteRecord>> GetWriteSet() { return table_write_set_; }
+  inline auto GetWriteSet() -> std::shared_ptr<std::deque<TableWriteRecord>> { return table_write_set_; }
 
   /** @return the list of index write records of this transaction */
-  inline std::shared_ptr<std::deque<IndexWriteRecord>> GetIndexWriteSet() { return index_write_set_; }
+  inline auto GetIndexWriteSet() -> std::shared_ptr<std::deque<IndexWriteRecord>> { return index_write_set_; }
 
   /** @return the page set */
-  inline std::shared_ptr<std::deque<Page *>> GetPageSet() { return page_set_; }
+  inline auto GetPageSet() -> std::shared_ptr<std::deque<Page *>> { return page_set_; }
 
   /**
    * Adds a tuple write record into the table write set.
@@ -214,7 +214,7 @@ class Transaction {
   inline void AddIntoPageSet(Page *page) { page_set_->push_back(page); }
 
   /** @return the deleted page set */
-  inline std::shared_ptr<std::unordered_set<page_id_t>> GetDeletedPageSet() { return deleted_page_set_; }
+  inline auto GetDeletedPageSet() -> std::shared_ptr<std::unordered_set<page_id_t>> { return deleted_page_set_; }
 
   /**
    * Adds a page to the deleted page set.
@@ -223,19 +223,19 @@ class Transaction {
   inline void AddIntoDeletedPageSet(page_id_t page_id) { deleted_page_set_->insert(page_id); }
 
   /** @return the set of resources under a shared lock */
-  inline std::shared_ptr<std::unordered_set<RID>> GetSharedLockSet() { return shared_lock_set_; }
+  inline auto GetSharedLockSet() -> std::shared_ptr<std::unordered_set<RID>> { return shared_lock_set_; }
 
   /** @return the set of resources under an exclusive lock */
-  inline std::shared_ptr<std::unordered_set<RID>> GetExclusiveLockSet() { return exclusive_lock_set_; }
+  inline auto GetExclusiveLockSet() -> std::shared_ptr<std::unordered_set<RID>> { return exclusive_lock_set_; }
 
   /** @return true if rid is shared locked by this transaction */
-  bool IsSharedLocked(const RID &rid) { return shared_lock_set_->find(rid) != shared_lock_set_->end(); }
+  auto IsSharedLocked(const RID &rid) -> bool { return shared_lock_set_->find(rid) != shared_lock_set_->end(); }
 
   /** @return true if rid is exclusively locked by this transaction */
-  bool IsExclusiveLocked(const RID &rid) { return exclusive_lock_set_->find(rid) != exclusive_lock_set_->end(); }
+  auto IsExclusiveLocked(const RID &rid) -> bool { return exclusive_lock_set_->find(rid) != exclusive_lock_set_->end(); }
 
   /** @return the current state of the transaction */
-  inline TransactionState GetState() { return state_; }
+  inline auto GetState() -> TransactionState { return state_; }
 
   /**
    * Set the state of the transaction.
@@ -244,7 +244,7 @@ class Transaction {
   inline void SetState(TransactionState state) { state_ = state; }
 
   /** @return the previous LSN */
-  inline lsn_t GetPrevLSN() { return prev_lsn_; }
+  inline auto GetPrevLSN() -> lsn_t { return prev_lsn_; }
 
   /**
    * Set the previous LSN.

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -41,7 +41,7 @@ class TransactionManager {
    * @param isolation_level an optional isolation level of the transaction.
    * @return an initialized transaction
    */
-  Transaction *Begin(Transaction *txn = nullptr, IsolationLevel isolation_level = IsolationLevel::REPEATABLE_READ);
+  auto Begin(Transaction *txn = nullptr, IsolationLevel isolation_level = IsolationLevel::REPEATABLE_READ) -> Transaction *;
 
   /**
    * Commits a transaction.
@@ -68,7 +68,7 @@ class TransactionManager {
    * @param txn_id the id of the transaction to be found, it must exist!
    * @return the transaction with the given transaction id
    */
-  static Transaction *GetTransaction(txn_id_t txn_id) {
+  static auto GetTransaction(txn_id_t txn_id) -> Transaction * {
     TransactionManager::txn_map_mutex.lock_shared();
     assert(TransactionManager::txn_map.find(txn_id) != TransactionManager::txn_map.end());
     auto *res = TransactionManager::txn_map[txn_id];

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -52,7 +52,7 @@ class ExtendibleHashTable {
    * @param value the value to be associated with the key
    * @return true if insert succeeded, false otherwise
    */
-  bool Insert(Transaction *transaction, const KeyType &key, const ValueType &value);
+  auto Insert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool;
 
   /**
    * Deletes the associated value for the given key.
@@ -62,7 +62,7 @@ class ExtendibleHashTable {
    * @param value the value to delete
    * @return true if remove succeeded, false otherwise
    */
-  bool Remove(Transaction *transaction, const KeyType &key, const ValueType &value);
+  auto Remove(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool;
 
   /**
    * Performs a point query on the hash table.
@@ -72,12 +72,12 @@ class ExtendibleHashTable {
    * @param[out] result the value(s) associated with a given key
    * @return the value(s) associated with the given key
    */
-  bool GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result);
+  auto GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) -> bool;
 
   /**
    * Returns the global depth.  Do not touch.
    */
-  uint32_t GetGlobalDepth();
+  auto GetGlobalDepth() -> uint32_t;
 
   /**
    * Helper function to verify the integrity of the extendible hash table's directory.  Do not touch.
@@ -92,7 +92,7 @@ class ExtendibleHashTable {
    * @param key the key to hash
    * @return the downcasted 32-bit hash
    */
-  inline uint32_t Hash(KeyType key);
+  inline auto Hash(KeyType key) -> uint32_t;
 
   /**
    * KeyToDirectoryIndex - maps a key to a directory index
@@ -110,7 +110,7 @@ class ExtendibleHashTable {
    * @param dir_page to use for lookup of global depth
    * @return the directory index
    */
-  inline uint32_t KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page);
+  inline auto KeyToDirectoryIndex(KeyType key, HashTableDirectoryPage *dir_page) -> uint32_t;
 
   /**
    * Get the bucket page_id corresponding to a key.
@@ -119,14 +119,14 @@ class ExtendibleHashTable {
    * @param dir_page a pointer to the hash table's directory page
    * @return the bucket page_id corresponding to the input key
    */
-  inline uint32_t KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page);
+  inline auto KeyToPageId(KeyType key, HashTableDirectoryPage *dir_page) -> uint32_t;
 
   /**
    * Fetches the directory page from the buffer pool manager.
    *
    * @return a pointer to the directory page
    */
-  HashTableDirectoryPage *FetchDirectoryPage();
+  auto FetchDirectoryPage() -> HashTableDirectoryPage *;
 
   /**
    * Fetches the a bucket page from the buffer pool manager using the bucket's page_id.
@@ -134,7 +134,7 @@ class ExtendibleHashTable {
    * @param bucket_page_id the page_id to fetch
    * @return a pointer to a bucket page
    */
-  HASH_TABLE_BUCKET_TYPE *FetchBucketPage(page_id_t bucket_page_id);
+  auto FetchBucketPage(page_id_t bucket_page_id) -> HASH_TABLE_BUCKET_TYPE *;
 
   /**
    * Performs insertion with an optional bucket splitting.
@@ -144,7 +144,7 @@ class ExtendibleHashTable {
    * @param value the value to insert
    * @return whether or not the insertion was successful
    */
-  bool SplitInsert(Transaction *transaction, const KeyType &key, const ValueType &value);
+  auto SplitInsert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool;
 
   /**
    * Optionally merges an empty bucket into it's pair.  This is called by Remove,

--- a/src/include/container/hash/hash_function.h
+++ b/src/include/container/hash/hash_function.h
@@ -25,7 +25,7 @@ class HashFunction {
    * @param key the key to be hashed
    * @return the hashed value
    */
-  virtual uint64_t GetHash(KeyType key) {
+  virtual auto GetHash(KeyType key) -> uint64_t {
     uint64_t hash[2];
     murmur3::MurmurHash3_x64_128(reinterpret_cast<const void *>(&key), static_cast<int>(sizeof(KeyType)), 0,
                                  reinterpret_cast<void *>(&hash));

--- a/src/include/container/hash/hash_table.h
+++ b/src/include/container/hash/hash_table.h
@@ -33,7 +33,7 @@ class HashTable {
    * @param value the value to be associated with the key
    * @return true if insert succeeded, false otherwise
    */
-  virtual bool Insert(Transaction *transaction, const KeyType &key, const ValueType &value) = 0;
+  virtual auto Insert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool = 0;
 
   /**
    * Deletes the associated value for the given key.
@@ -42,7 +42,7 @@ class HashTable {
    * @param value the value to delete
    * @return true if remove succeeded, false otherwise
    */
-  virtual bool Remove(Transaction *transaction, const KeyType &key, const ValueType &value) = 0;
+  virtual auto Remove(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool = 0;
 
   /**
    * Performs a point query on the hash table.
@@ -51,7 +51,7 @@ class HashTable {
    * @param[out] result the value(s) associated with a given key
    * @return the value(s) associated with the given key
    */
-  virtual bool GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) = 0;
+  virtual auto GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) -> bool = 0;
 };
 
 }  // namespace bustub

--- a/src/include/container/hash/linear_probe_hash_table.h
+++ b/src/include/container/hash/linear_probe_hash_table.h
@@ -54,7 +54,7 @@ class LinearProbeHashTable : public HashTable<KeyType, ValueType, KeyComparator>
    * @param value the value to be associated with the key
    * @return true if insert succeeded, false otherwise
    */
-  bool Insert(Transaction *transaction, const KeyType &key, const ValueType &value) override;
+  auto Insert(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool override;
 
   /**
    * Deletes the associated value for the given key.
@@ -63,7 +63,7 @@ class LinearProbeHashTable : public HashTable<KeyType, ValueType, KeyComparator>
    * @param value the value to delete
    * @return true if remove succeeded, false otherwise
    */
-  bool Remove(Transaction *transaction, const KeyType &key, const ValueType &value) override;
+  auto Remove(Transaction *transaction, const KeyType &key, const ValueType &value) -> bool override;
 
   /**
    * Performs a point query on the hash table.
@@ -72,7 +72,7 @@ class LinearProbeHashTable : public HashTable<KeyType, ValueType, KeyComparator>
    * @param[out] result the value(s) associated with a given key
    * @return the value(s) associated with the given key
    */
-  bool GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) override;
+  auto GetValue(Transaction *transaction, const KeyType &key, std::vector<ValueType> *result) -> bool override;
 
   /**
    * Resizes the table to at least twice the initial size provided.
@@ -84,7 +84,7 @@ class LinearProbeHashTable : public HashTable<KeyType, ValueType, KeyComparator>
    * Gets the size of the hash table
    * @return current size of the hash table
    */
-  size_t GetSize();
+  auto GetSize() -> size_t;
 
  private:
   // member variable

--- a/src/include/execution/execution_engine.h
+++ b/src/include/execution/execution_engine.h
@@ -47,8 +47,8 @@ class ExecutionEngine {
    * @param exec_ctx The executor context in which the query executes
    * @return `true` if execution of the query plan succeeds, `false` otherwise
    */
-  bool Execute(const AbstractPlanNode *plan, std::vector<Tuple> *result_set, Transaction *txn,
-               ExecutorContext *exec_ctx) {
+  auto Execute(const AbstractPlanNode *plan, std::vector<Tuple> *result_set, Transaction *txn,
+               ExecutorContext *exec_ctx) -> bool {
     // Construct and executor for the plan
     auto executor = ExecutorFactory::CreateExecutor(exec_ctx, plan);
 

--- a/src/include/execution/executor_context.h
+++ b/src/include/execution/executor_context.h
@@ -43,22 +43,22 @@ class ExecutorContext {
   DISALLOW_COPY_AND_MOVE(ExecutorContext);
 
   /** @return the running transaction */
-  Transaction *GetTransaction() const { return transaction_; }
+  auto GetTransaction() const -> Transaction * { return transaction_; }
 
   /** @return the catalog */
-  Catalog *GetCatalog() { return catalog_; }
+  auto GetCatalog() -> Catalog * { return catalog_; }
 
   /** @return the buffer pool manager */
-  BufferPoolManager *GetBufferPoolManager() { return bpm_; }
+  auto GetBufferPoolManager() -> BufferPoolManager * { return bpm_; }
 
   /** @return the log manager - don't worry about it for now */
-  LogManager *GetLogManager() { return nullptr; }
+  auto GetLogManager() -> LogManager * { return nullptr; }
 
   /** @return the lock manager */
-  LockManager *GetLockManager() { return lock_mgr_; }
+  auto GetLockManager() -> LockManager * { return lock_mgr_; }
 
   /** @return the transaction manager */
-  TransactionManager *GetTransactionManager() { return txn_mgr_; }
+  auto GetTransactionManager() -> TransactionManager * { return txn_mgr_; }
 
  private:
   /** The transaction context associated with this executor context */

--- a/src/include/execution/executor_factory.h
+++ b/src/include/execution/executor_factory.h
@@ -29,6 +29,6 @@ class ExecutorFactory {
    * @param plan The plan node that needs to be executed
    * @return An executor for the given plan in the provided context
    */
-  static std::unique_ptr<AbstractExecutor> CreateExecutor(ExecutorContext *exec_ctx, const AbstractPlanNode *plan);
+  static auto CreateExecutor(ExecutorContext *exec_ctx, const AbstractPlanNode *plan) -> std::unique_ptr<AbstractExecutor>;
 };
 }  // namespace bustub

--- a/src/include/execution/executors/abstract_executor.h
+++ b/src/include/execution/executors/abstract_executor.h
@@ -44,13 +44,13 @@ class AbstractExecutor {
    * @param[out] rid The next tuple RID produced by this executor
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  virtual bool Next(Tuple *tuple, RID *rid) = 0;
+  virtual auto Next(Tuple *tuple, RID *rid) -> bool = 0;
 
   /** @return The schema of the tuples that this executor produces */
-  virtual const Schema *GetOutputSchema() = 0;
+  virtual auto GetOutputSchema() -> const Schema * = 0;
 
   /** @return The executor context in which this executor runs */
-  ExecutorContext *GetExecutorContext() { return exec_ctx_; }
+  auto GetExecutorContext() -> ExecutorContext * { return exec_ctx_; }
 
  protected:
   /** The executor context in which the executor runs */

--- a/src/include/execution/executors/aggregation_executor.h
+++ b/src/include/execution/executors/aggregation_executor.h
@@ -43,7 +43,7 @@ class SimpleAggregationHashTable {
       : agg_exprs_{agg_exprs}, agg_types_{agg_types} {}
 
   /** @return The initial aggregrate value for this aggregation executor */
-  AggregateValue GenerateInitialAggregateValue() {
+  auto GenerateInitialAggregateValue() -> AggregateValue {
     std::vector<Value> values{};
     for (const auto &agg_type : agg_types_) {
       switch (agg_type) {
@@ -115,22 +115,22 @@ class SimpleAggregationHashTable {
     explicit Iterator(std::unordered_map<AggregateKey, AggregateValue>::const_iterator iter) : iter_{iter} {}
 
     /** @return The key of the iterator */
-    const AggregateKey &Key() { return iter_->first; }
+    auto Key() -> const AggregateKey & { return iter_->first; }
 
     /** @return The value of the iterator */
-    const AggregateValue &Val() { return iter_->second; }
+    auto Val() -> const AggregateValue & { return iter_->second; }
 
     /** @return The iterator before it is incremented */
-    Iterator &operator++() {
+    auto operator++() -> Iterator & {
       ++iter_;
       return *this;
     }
 
     /** @return `true` if both iterators are identical */
-    bool operator==(const Iterator &other) { return this->iter_ == other.iter_; }
+    auto operator==(const Iterator &other) -> bool { return this->iter_ == other.iter_; }
 
     /** @return `true` if both iterators are different */
-    bool operator!=(const Iterator &other) { return this->iter_ != other.iter_; }
+    auto operator!=(const Iterator &other) -> bool { return this->iter_ != other.iter_; }
 
    private:
     /** Aggregates map */
@@ -138,10 +138,10 @@ class SimpleAggregationHashTable {
   };
 
   /** @return Iterator to the start of the hash table */
-  Iterator Begin() { return Iterator{ht_.cbegin()}; }
+  auto Begin() -> Iterator { return Iterator{ht_.cbegin()}; }
 
   /** @return Iterator to the end of the hash table */
-  Iterator End() { return Iterator{ht_.cend()}; }
+  auto End() -> Iterator { return Iterator{ht_.cend()}; }
 
  private:
   /** The hash table is just a map from aggregate keys to aggregate values */
@@ -176,17 +176,17 @@ class AggregationExecutor : public AbstractExecutor {
    * @param[out] rid The next tuple RID produced by the insert
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the aggregation */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
   /** Do not use or remove this function, otherwise you will get zero points. */
-  const AbstractExecutor *GetChildExecutor() const;
+  auto GetChildExecutor() const -> const AbstractExecutor *;
 
  private:
   /** @return The tuple as an AggregateKey */
-  AggregateKey MakeAggregateKey(const Tuple *tuple) {
+  auto MakeAggregateKey(const Tuple *tuple) -> AggregateKey {
     std::vector<Value> keys;
     for (const auto &expr : plan_->GetGroupBys()) {
       keys.emplace_back(expr->Evaluate(tuple, child_->GetOutputSchema()));
@@ -195,7 +195,7 @@ class AggregationExecutor : public AbstractExecutor {
   }
 
   /** @return The tuple as an AggregateValue */
-  AggregateValue MakeAggregateValue(const Tuple *tuple) {
+  auto MakeAggregateValue(const Tuple *tuple) -> AggregateValue {
     std::vector<Value> vals;
     for (const auto &expr : plan_->GetAggregates()) {
       vals.emplace_back(expr->Evaluate(tuple, child_->GetOutputSchema()));

--- a/src/include/execution/executors/delete_executor.h
+++ b/src/include/execution/executors/delete_executor.h
@@ -50,10 +50,10 @@ class DeleteExecutor : public AbstractExecutor {
    * NOTE: DeleteExecutor::Next() does not use the `tuple` out-parameter.
    * NOTE: DeleteExecutor::Next() does not use the `rid` out-parameter.
    */
-  bool Next([[maybe_unused]] Tuple *tuple, RID *rid) override;
+  auto Next([[maybe_unused]] Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the delete */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /** The delete plan node to be executed */

--- a/src/include/execution/executors/distinct_executor.h
+++ b/src/include/execution/executors/distinct_executor.h
@@ -43,10 +43,10 @@ class DistinctExecutor : public AbstractExecutor {
    * @param[out] rid The next tuple RID produced by the distinct
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the distinct */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /** The distinct plan node to be executed */

--- a/src/include/execution/executors/hash_join_executor.h
+++ b/src/include/execution/executors/hash_join_executor.h
@@ -46,10 +46,10 @@ class HashJoinExecutor : public AbstractExecutor {
    * @param[out] rid The next tuple RID produced by the join
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the join */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /** The NestedLoopJoin plan node to be executed. */

--- a/src/include/execution/executors/index_scan_executor.h
+++ b/src/include/execution/executors/index_scan_executor.h
@@ -35,11 +35,11 @@ class IndexScanExecutor : public AbstractExecutor {
    */
   IndexScanExecutor(ExecutorContext *exec_ctx, const IndexScanPlanNode *plan);
 
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
   void Init() override;
 
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
  private:
   /** The index scan plan node to be executed. */

--- a/src/include/execution/executors/insert_executor.h
+++ b/src/include/execution/executors/insert_executor.h
@@ -51,10 +51,10 @@ class InsertExecutor : public AbstractExecutor {
    * NOTE: InsertExecutor::Next() does not use the `tuple` out-parameter.
    * NOTE: InsertExecutor::Next() does not use the `rid` out-parameter.
    */
-  bool Next([[maybe_unused]] Tuple *tuple, RID *rid) override;
+  auto Next([[maybe_unused]] Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the insert */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /** The insert plan node to be executed*/

--- a/src/include/execution/executors/limit_executor.h
+++ b/src/include/execution/executors/limit_executor.h
@@ -43,10 +43,10 @@ class LimitExecutor : public AbstractExecutor {
    * @param[out] rid The next tuple RID produced by the limit
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the limit */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /** The limit plan node to be executed */

--- a/src/include/execution/executors/nested_index_join_executor.h
+++ b/src/include/execution/executors/nested_index_join_executor.h
@@ -41,11 +41,11 @@ class NestIndexJoinExecutor : public AbstractExecutor {
   NestIndexJoinExecutor(ExecutorContext *exec_ctx, const NestedIndexJoinPlanNode *plan,
                         std::unique_ptr<AbstractExecutor> &&child_executor);
 
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); }
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); }
 
   void Init() override;
 
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
  private:
   /** The nested index join plan node. */

--- a/src/include/execution/executors/nested_loop_join_executor.h
+++ b/src/include/execution/executors/nested_loop_join_executor.h
@@ -47,10 +47,10 @@ class NestedLoopJoinExecutor : public AbstractExecutor {
    * @param[out] rid The next tuple RID produced by the join
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the insert */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /** The NestedLoopJoin plan node to be executed. */

--- a/src/include/execution/executors/seq_scan_executor.h
+++ b/src/include/execution/executors/seq_scan_executor.h
@@ -42,10 +42,10 @@ class SeqScanExecutor : public AbstractExecutor {
    * @param[out] rid The next tuple RID produced by the scan
    * @return `true` if a tuple was produced, `false` if there are no more tuples
    */
-  bool Next(Tuple *tuple, RID *rid) override;
+  auto Next(Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the sequential scan */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); }
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); }
 
  private:
   /** The sequential scan plan node to be executed */

--- a/src/include/execution/executors/update_executor.h
+++ b/src/include/execution/executors/update_executor.h
@@ -53,10 +53,10 @@ class UpdateExecutor : public AbstractExecutor {
    * NOTE: UpdateExecutor::Next() does not use the `tuple` out-parameter.
    * NOTE: UpdateExecutor::Next() does not use the `rid` out-parameter.
    */
-  bool Next([[maybe_unused]] Tuple *tuple, RID *rid) override;
+  auto Next([[maybe_unused]] Tuple *tuple, RID *rid) -> bool override;
 
   /** @return The output schema for the update */
-  const Schema *GetOutputSchema() override { return plan_->OutputSchema(); };
+  auto GetOutputSchema() -> const Schema * override { return plan_->OutputSchema(); };
 
  private:
   /**
@@ -64,7 +64,7 @@ class UpdateExecutor : public AbstractExecutor {
    * based on the `UpdateInfo` provided in the plan.
    * @param src_tuple The tuple to be updated
    */
-  Tuple GenerateUpdatedTuple(const Tuple &src_tuple);
+  auto GenerateUpdatedTuple(const Tuple &src_tuple) -> Tuple;
 
   /** The update plan node to be executed */
   const UpdatePlanNode *plan_;

--- a/src/include/execution/expressions/abstract_expression.h
+++ b/src/include/execution/expressions/abstract_expression.h
@@ -37,7 +37,7 @@ class AbstractExpression {
   virtual ~AbstractExpression() = default;
 
   /** @return The value obtained by evaluating the tuple with the given schema */
-  virtual Value Evaluate(const Tuple *tuple, const Schema *schema) const = 0;
+  virtual auto Evaluate(const Tuple *tuple, const Schema *schema) const -> Value = 0;
 
   /**
    * Returns the value obtained by evaluating a JOIN.
@@ -47,8 +47,8 @@ class AbstractExpression {
    * @param right_schema The right tuple's schema
    * @return The value obtained by evaluating a JOIN on the left and right
    */
-  virtual Value EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
-                             const Schema *right_schema) const = 0;
+  virtual auto EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
+                             const Schema *right_schema) const -> Value = 0;
 
   /**
    * Returns the value obtained by evaluating the aggregates.
@@ -56,16 +56,16 @@ class AbstractExpression {
    * @param aggregates The aggregate values
    * @return The value obtained by checking the aggregates and group-bys
    */
-  virtual Value EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const = 0;
+  virtual auto EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const -> Value = 0;
 
   /** @return the child_idx'th child of this expression */
-  const AbstractExpression *GetChildAt(uint32_t child_idx) const { return children_[child_idx]; }
+  auto GetChildAt(uint32_t child_idx) const -> const AbstractExpression * { return children_[child_idx]; }
 
   /** @return the children of this expression, ordering may matter */
-  const std::vector<const AbstractExpression *> &GetChildren() const { return children_; }
+  auto GetChildren() const -> const std::vector<const AbstractExpression *> & { return children_; }
 
   /** @return the type of this expression if it were to be evaluated */
-  virtual TypeId GetReturnType() const { return ret_type_; }
+  virtual auto GetReturnType() const -> TypeId { return ret_type_; }
 
  private:
   /** The children of this expression. Note that the order of appearance of children may matter. */

--- a/src/include/execution/expressions/aggregate_value_expression.h
+++ b/src/include/execution/expressions/aggregate_value_expression.h
@@ -34,13 +34,13 @@ class AggregateValueExpression : public AbstractExpression {
       : AbstractExpression({}, ret_type), is_group_by_term_{is_group_by_term}, term_idx_{term_idx} {}
 
   /** Invalid operation for `AggregateValueExpression` */
-  Value Evaluate(const Tuple *tuple, const Schema *schema) const override {
+  auto Evaluate(const Tuple *tuple, const Schema *schema) const -> Value override {
     UNREACHABLE("Aggregation should only refer to group-by and aggregates.");
   }
 
   /** Invalid operation for `AggregateValueExpression` */
-  Value EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
-                     const Schema *right_schema) const override {
+  auto EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
+                     const Schema *right_schema) const -> Value override {
     UNREACHABLE("Aggregation should only refer to group-by and aggregates.");
   }
 
@@ -50,7 +50,7 @@ class AggregateValueExpression : public AbstractExpression {
    * @param aggregates The aggregate values
    * @return The value obtained by checking the aggregates and group-bys
    */
-  Value EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const override {
+  auto EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const -> Value override {
     return is_group_by_term_ ? group_bys[term_idx_] : aggregates[term_idx_];
   }
 

--- a/src/include/execution/expressions/column_value_expression.h
+++ b/src/include/execution/expressions/column_value_expression.h
@@ -33,20 +33,20 @@ class ColumnValueExpression : public AbstractExpression {
   ColumnValueExpression(uint32_t tuple_idx, uint32_t col_idx, TypeId ret_type)
       : AbstractExpression({}, ret_type), tuple_idx_{tuple_idx}, col_idx_{col_idx} {}
 
-  Value Evaluate(const Tuple *tuple, const Schema *schema) const override { return tuple->GetValue(schema, col_idx_); }
+  auto Evaluate(const Tuple *tuple, const Schema *schema) const -> Value override { return tuple->GetValue(schema, col_idx_); }
 
-  Value EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
-                     const Schema *right_schema) const override {
+  auto EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
+                     const Schema *right_schema) const -> Value override {
     return tuple_idx_ == 0 ? left_tuple->GetValue(left_schema, col_idx_)
                            : right_tuple->GetValue(right_schema, col_idx_);
   }
 
-  Value EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const override {
+  auto EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const -> Value override {
     BUSTUB_ASSERT(false, "Aggregation should only refer to group-by and aggregates.");
   }
 
-  uint32_t GetTupleIdx() const { return tuple_idx_; }
-  uint32_t GetColIdx() const { return col_idx_; }
+  auto GetTupleIdx() const -> uint32_t { return tuple_idx_; }
+  auto GetColIdx() const -> uint32_t { return col_idx_; }
 
  private:
   /** Tuple index 0 = left side of join, tuple index 1 = right side of join */

--- a/src/include/execution/expressions/comparison_expression.h
+++ b/src/include/execution/expressions/comparison_expression.h
@@ -34,27 +34,27 @@ class ComparisonExpression : public AbstractExpression {
   ComparisonExpression(const AbstractExpression *left, const AbstractExpression *right, ComparisonType comp_type)
       : AbstractExpression({left, right}, TypeId::BOOLEAN), comp_type_{comp_type} {}
 
-  Value Evaluate(const Tuple *tuple, const Schema *schema) const override {
+  auto Evaluate(const Tuple *tuple, const Schema *schema) const -> Value override {
     Value lhs = GetChildAt(0)->Evaluate(tuple, schema);
     Value rhs = GetChildAt(1)->Evaluate(tuple, schema);
     return ValueFactory::GetBooleanValue(PerformComparison(lhs, rhs));
   }
 
-  Value EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
-                     const Schema *right_schema) const override {
+  auto EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
+                     const Schema *right_schema) const -> Value override {
     Value lhs = GetChildAt(0)->EvaluateJoin(left_tuple, left_schema, right_tuple, right_schema);
     Value rhs = GetChildAt(1)->EvaluateJoin(left_tuple, left_schema, right_tuple, right_schema);
     return ValueFactory::GetBooleanValue(PerformComparison(lhs, rhs));
   }
 
-  Value EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const override {
+  auto EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const -> Value override {
     Value lhs = GetChildAt(0)->EvaluateAggregate(group_bys, aggregates);
     Value rhs = GetChildAt(1)->EvaluateAggregate(group_bys, aggregates);
     return ValueFactory::GetBooleanValue(PerformComparison(lhs, rhs));
   }
 
  private:
-  CmpBool PerformComparison(const Value &lhs, const Value &rhs) const {
+  auto PerformComparison(const Value &lhs, const Value &rhs) const -> CmpBool {
     switch (comp_type_) {
       case ComparisonType::Equal:
         return lhs.CompareEquals(rhs);

--- a/src/include/execution/expressions/constant_value_expression.h
+++ b/src/include/execution/expressions/constant_value_expression.h
@@ -25,14 +25,14 @@ class ConstantValueExpression : public AbstractExpression {
   /** Creates a new constant value expression wrapping the given value. */
   explicit ConstantValueExpression(const Value &val) : AbstractExpression({}, val.GetTypeId()), val_(val) {}
 
-  Value Evaluate(const Tuple *tuple, const Schema *schema) const override { return val_; }
+  auto Evaluate(const Tuple *tuple, const Schema *schema) const -> Value override { return val_; }
 
-  Value EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
-                     const Schema *right_schema) const override {
+  auto EvaluateJoin(const Tuple *left_tuple, const Schema *left_schema, const Tuple *right_tuple,
+                     const Schema *right_schema) const -> Value override {
     return val_;
   }
 
-  Value EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const override {
+  auto EvaluateAggregate(const std::vector<Value> &group_bys, const std::vector<Value> &aggregates) const -> Value override {
     return val_;
   }
 

--- a/src/include/execution/plans/abstract_plan.h
+++ b/src/include/execution/plans/abstract_plan.h
@@ -54,16 +54,16 @@ class AbstractPlanNode {
   virtual ~AbstractPlanNode() = default;
 
   /** @return the schema for the output of this plan node */
-  const Schema *OutputSchema() const { return output_schema_; }
+  auto OutputSchema() const -> const Schema * { return output_schema_; }
 
   /** @return the child of this plan node at index child_idx */
-  const AbstractPlanNode *GetChildAt(uint32_t child_idx) const { return children_[child_idx]; }
+  auto GetChildAt(uint32_t child_idx) const -> const AbstractPlanNode * { return children_[child_idx]; }
 
   /** @return the children of this plan node */
-  const std::vector<const AbstractPlanNode *> &GetChildren() const { return children_; }
+  auto GetChildren() const -> const std::vector<const AbstractPlanNode *> & { return children_; }
 
   /** @return the type of this plan node */
-  virtual PlanType GetType() const = 0;
+  virtual auto GetType() const -> PlanType = 0;
 
  private:
   /**

--- a/src/include/execution/plans/aggregation_plan.h
+++ b/src/include/execution/plans/aggregation_plan.h
@@ -51,31 +51,31 @@ class AggregationPlanNode : public AbstractPlanNode {
         agg_types_(std::move(agg_types)) {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::Aggregation; }
+  auto GetType() const -> PlanType override { return PlanType::Aggregation; }
 
   /** @return the child of this aggregation plan node */
-  const AbstractPlanNode *GetChildPlan() const {
+  auto GetChildPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 1, "Aggregation expected to only have one child.");
     return GetChildAt(0);
   }
 
   /** @return The having clause */
-  const AbstractExpression *GetHaving() const { return having_; }
+  auto GetHaving() const -> const AbstractExpression * { return having_; }
 
   /** @return The idx'th group by expression */
-  const AbstractExpression *GetGroupByAt(uint32_t idx) const { return group_bys_[idx]; }
+  auto GetGroupByAt(uint32_t idx) const -> const AbstractExpression * { return group_bys_[idx]; }
 
   /** @return The group by expressions */
-  const std::vector<const AbstractExpression *> &GetGroupBys() const { return group_bys_; }
+  auto GetGroupBys() const -> const std::vector<const AbstractExpression *> & { return group_bys_; }
 
   /** @return The idx'th aggregate expression */
-  const AbstractExpression *GetAggregateAt(uint32_t idx) const { return aggregates_[idx]; }
+  auto GetAggregateAt(uint32_t idx) const -> const AbstractExpression * { return aggregates_[idx]; }
 
   /** @return The aggregate expressions */
-  const std::vector<const AbstractExpression *> &GetAggregates() const { return aggregates_; }
+  auto GetAggregates() const -> const std::vector<const AbstractExpression *> & { return aggregates_; }
 
   /** @return The aggregate types */
-  const std::vector<AggregationType> &GetAggregateTypes() const { return agg_types_; }
+  auto GetAggregateTypes() const -> const std::vector<AggregationType> & { return agg_types_; }
 
  private:
   /** A HAVING clause expression (may be `nullptr`) */
@@ -98,7 +98,7 @@ struct AggregateKey {
    * @param other the other aggregate key to be compared with
    * @return `true` if both aggregate keys have equivalent group-by expressions, `false` otherwise
    */
-  bool operator==(const AggregateKey &other) const {
+  auto operator==(const AggregateKey &other) const -> bool {
     for (uint32_t i = 0; i < other.group_bys_.size(); i++) {
       if (group_bys_[i].CompareEquals(other.group_bys_[i]) != CmpBool::CmpTrue) {
         return false;
@@ -121,7 +121,7 @@ namespace std {
 /** Implements std::hash on AggregateKey */
 template <>
 struct hash<bustub::AggregateKey> {
-  std::size_t operator()(const bustub::AggregateKey &agg_key) const {
+  auto operator()(const bustub::AggregateKey &agg_key) const -> std::size_t {
     size_t curr_hash = 0;
     for (const auto &key : agg_key.group_bys_) {
       if (!key.IsNull()) {

--- a/src/include/execution/plans/delete_plan.h
+++ b/src/include/execution/plans/delete_plan.h
@@ -35,13 +35,13 @@ class DeletePlanNode : public AbstractPlanNode {
       : AbstractPlanNode(nullptr, {child}), table_oid_{table_oid} {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::Delete; }
+  auto GetType() const -> PlanType override { return PlanType::Delete; }
 
   /** @return The identifier of the table from which tuples are deleted*/
-  table_oid_t TableOid() const { return table_oid_; }
+  auto TableOid() const -> table_oid_t { return table_oid_; }
 
   /** @return The child plan providing tuples to be deleted */
-  const AbstractPlanNode *GetChildPlan() const {
+  auto GetChildPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 1, "delete should have at most one child plan.");
     return GetChildAt(0);
   }

--- a/src/include/execution/plans/distinct_plan.h
+++ b/src/include/execution/plans/distinct_plan.h
@@ -29,10 +29,10 @@ class DistinctPlanNode : public AbstractPlanNode {
       : AbstractPlanNode(output_schema, {child}) {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::Distinct; }
+  auto GetType() const -> PlanType override { return PlanType::Distinct; }
 
   /** @return The child plan node */
-  const AbstractPlanNode *GetChildPlan() const {
+  auto GetChildPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 1, "Distinct should have at most one child plan.");
     return GetChildAt(0);
   }

--- a/src/include/execution/plans/hash_join_plan.h
+++ b/src/include/execution/plans/hash_join_plan.h
@@ -38,22 +38,22 @@ class HashJoinPlanNode : public AbstractPlanNode {
         right_key_expression_{right_key_expression} {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::HashJoin; }
+  auto GetType() const -> PlanType override { return PlanType::HashJoin; }
 
   /** @return The expression to compute the left join key */
-  const AbstractExpression *LeftJoinKeyExpression() const { return left_key_expression_; }
+  auto LeftJoinKeyExpression() const -> const AbstractExpression * { return left_key_expression_; }
 
   /** @return The expression to compute the right join key */
-  const AbstractExpression *RightJoinKeyExpression() const { return right_key_expression_; }
+  auto RightJoinKeyExpression() const -> const AbstractExpression * { return right_key_expression_; }
 
   /** @return The left plan node of the hash join */
-  const AbstractPlanNode *GetLeftPlan() const {
+  auto GetLeftPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 2, "Hash joins should have exactly two children plans.");
     return GetChildAt(0);
   }
 
   /** @return The right plan node of the hash join */
-  const AbstractPlanNode *GetRightPlan() const {
+  auto GetRightPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 2, "Hash joins should have exactly two children plans.");
     return GetChildAt(1);
   }

--- a/src/include/execution/plans/index_scan_plan.h
+++ b/src/include/execution/plans/index_scan_plan.h
@@ -32,13 +32,13 @@ class IndexScanPlanNode : public AbstractPlanNode {
   IndexScanPlanNode(const Schema *output, const AbstractExpression *predicate, index_oid_t index_oid)
       : AbstractPlanNode(output, {}), predicate_{predicate}, index_oid_(index_oid) {}
 
-  PlanType GetType() const override { return PlanType::IndexScan; }
+  auto GetType() const -> PlanType override { return PlanType::IndexScan; }
 
   /** @return the predicate to test tuples against; tuples should only be returned if they evaluate to true */
-  const AbstractExpression *GetPredicate() const { return predicate_; }
+  auto GetPredicate() const -> const AbstractExpression * { return predicate_; }
 
   /** @return the identifier of the table that should be scanned */
-  index_oid_t GetIndexOid() const { return index_oid_; }
+  auto GetIndexOid() const -> index_oid_t { return index_oid_; }
 
  private:
   /** The predicate that all returned tuples must satisfy. */

--- a/src/include/execution/plans/insert_plan.h
+++ b/src/include/execution/plans/insert_plan.h
@@ -48,29 +48,29 @@ class InsertPlanNode : public AbstractPlanNode {
       : AbstractPlanNode(nullptr, {child}), table_oid_(table_oid) {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::Insert; }
+  auto GetType() const -> PlanType override { return PlanType::Insert; }
 
   /** @return The identifier of the table into which tuples are inserted */
-  table_oid_t TableOid() const { return table_oid_; }
+  auto TableOid() const -> table_oid_t { return table_oid_; }
 
   /** @return `true` if we embed insert values directly into the plan, `false` if we have a child plan that provides
    * tuples*/
-  bool IsRawInsert() const { return GetChildren().empty(); }
+  auto IsRawInsert() const -> bool { return GetChildren().empty(); }
 
   /** @return The raw value to be inserted at the particular index */
-  const std::vector<Value> &RawValuesAt(uint32_t idx) const {
+  auto RawValuesAt(uint32_t idx) const -> const std::vector<Value> & {
     BUSTUB_ASSERT(IsRawInsert(), "This is not a raw insert, you should use the child plan.");
     return raw_values_[idx];
   }
 
   /** @return The raw values to be inserted */
-  const std::vector<std::vector<Value>> &RawValues() const {
+  auto RawValues() const -> const std::vector<std::vector<Value>> & {
     BUSTUB_ASSERT(IsRawInsert(), "This is not a raw insert, you should use the child plan.");
     return raw_values_;
   }
 
   /** @return the child plan providing tuples to be inserted */
-  const AbstractPlanNode *GetChildPlan() const {
+  auto GetChildPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(!IsRawInsert(), "This is a raw insert, no child plan should be used.");
     BUSTUB_ASSERT(GetChildren().size() == 1, "Insert should have at most one child plan.");
     return GetChildAt(0);

--- a/src/include/execution/plans/limit_plan.h
+++ b/src/include/execution/plans/limit_plan.h
@@ -30,13 +30,13 @@ class LimitPlanNode : public AbstractPlanNode {
       : AbstractPlanNode(output_schema, {child}), limit_{limit} {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::Limit; }
+  auto GetType() const -> PlanType override { return PlanType::Limit; }
 
   /** @return The limit */
-  size_t GetLimit() const { return limit_; }
+  auto GetLimit() const -> size_t { return limit_; }
 
   /** @return The child plan node */
-  const AbstractPlanNode *GetChildPlan() const {
+  auto GetChildPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 1, "Limit should have at most one child plan.");
     return GetChildAt(0);
   }

--- a/src/include/execution/plans/nested_index_join_plan.h
+++ b/src/include/execution/plans/nested_index_join_plan.h
@@ -39,25 +39,25 @@ class NestedIndexJoinPlanNode : public AbstractPlanNode {
         outer_table_schema_(outer_table_schema),
         inner_table_schema_(inner_table_schema) {}
 
-  PlanType GetType() const override { return PlanType::NestedIndexJoin; }
+  auto GetType() const -> PlanType override { return PlanType::NestedIndexJoin; }
 
   /** @return the predicate to be used in the nested index join */
-  const AbstractExpression *Predicate() const { return predicate_; }
+  auto Predicate() const -> const AbstractExpression * { return predicate_; }
 
   /** @return the plan node for the outer table of the nested index join */
-  const AbstractPlanNode *GetChildPlan() const { return GetChildAt(0); }
+  auto GetChildPlan() const -> const AbstractPlanNode * { return GetChildAt(0); }
 
   /** @return the table oid for the inner table of the nested index join */
-  table_oid_t GetInnerTableOid() const { return inner_table_oid_; }
+  auto GetInnerTableOid() const -> table_oid_t { return inner_table_oid_; }
 
   /** @return the index associated with the nested index join */
-  std::string GetIndexName() const { return index_name_; }
+  auto GetIndexName() const -> std::string { return index_name_; }
 
   /** @return Schema with needed columns in from the outer table */
-  const Schema *OuterTableSchema() const { return outer_table_schema_; }
+  auto OuterTableSchema() const -> const Schema * { return outer_table_schema_; }
 
   /** @return Schema with needed columns in from the inner table */
-  const Schema *InnerTableSchema() const { return inner_table_schema_; }
+  auto InnerTableSchema() const -> const Schema * { return inner_table_schema_; }
 
  private:
   /** The nested index join predicate. */

--- a/src/include/execution/plans/nested_loop_join_plan.h
+++ b/src/include/execution/plans/nested_loop_join_plan.h
@@ -38,19 +38,19 @@ class NestedLoopJoinPlanNode : public AbstractPlanNode {
       : AbstractPlanNode(output_schema, std::move(children)), predicate_(predicate) {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::NestedLoopJoin; }
+  auto GetType() const -> PlanType override { return PlanType::NestedLoopJoin; }
 
   /** @return The predicate to be used in the nested loop join */
-  const AbstractExpression *Predicate() const { return predicate_; }
+  auto Predicate() const -> const AbstractExpression * { return predicate_; }
 
   /** @return The left plan node of the nested loop join, by convention it should be the smaller table */
-  const AbstractPlanNode *GetLeftPlan() const {
+  auto GetLeftPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 2, "Nested loop joins should have exactly two children plans.");
     return GetChildAt(0);
   }
 
   /** @return The right plan node of the nested loop join */
-  const AbstractPlanNode *GetRightPlan() const {
+  auto GetRightPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 2, "Nested loop joins should have exactly two children plans.");
     return GetChildAt(1);
   }

--- a/src/include/execution/plans/seq_scan_plan.h
+++ b/src/include/execution/plans/seq_scan_plan.h
@@ -34,13 +34,13 @@ class SeqScanPlanNode : public AbstractPlanNode {
       : AbstractPlanNode(output, {}), predicate_{predicate}, table_oid_{table_oid} {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::SeqScan; }
+  auto GetType() const -> PlanType override { return PlanType::SeqScan; }
 
   /** @return The predicate to test tuples against; tuples should only be returned if they evaluate to true */
-  const AbstractExpression *GetPredicate() const { return predicate_; }
+  auto GetPredicate() const -> const AbstractExpression * { return predicate_; }
 
   /** @return The identifier of the table that should be scanned */
-  table_oid_t GetTableOid() const { return table_oid_; }
+  auto GetTableOid() const -> table_oid_t { return table_oid_; }
 
  private:
   /** The predicate that all returned tuples must satisfy */

--- a/src/include/execution/plans/update_plan.h
+++ b/src/include/execution/plans/update_plan.h
@@ -48,19 +48,19 @@ class UpdatePlanNode : public AbstractPlanNode {
       : AbstractPlanNode(nullptr, {child}), table_oid_{table_oid}, update_attrs_{std::move(update_attrs)} {}
 
   /** @return The type of the plan node */
-  PlanType GetType() const override { return PlanType::Update; }
+  auto GetType() const -> PlanType override { return PlanType::Update; }
 
   /** @return The identifier of the table that should be updated */
-  table_oid_t TableOid() const { return table_oid_; }
+  auto TableOid() const -> table_oid_t { return table_oid_; }
 
   /** @return The child plan providing tuples to be inserted */
-  const AbstractPlanNode *GetChildPlan() const {
+  auto GetChildPlan() const -> const AbstractPlanNode * {
     BUSTUB_ASSERT(GetChildren().size() == 1, "UPDATE should have at most one child plan.");
     return GetChildAt(0);
   }
 
   /** @return The update attributes */
-  const std::unordered_map<uint32_t, UpdateInfo> &GetUpdateAttr() const { return update_attrs_; }
+  auto GetUpdateAttr() const -> const std::unordered_map<uint32_t, UpdateInfo> & { return update_attrs_; }
 
  private:
   /** The table to be updated. */

--- a/src/include/primer/p0_starter.h
+++ b/src/include/primer/p0_starter.h
@@ -51,10 +51,10 @@ class Matrix {
 
  public:
   /** @return The number of rows in the matrix */
-  virtual int GetRowCount() const = 0;
+  virtual auto GetRowCount() const -> int = 0;
 
   /** @return The number of columns in the matrix */
-  virtual int GetColumnCount() const = 0;
+  virtual auto GetColumnCount() const -> int = 0;
 
   /**
    * Get the (i,j)th matrix element.
@@ -66,7 +66,7 @@ class Matrix {
    * @return The (i,j)th matrix element
    * @throws OUT_OF_RANGE if either index is out of range
    */
-  virtual T GetElement(int i, int j) const = 0;
+  virtual auto GetElement(int i, int j) const -> T = 0;
 
   /**
    * Set the (i,j)th matrix element.
@@ -118,13 +118,13 @@ class RowMatrix : public Matrix<T> {
    * TODO(P0): Add implementation
    * @return The number of rows in the matrix
    */
-  int GetRowCount() const override { return 0; }
+  auto GetRowCount() const -> int override { return 0; }
 
   /**
    * TODO(P0): Add implementation
    * @return The number of columns in the matrix
    */
-  int GetColumnCount() const override { return 0; }
+  auto GetColumnCount() const -> int override { return 0; }
 
   /**
    * TODO(P0): Add implementation
@@ -138,7 +138,7 @@ class RowMatrix : public Matrix<T> {
    * @return The (i,j)th matrix element
    * @throws OUT_OF_RANGE if either index is out of range
    */
-  T GetElement(int i, int j) const override {
+  auto GetElement(int i, int j) const -> T override {
     throw NotImplementedException{"RowMatrix::GetElement() not implemented."};
   }
 
@@ -202,7 +202,7 @@ class RowMatrixOperations {
    * @param matrixB Input matrix
    * @return The result of matrix addition
    */
-  static std::unique_ptr<RowMatrix<T>> Add(const RowMatrix<T> *matrixA, const RowMatrix<T> *matrixB) {
+  static auto Add(const RowMatrix<T> *matrixA, const RowMatrix<T> *matrixB) -> std::unique_ptr<RowMatrix<T>> {
     // TODO(P0): Add implementation
     return std::unique_ptr<RowMatrix<T>>(nullptr);
   }
@@ -214,7 +214,7 @@ class RowMatrixOperations {
    * @param matrixB Input matrix
    * @return The result of matrix multiplication
    */
-  static std::unique_ptr<RowMatrix<T>> Multiply(const RowMatrix<T> *matrixA, const RowMatrix<T> *matrixB) {
+  static auto Multiply(const RowMatrix<T> *matrixA, const RowMatrix<T> *matrixB) -> std::unique_ptr<RowMatrix<T>> {
     // TODO(P0): Add implementation
     return std::unique_ptr<RowMatrix<T>>(nullptr);
   }
@@ -227,8 +227,8 @@ class RowMatrixOperations {
    * @param matrixC Input matrix
    * @return The result of general matrix multiply
    */
-  static std::unique_ptr<RowMatrix<T>> GEMM(const RowMatrix<T> *matrixA, const RowMatrix<T> *matrixB,
-                                            const RowMatrix<T> *matrixC) {
+  static auto GEMM(const RowMatrix<T> *matrixA, const RowMatrix<T> *matrixB,
+                                            const RowMatrix<T> *matrixC) -> std::unique_ptr<RowMatrix<T>> {
     // TODO(P0): Add implementation
     return std::unique_ptr<RowMatrix<T>>(nullptr);
   }

--- a/src/include/recovery/log_manager.h
+++ b/src/include/recovery/log_manager.h
@@ -44,12 +44,12 @@ class LogManager {
   void RunFlushThread();
   void StopFlushThread();
 
-  lsn_t AppendLogRecord(LogRecord *log_record);
+  auto AppendLogRecord(LogRecord *log_record) -> lsn_t;
 
-  inline lsn_t GetNextLSN() { return next_lsn_; }
-  inline lsn_t GetPersistentLSN() { return persistent_lsn_; }
+  inline auto GetNextLSN() -> lsn_t { return next_lsn_; }
+  inline auto GetPersistentLSN() -> lsn_t { return persistent_lsn_; }
   inline void SetPersistentLSN(lsn_t lsn) { persistent_lsn_ = lsn; }
-  inline char *GetLogBuffer() { return log_buffer_; }
+  inline auto GetLogBuffer() -> char * { return log_buffer_; }
 
  private:
   // TODO(students): you may add your own member variables

--- a/src/include/recovery/log_record.h
+++ b/src/include/recovery/log_record.h
@@ -112,34 +112,34 @@ class LogRecord {
 
   ~LogRecord() = default;
 
-  inline Tuple &GetDeleteTuple() { return delete_tuple_; }
+  inline auto GetDeleteTuple() -> Tuple & { return delete_tuple_; }
 
-  inline RID &GetDeleteRID() { return delete_rid_; }
+  inline auto GetDeleteRID() -> RID & { return delete_rid_; }
 
-  inline Tuple &GetInsertTuple() { return insert_tuple_; }
+  inline auto GetInsertTuple() -> Tuple & { return insert_tuple_; }
 
-  inline RID &GetInsertRID() { return insert_rid_; }
+  inline auto GetInsertRID() -> RID & { return insert_rid_; }
 
-  inline Tuple &GetOriginalTuple() { return old_tuple_; }
+  inline auto GetOriginalTuple() -> Tuple & { return old_tuple_; }
 
-  inline Tuple &GetUpdateTuple() { return new_tuple_; }
+  inline auto GetUpdateTuple() -> Tuple & { return new_tuple_; }
 
-  inline RID &GetUpdateRID() { return update_rid_; }
+  inline auto GetUpdateRID() -> RID & { return update_rid_; }
 
-  inline page_id_t GetNewPageRecord() { return prev_page_id_; }
+  inline auto GetNewPageRecord() -> page_id_t { return prev_page_id_; }
 
-  inline int32_t GetSize() { return size_; }
+  inline auto GetSize() -> int32_t { return size_; }
 
-  inline lsn_t GetLSN() { return lsn_; }
+  inline auto GetLSN() -> lsn_t { return lsn_; }
 
-  inline txn_id_t GetTxnId() { return txn_id_; }
+  inline auto GetTxnId() -> txn_id_t { return txn_id_; }
 
-  inline lsn_t GetPrevLSN() { return prev_lsn_; }
+  inline auto GetPrevLSN() -> lsn_t { return prev_lsn_; }
 
-  inline LogRecordType &GetLogRecordType() { return log_record_type_; }
+  inline auto GetLogRecordType() -> LogRecordType & { return log_record_type_; }
 
   // For debug purpose
-  inline std::string ToString() const {
+  inline auto ToString() const -> std::string {
     std::ostringstream os;
     os << "Log["
        << "size:" << size_ << ", "

--- a/src/include/recovery/log_recovery.h
+++ b/src/include/recovery/log_recovery.h
@@ -39,7 +39,7 @@ class LogRecovery {
 
   void Redo();
   void Undo();
-  bool DeserializeLogRecord(const char *data, LogRecord *log_record);
+  auto DeserializeLogRecord(const char *data, LogRecord *log_record) -> bool;
 
  private:
   DiskManager *disk_manager_ __attribute__((__unused__));

--- a/src/include/storage/disk/disk_manager.h
+++ b/src/include/storage/disk/disk_manager.h
@@ -69,16 +69,16 @@ class DiskManager {
    * @param offset offset of the log entry in the file
    * @return true if the read was successful, false otherwise
    */
-  bool ReadLog(char *log_data, int size, int offset);
+  auto ReadLog(char *log_data, int size, int offset) -> bool;
 
   /** @return the number of disk flushes */
-  int GetNumFlushes() const;
+  auto GetNumFlushes() const -> int;
 
   /** @return true iff the in-memory content has not been flushed yet */
-  bool GetFlushState() const;
+  auto GetFlushState() const -> bool;
 
   /** @return the number of disk writes */
-  int GetNumWrites() const;
+  auto GetNumWrites() const -> int;
 
   /**
    * Sets the future which is used to check for non-blocking flushes.
@@ -87,10 +87,10 @@ class DiskManager {
   inline void SetFlushLogFuture(std::future<void> *f) { flush_log_f_ = f; }
 
   /** Checks if the non-blocking flush future was set. */
-  inline bool HasFlushLogFuture() { return flush_log_f_ != nullptr; }
+  inline auto HasFlushLogFuture() -> bool { return flush_log_f_ != nullptr; }
 
  private:
-  int GetFileSize(const std::string &file_name);
+  auto GetFileSize(const std::string &file_name) -> int;
   // stream to write log file
   std::fstream log_io_;
   std::string log_name_;

--- a/src/include/storage/index/b_plus_tree.h
+++ b/src/include/storage/index/b_plus_tree.h
@@ -43,21 +43,21 @@ class BPlusTree {
                      int leaf_max_size = LEAF_PAGE_SIZE, int internal_max_size = INTERNAL_PAGE_SIZE);
 
   // Returns true if this B+ tree has no keys and values.
-  bool IsEmpty() const;
+  auto IsEmpty() const -> bool;
 
   // Insert a key-value pair into this B+ tree.
-  bool Insert(const KeyType &key, const ValueType &value, Transaction *transaction = nullptr);
+  auto Insert(const KeyType &key, const ValueType &value, Transaction *transaction = nullptr) -> bool;
 
   // Remove a key and its value from this B+ tree.
   void Remove(const KeyType &key, Transaction *transaction = nullptr);
 
   // return the value associated with a given key
-  bool GetValue(const KeyType &key, std::vector<ValueType> *result, Transaction *transaction = nullptr);
+  auto GetValue(const KeyType &key, std::vector<ValueType> *result, Transaction *transaction = nullptr) -> bool;
 
   // index iterator
-  INDEXITERATOR_TYPE Begin();
-  INDEXITERATOR_TYPE Begin(const KeyType &key);
-  INDEXITERATOR_TYPE End();
+  auto Begin() -> INDEXITERATOR_TYPE;
+  auto Begin(const KeyType &key) -> INDEXITERATOR_TYPE;
+  auto End() -> INDEXITERATOR_TYPE;
 
   // print the B+ tree
   void Print(BufferPoolManager *bpm);
@@ -71,30 +71,30 @@ class BPlusTree {
   // read data from file and remove one by one
   void RemoveFromFile(const std::string &file_name, Transaction *transaction = nullptr);
   // expose for test purpose
-  Page *FindLeafPage(const KeyType &key, bool leftMost = false);
+  auto FindLeafPage(const KeyType &key, bool leftMost = false) -> Page *;
 
  private:
   void StartNewTree(const KeyType &key, const ValueType &value);
 
-  bool InsertIntoLeaf(const KeyType &key, const ValueType &value, Transaction *transaction = nullptr);
+  auto InsertIntoLeaf(const KeyType &key, const ValueType &value, Transaction *transaction = nullptr) -> bool;
 
   void InsertIntoParent(BPlusTreePage *old_node, const KeyType &key, BPlusTreePage *new_node,
                         Transaction *transaction = nullptr);
 
   template <typename N>
-  N *Split(N *node);
+  auto Split(N *node) -> N *;
 
   template <typename N>
-  bool CoalesceOrRedistribute(N *node, Transaction *transaction = nullptr);
+  auto CoalesceOrRedistribute(N *node, Transaction *transaction = nullptr) -> bool;
 
   template <typename N>
-  bool Coalesce(N **neighbor_node, N **node, BPlusTreeInternalPage<KeyType, page_id_t, KeyComparator> **parent,
-                int index, Transaction *transaction = nullptr);
+  auto Coalesce(N **neighbor_node, N **node, BPlusTreeInternalPage<KeyType, page_id_t, KeyComparator> **parent,
+                int index, Transaction *transaction = nullptr) -> bool;
 
   template <typename N>
   void Redistribute(N *neighbor_node, N *node, int index);
 
-  bool AdjustRoot(BPlusTreePage *node);
+  auto AdjustRoot(BPlusTreePage *node) -> bool;
 
   void UpdateRootPageId(int insert_record = 0);
 

--- a/src/include/storage/index/b_plus_tree_index.h
+++ b/src/include/storage/index/b_plus_tree_index.h
@@ -34,11 +34,11 @@ class BPlusTreeIndex : public Index {
 
   void ScanKey(const Tuple &key, std::vector<RID> *result, Transaction *transaction) override;
 
-  INDEXITERATOR_TYPE GetBeginIterator();
+  auto GetBeginIterator() -> INDEXITERATOR_TYPE;
 
-  INDEXITERATOR_TYPE GetBeginIterator(const KeyType &key);
+  auto GetBeginIterator(const KeyType &key) -> INDEXITERATOR_TYPE;
 
-  INDEXITERATOR_TYPE GetEndIterator();
+  auto GetEndIterator() -> INDEXITERATOR_TYPE;
 
  protected:
   // comparator for key

--- a/src/include/storage/index/generic_key.h
+++ b/src/include/storage/index/generic_key.h
@@ -41,7 +41,7 @@ class GenericKey {
     memcpy(data_, &key, sizeof(int64_t));
   }
 
-  inline Value ToValue(Schema *schema, uint32_t column_idx) const {
+  inline auto ToValue(Schema *schema, uint32_t column_idx) const -> Value {
     const char *data_ptr;
     const auto &col = schema->GetColumn(column_idx);
     const TypeId column_type = col.GetType();
@@ -57,11 +57,11 @@ class GenericKey {
 
   // NOTE: for test purpose only
   // interpret the first 8 bytes as int64_t from data vector
-  inline int64_t ToString() const { return *reinterpret_cast<int64_t *>(const_cast<char *>(data_)); }
+  inline auto ToString() const -> int64_t { return *reinterpret_cast<int64_t *>(const_cast<char *>(data_)); }
 
   // NOTE: for test purpose only
   // interpret the first 8 bytes as int64_t from data vector
-  friend std::ostream &operator<<(std::ostream &os, const GenericKey &key) {
+  friend auto operator<<(std::ostream &os, const GenericKey &key) -> std::ostream & {
     os << key.ToString();
     return os;
   }
@@ -76,7 +76,7 @@ class GenericKey {
 template <size_t KeySize>
 class GenericComparator {
  public:
-  inline int operator()(const GenericKey<KeySize> &lhs, const GenericKey<KeySize> &rhs) const {
+  inline auto operator()(const GenericKey<KeySize> &lhs, const GenericKey<KeySize> &rhs) const -> int {
     uint32_t column_count = key_schema_->GetColumnCount();
 
     for (uint32_t i = 0; i < column_count; i++) {

--- a/src/include/storage/index/hash_comparator.h
+++ b/src/include/storage/index/hash_comparator.h
@@ -22,7 +22,7 @@ namespace bustub {
  */
 class HashComparator {
  public:
-  inline int operator()(const hash_t lhs, const hash_t rhs) { return lhs < rhs ? -1 : (lhs > rhs ? 1 : 0); }
+  inline auto operator()(const hash_t lhs, const hash_t rhs) -> int { return lhs < rhs ? -1 : (lhs > rhs ? 1 : 0); }
 };
 
 }  // namespace bustub

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -53,13 +53,13 @@ class IndexMetadata {
   ~IndexMetadata() { delete key_schema_; }
 
   /** @return The name of the index */
-  inline const std::string &GetName() const { return name_; }
+  inline auto GetName() const -> const std::string & { return name_; }
 
   /** @return The name of the table on which the index is created */
-  inline const std::string &GetTableName() { return table_name_; }
+  inline auto GetTableName() -> const std::string & { return table_name_; }
 
   /** @return A schema object pointer that represents the indexed key */
-  inline Schema *GetKeySchema() const { return key_schema_; }
+  inline auto GetKeySchema() const -> Schema * { return key_schema_; }
 
   /**
    * @return The number of columns inside index key (not in tuple key)
@@ -67,13 +67,13 @@ class IndexMetadata {
    * NOTE: this must be defined inside the cpp source file because it
    * uses the member of catalog::Schema which is not known here.
    */
-  std::uint32_t GetIndexColumnCount() const { return static_cast<uint32_t>(key_attrs_.size()); }
+  auto GetIndexColumnCount() const -> std::uint32_t { return static_cast<uint32_t>(key_attrs_.size()); }
 
   /** @return The mapping relation between indexed columns and base table columns */
-  inline const std::vector<uint32_t> &GetKeyAttrs() const { return key_attrs_; }
+  inline auto GetKeyAttrs() const -> const std::vector<uint32_t> & { return key_attrs_; }
 
   /** @return A string representation for debugging */
-  std::string ToString() const {
+  auto ToString() const -> std::string {
     std::stringstream os;
 
     os << "IndexMetadata["
@@ -125,22 +125,22 @@ class Index {
   virtual ~Index() = default;
 
   /** @return A non-owning pointer to the metadata object associated with the index */
-  IndexMetadata *GetMetadata() const { return metadata_.get(); }
+  auto GetMetadata() const -> IndexMetadata * { return metadata_.get(); }
 
   /** @return The number of indexed columns */
-  std::uint32_t GetIndexColumnCount() const { return metadata_->GetIndexColumnCount(); }
+  auto GetIndexColumnCount() const -> std::uint32_t { return metadata_->GetIndexColumnCount(); }
 
   /** @return The index name */
-  const std::string &GetName() const { return metadata_->GetName(); }
+  auto GetName() const -> const std::string & { return metadata_->GetName(); }
 
   /** @return The index key schema */
-  Schema *GetKeySchema() const { return metadata_->GetKeySchema(); }
+  auto GetKeySchema() const -> Schema * { return metadata_->GetKeySchema(); }
 
   /** @return The index key attributes */
-  const std::vector<uint32_t> &GetKeyAttrs() const { return metadata_->GetKeyAttrs(); }
+  auto GetKeyAttrs() const -> const std::vector<uint32_t> & { return metadata_->GetKeyAttrs(); }
 
   /** @return A string representation for debugging */
-  std::string ToString() const {
+  auto ToString() const -> std::string {
     std::stringstream os;
     os << "INDEX: (" << GetName() << ")";
     os << metadata_->ToString();

--- a/src/include/storage/index/index_iterator.h
+++ b/src/include/storage/index/index_iterator.h
@@ -26,15 +26,15 @@ class IndexIterator {
   IndexIterator();
   ~IndexIterator();  // NOLINT
 
-  bool IsEnd();
+  auto IsEnd() -> bool;
 
-  const MappingType &operator*();
+  auto operator*() -> const MappingType &;
 
-  IndexIterator &operator++();
+  auto operator++() -> IndexIterator &;
 
-  bool operator==(const IndexIterator &itr) const { throw std::runtime_error("unimplemented"); }
+  auto operator==(const IndexIterator &itr) const -> bool { throw std::runtime_error("unimplemented"); }
 
-  bool operator!=(const IndexIterator &itr) const { throw std::runtime_error("unimplemented"); }
+  auto operator!=(const IndexIterator &itr) const -> bool { throw std::runtime_error("unimplemented"); }
 
  private:
   // add your own private member variables here

--- a/src/include/storage/index/int_comparator.h
+++ b/src/include/storage/index/int_comparator.h
@@ -20,7 +20,7 @@ namespace bustub {
  */
 class IntComparator {
  public:
-  inline int operator()(const int lhs, const int rhs) const {
+  inline auto operator()(const int lhs, const int rhs) const -> int {
     if (lhs < rhs) {
       return -1;
     }

--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -38,16 +38,16 @@ class BPlusTreeInternalPage : public BPlusTreePage {
   // must call initialize method after "create" a new node
   void Init(page_id_t page_id, page_id_t parent_id = INVALID_PAGE_ID, int max_size = INTERNAL_PAGE_SIZE);
 
-  KeyType KeyAt(int index) const;
+  auto KeyAt(int index) const -> KeyType;
   void SetKeyAt(int index, const KeyType &key);
-  int ValueIndex(const ValueType &value) const;
-  ValueType ValueAt(int index) const;
+  auto ValueIndex(const ValueType &value) const -> int;
+  auto ValueAt(int index) const -> ValueType;
 
-  ValueType Lookup(const KeyType &key, const KeyComparator &comparator) const;
+  auto Lookup(const KeyType &key, const KeyComparator &comparator) const -> ValueType;
   void PopulateNewRoot(const ValueType &old_value, const KeyType &new_key, const ValueType &new_value);
-  int InsertNodeAfter(const ValueType &old_value, const KeyType &new_key, const ValueType &new_value);
+  auto InsertNodeAfter(const ValueType &old_value, const KeyType &new_key, const ValueType &new_value) -> int;
   void Remove(int index);
-  ValueType RemoveAndReturnOnlyChild();
+  auto RemoveAndReturnOnlyChild() -> ValueType;
 
   // Split and Merge utility methods
   void MoveAllTo(BPlusTreeInternalPage *recipient, const KeyType &middle_key, BufferPoolManager *buffer_pool_manager);

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -46,16 +46,16 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   // method to set default values
   void Init(page_id_t page_id, page_id_t parent_id = INVALID_PAGE_ID, int max_size = LEAF_PAGE_SIZE);
   // helper methods
-  page_id_t GetNextPageId() const;
+  auto GetNextPageId() const -> page_id_t;
   void SetNextPageId(page_id_t next_page_id);
-  KeyType KeyAt(int index) const;
-  int KeyIndex(const KeyType &key, const KeyComparator &comparator) const;
-  const MappingType &GetItem(int index);
+  auto KeyAt(int index) const -> KeyType;
+  auto KeyIndex(const KeyType &key, const KeyComparator &comparator) const -> int;
+  auto GetItem(int index) -> const MappingType &;
 
   // insert and delete methods
-  int Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator);
-  bool Lookup(const KeyType &key, ValueType *value, const KeyComparator &comparator) const;
-  int RemoveAndDeleteRecord(const KeyType &key, const KeyComparator &comparator);
+  auto Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator) -> int;
+  auto Lookup(const KeyType &key, ValueType *value, const KeyComparator &comparator) const -> bool;
+  auto RemoveAndDeleteRecord(const KeyType &key, const KeyComparator &comparator) -> int;
 
   // Split and Merge utility methods
   void MoveHalfTo(BPlusTreeLeafPage *recipient);

--- a/src/include/storage/page/b_plus_tree_page.h
+++ b/src/include/storage/page/b_plus_tree_page.h
@@ -42,22 +42,22 @@ enum class IndexPageType { INVALID_INDEX_PAGE = 0, LEAF_PAGE, INTERNAL_PAGE };
  */
 class BPlusTreePage {
  public:
-  bool IsLeafPage() const;
-  bool IsRootPage() const;
+  auto IsLeafPage() const -> bool;
+  auto IsRootPage() const -> bool;
   void SetPageType(IndexPageType page_type);
 
-  int GetSize() const;
+  auto GetSize() const -> int;
   void SetSize(int size);
   void IncreaseSize(int amount);
 
-  int GetMaxSize() const;
+  auto GetMaxSize() const -> int;
   void SetMaxSize(int max_size);
-  int GetMinSize() const;
+  auto GetMinSize() const -> int;
 
-  page_id_t GetParentPageId() const;
+  auto GetParentPageId() const -> page_id_t;
   void SetParentPageId(page_id_t parent_page_id);
 
-  page_id_t GetPageId() const;
+  auto GetPageId() const -> page_id_t;
   void SetPageId(page_id_t page_id);
 
   void SetLSN(lsn_t lsn = INVALID_LSN);

--- a/src/include/storage/page/hash_table_block_page.h
+++ b/src/include/storage/page/hash_table_block_page.h
@@ -45,7 +45,7 @@ class HashTableBlockPage {
    * @param bucket_ind the index in the block to get the key at
    * @return key at index bucket_ind of the block
    */
-  KeyType KeyAt(slot_offset_t bucket_ind) const;
+  auto KeyAt(slot_offset_t bucket_ind) const -> KeyType;
 
   /**
    * Gets the value at an index in the block.
@@ -53,7 +53,7 @@ class HashTableBlockPage {
    * @param bucket_ind the index in the block to get the value at
    * @return value at index bucket_ind of the block
    */
-  ValueType ValueAt(slot_offset_t bucket_ind) const;
+  auto ValueAt(slot_offset_t bucket_ind) const -> ValueType;
 
   /**
    * Attempts to insert a key and value into an index in the block.
@@ -68,7 +68,7 @@ class HashTableBlockPage {
    * index is marked as occupied before the key and value can be inserted,
    * Insert returns false.
    */
-  bool Insert(slot_offset_t bucket_ind, const KeyType &key, const ValueType &value);
+  auto Insert(slot_offset_t bucket_ind, const KeyType &key, const ValueType &value) -> bool;
 
   /**
    * Removes a key and value at index.
@@ -83,7 +83,7 @@ class HashTableBlockPage {
    * @param bucket_ind index to look at
    * @return true if the index is occupied, false otherwise
    */
-  bool IsOccupied(slot_offset_t bucket_ind) const;
+  auto IsOccupied(slot_offset_t bucket_ind) const -> bool;
 
   /**
    * Returns whether or not an index is readable (valid key/value pair)
@@ -91,14 +91,14 @@ class HashTableBlockPage {
    * @param bucket_ind index to look at
    * @return true if the index is readable, false otherwise
    */
-  bool IsReadable(slot_offset_t bucket_ind) const;
+  auto IsReadable(slot_offset_t bucket_ind) const -> bool;
 
   /**
    * Scan the bucket and collect values that have the matching key
    *
    * @return true if at least one key matched
    */
-  bool GetValue(KeyType key, KeyComparator cmp, std::vector<ValueType> *result);
+  auto GetValue(KeyType key, KeyComparator cmp, std::vector<ValueType> *result) -> bool;
 
   /**
    * Attempts to insert a key and value in the bucket.
@@ -110,28 +110,28 @@ class HashTableBlockPage {
    * @param value value to insert
    * @return true if inserted, false if duplicate KV pair or bucket is full
    */
-  bool Insert(KeyType key, ValueType value, KeyComparator cmp);
+  auto Insert(KeyType key, ValueType value, KeyComparator cmp) -> bool;
 
   /**
    * Removes a key and value.
    * @return true if removed, false if not found
    */
-  bool Remove(KeyType key, ValueType value, KeyComparator cmp);
+  auto Remove(KeyType key, ValueType value, KeyComparator cmp) -> bool;
 
   /**
    * @return the number of readable elements, i.e. current size
    */
-  uint32_t NumReadable();
+  auto NumReadable() -> uint32_t;
 
   /**
    * @return whether the bucket is full
    */
-  bool IsFull();
+  auto IsFull() -> bool;
 
   /**
    * @return whether the bucket is empty
    */
-  bool IsEmpty();
+  auto IsEmpty() -> bool;
 
   /**
    * Prints the bucket's occupancy information

--- a/src/include/storage/page/hash_table_bucket_page.h
+++ b/src/include/storage/page/hash_table_bucket_page.h
@@ -45,7 +45,7 @@ class HashTableBucketPage {
    *
    * @return true if at least one key matched
    */
-  bool GetValue(KeyType key, KeyComparator cmp, std::vector<ValueType> *result);
+  auto GetValue(KeyType key, KeyComparator cmp, std::vector<ValueType> *result) -> bool;
 
   /**
    * Attempts to insert a key and value in the bucket.  Uses the occupied_
@@ -55,14 +55,14 @@ class HashTableBucketPage {
    * @param value value to insert
    * @return true if inserted, false if duplicate KV pair or bucket is full
    */
-  bool Insert(KeyType key, ValueType value, KeyComparator cmp);
+  auto Insert(KeyType key, ValueType value, KeyComparator cmp) -> bool;
 
   /**
    * Removes a key and value.
    *
    * @return true if removed, false if not found
    */
-  bool Remove(KeyType key, ValueType value, KeyComparator cmp);
+  auto Remove(KeyType key, ValueType value, KeyComparator cmp) -> bool;
 
   /**
    * Gets the key at an index in the bucket.
@@ -70,7 +70,7 @@ class HashTableBucketPage {
    * @param bucket_idx the index in the bucket to get the key at
    * @return key at index bucket_idx of the bucket
    */
-  KeyType KeyAt(uint32_t bucket_idx) const;
+  auto KeyAt(uint32_t bucket_idx) const -> KeyType;
 
   /**
    * Gets the value at an index in the bucket.
@@ -78,7 +78,7 @@ class HashTableBucketPage {
    * @param bucket_idx the index in the bucket to get the value at
    * @return value at index bucket_idx of the bucket
    */
-  ValueType ValueAt(uint32_t bucket_idx) const;
+  auto ValueAt(uint32_t bucket_idx) const -> ValueType;
 
   /**
    * Remove the KV pair at bucket_idx
@@ -91,7 +91,7 @@ class HashTableBucketPage {
    * @param bucket_idx index to look at
    * @return true if the index is occupied, false otherwise
    */
-  bool IsOccupied(uint32_t bucket_idx) const;
+  auto IsOccupied(uint32_t bucket_idx) const -> bool;
 
   /**
    * SetOccupied - Updates the bitmap to indicate that the entry at
@@ -107,7 +107,7 @@ class HashTableBucketPage {
    * @param bucket_idx index to lookup
    * @return true if the index is readable, false otherwise
    */
-  bool IsReadable(uint32_t bucket_idx) const;
+  auto IsReadable(uint32_t bucket_idx) const -> bool;
 
   /**
    * SetReadable - Updates the bitmap to indicate that the entry at
@@ -120,17 +120,17 @@ class HashTableBucketPage {
   /**
    * @return the number of readable elements, i.e. current size
    */
-  uint32_t NumReadable();
+  auto NumReadable() -> uint32_t;
 
   /**
    * @return whether the bucket is full
    */
-  bool IsFull();
+  auto IsFull() -> bool;
 
   /**
    * @return whether the bucket is empty
    */
-  bool IsEmpty();
+  auto IsEmpty() -> bool;
 
   /**
    * Prints the bucket's occupancy information

--- a/src/include/storage/page/hash_table_directory_page.h
+++ b/src/include/storage/page/hash_table_directory_page.h
@@ -36,7 +36,7 @@ class HashTableDirectoryPage {
   /**
    * @return the page ID of this page
    */
-  page_id_t GetPageId() const;
+  auto GetPageId() const -> page_id_t;
 
   /**
    * Sets the page ID of this page
@@ -48,7 +48,7 @@ class HashTableDirectoryPage {
   /**
    * @return the lsn of this page
    */
-  lsn_t GetLSN() const;
+  auto GetLSN() const -> lsn_t;
 
   /**
    * Sets the LSN of this page
@@ -63,7 +63,7 @@ class HashTableDirectoryPage {
    * @param bucket_idx the index in the directory to lookup
    * @return bucket page_id corresponding to bucket_idx
    */
-  page_id_t GetBucketPageId(uint32_t bucket_idx);
+  auto GetBucketPageId(uint32_t bucket_idx) -> page_id_t;
 
   /**
    * Updates the directory index using a bucket index and page_id
@@ -79,7 +79,7 @@ class HashTableDirectoryPage {
    * @param bucket_idx the directory index for which to find the split image
    * @return the directory index of the split image
    **/
-  uint32_t GetSplitImageIndex(uint32_t bucket_idx);
+  auto GetSplitImageIndex(uint32_t bucket_idx) -> uint32_t;
 
   /**
    * GetGlobalDepthMask - returns a mask of global_depth 1's and the rest 0's.
@@ -95,7 +95,7 @@ class HashTableDirectoryPage {
    *
    * @return mask of global_depth 1's and the rest 0's (with 1's from LSB upwards)
    */
-  uint32_t GetGlobalDepthMask();
+  auto GetGlobalDepthMask() -> uint32_t;
 
   /**
    * GetLocalDepthMask - same as global depth mask, except it
@@ -104,14 +104,14 @@ class HashTableDirectoryPage {
    * @param bucket_idx the index to use for looking up local depth
    * @return mask of local 1's and the rest 0's (with 1's from LSB upwards)
    */
-  uint32_t GetLocalDepthMask(uint32_t bucket_idx);
+  auto GetLocalDepthMask(uint32_t bucket_idx) -> uint32_t;
 
   /**
    * Get the global depth of the hash table directory
    *
    * @return the global depth of the directory
    */
-  uint32_t GetGlobalDepth();
+  auto GetGlobalDepth() -> uint32_t;
 
   /**
    * Increment the global depth of the directory
@@ -126,12 +126,12 @@ class HashTableDirectoryPage {
   /**
    * @return true if the directory can be shrunk
    */
-  bool CanShrink();
+  auto CanShrink() -> bool;
 
   /**
    * @return the current directory size
    */
-  uint32_t Size();
+  auto Size() -> uint32_t;
 
   /**
    * Gets the local depth of the bucket at bucket_idx
@@ -139,7 +139,7 @@ class HashTableDirectoryPage {
    * @param bucket_idx the bucket index to lookup
    * @return the local depth of the bucket at bucket_idx
    */
-  uint32_t GetLocalDepth(uint32_t bucket_idx);
+  auto GetLocalDepth(uint32_t bucket_idx) -> uint32_t;
 
   /**
    * Set the local depth of the bucket at bucket_idx to local_depth
@@ -169,7 +169,7 @@ class HashTableDirectoryPage {
    * @param bucket_idx bucket index to lookup
    * @return the high bit corresponding to the bucket's local depth
    */
-  uint32_t GetLocalHighBit(uint32_t bucket_idx);
+  auto GetLocalHighBit(uint32_t bucket_idx) -> uint32_t;
 
   /**
    * VerifyIntegrity

--- a/src/include/storage/page/hash_table_header_page.h
+++ b/src/include/storage/page/hash_table_header_page.h
@@ -36,7 +36,7 @@ class HashTableHeaderPage {
   /**
    * @return the number of buckets in the hash table;
    */
-  size_t GetSize() const;
+  auto GetSize() const -> size_t;
 
   /**
    * Sets the size field of the hash table to size
@@ -48,7 +48,7 @@ class HashTableHeaderPage {
   /**
    * @return the page ID of this page
    */
-  page_id_t GetPageId() const;
+  auto GetPageId() const -> page_id_t;
 
   /**
    * Sets the page ID of this page
@@ -60,7 +60,7 @@ class HashTableHeaderPage {
   /**
    * @return the lsn of this page
    */
-  lsn_t GetLSN() const;
+  auto GetLSN() const -> lsn_t;
 
   /**
    * Sets the LSN of this page
@@ -82,12 +82,12 @@ class HashTableHeaderPage {
    * @param index the index of the block
    * @return the page_id for the block.
    */
-  page_id_t GetBlockPageId(size_t index);
+  auto GetBlockPageId(size_t index) -> page_id_t;
 
   /**
    * @return the number of blocks currently stored in the header page
    */
-  size_t NumBlocks();
+  auto NumBlocks() -> size_t;
 
  private:
   __attribute__((unused)) lsn_t lsn_;

--- a/src/include/storage/page/header_page.h
+++ b/src/include/storage/page/header_page.h
@@ -32,19 +32,19 @@ class HeaderPage : public Page {
   /**
    * Record related
    */
-  bool InsertRecord(const std::string &name, page_id_t root_id);
-  bool DeleteRecord(const std::string &name);
-  bool UpdateRecord(const std::string &name, page_id_t root_id);
+  auto InsertRecord(const std::string &name, page_id_t root_id) -> bool;
+  auto DeleteRecord(const std::string &name) -> bool;
+  auto UpdateRecord(const std::string &name, page_id_t root_id) -> bool;
 
   // return root_id if success
-  bool GetRootId(const std::string &name, page_id_t *root_id);
-  int GetRecordCount();
+  auto GetRootId(const std::string &name, page_id_t *root_id) -> bool;
+  auto GetRecordCount() -> int;
 
  private:
   /**
    * helper functions
    */
-  int FindRecord(const std::string &name);
+  auto FindRecord(const std::string &name) -> int;
 
   void SetRecordCount(int record_count);
 };

--- a/src/include/storage/page/page.h
+++ b/src/include/storage/page/page.h
@@ -37,16 +37,16 @@ class Page {
   ~Page() = default;
 
   /** @return the actual data contained within this page */
-  inline char *GetData() { return data_; }
+  inline auto GetData() -> char * { return data_; }
 
   /** @return the page id of this page */
-  inline page_id_t GetPageId() { return page_id_; }
+  inline auto GetPageId() -> page_id_t { return page_id_; }
 
   /** @return the pin count of this page */
-  inline int GetPinCount() { return pin_count_; }
+  inline auto GetPinCount() -> int { return pin_count_; }
 
   /** @return true if the page in memory has been modified from the page on disk, false otherwise */
-  inline bool IsDirty() { return is_dirty_; }
+  inline auto IsDirty() -> bool { return is_dirty_; }
 
   /** Acquire the page write latch. */
   inline void WLatch() { rwlatch_.WLock(); }
@@ -61,7 +61,7 @@ class Page {
   inline void RUnlatch() { rwlatch_.RUnlock(); }
 
   /** @return the page LSN. */
-  inline lsn_t GetLSN() { return *reinterpret_cast<lsn_t *>(GetData() + OFFSET_LSN); }
+  inline auto GetLSN() -> lsn_t { return *reinterpret_cast<lsn_t *>(GetData() + OFFSET_LSN); }
 
   /** Sets the page LSN. */
   inline void SetLSN(lsn_t lsn) { memcpy(GetData() + OFFSET_LSN, &lsn, sizeof(lsn_t)); }

--- a/src/include/storage/page/table_page.h
+++ b/src/include/storage/page/table_page.h
@@ -54,13 +54,13 @@ class TablePage : public Page {
   void Init(page_id_t page_id, uint32_t page_size, page_id_t prev_page_id, LogManager *log_manager, Transaction *txn);
 
   /** @return the page ID of this table page */
-  page_id_t GetTablePageId() { return *reinterpret_cast<page_id_t *>(GetData()); }
+  auto GetTablePageId() -> page_id_t { return *reinterpret_cast<page_id_t *>(GetData()); }
 
   /** @return the page ID of the previous table page */
-  page_id_t GetPrevPageId() { return *reinterpret_cast<page_id_t *>(GetData() + OFFSET_PREV_PAGE_ID); }
+  auto GetPrevPageId() -> page_id_t { return *reinterpret_cast<page_id_t *>(GetData() + OFFSET_PREV_PAGE_ID); }
 
   /** @return the page ID of the next table page */
-  page_id_t GetNextPageId() { return *reinterpret_cast<page_id_t *>(GetData() + OFFSET_NEXT_PAGE_ID); }
+  auto GetNextPageId() -> page_id_t { return *reinterpret_cast<page_id_t *>(GetData() + OFFSET_NEXT_PAGE_ID); }
 
   /** Set the page id of the previous page in the table. */
   void SetPrevPageId(page_id_t prev_page_id) {
@@ -81,7 +81,7 @@ class TablePage : public Page {
    * @param log_manager the log manager
    * @return true if the insert is successful (i.e. there is enough space)
    */
-  bool InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, LockManager *lock_manager, LogManager *log_manager);
+  auto InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, LockManager *lock_manager, LogManager *log_manager) -> bool;
 
   /**
    * Mark a tuple as deleted. This does not actually delete the tuple.
@@ -91,7 +91,7 @@ class TablePage : public Page {
    * @param log_manager the log manager
    * @return true if marking the tuple as deleted is successful (i.e the tuple exists)
    */
-  bool MarkDelete(const RID &rid, Transaction *txn, LockManager *lock_manager, LogManager *log_manager);
+  auto MarkDelete(const RID &rid, Transaction *txn, LockManager *lock_manager, LogManager *log_manager) -> bool;
 
   /**
    * Update a tuple.
@@ -103,8 +103,8 @@ class TablePage : public Page {
    * @param log_manager the log manager
    * @return true if updating the tuple succeeded
    */
-  bool UpdateTuple(const Tuple &new_tuple, Tuple *old_tuple, const RID &rid, Transaction *txn,
-                   LockManager *lock_manager, LogManager *log_manager);
+  auto UpdateTuple(const Tuple &new_tuple, Tuple *old_tuple, const RID &rid, Transaction *txn,
+                   LockManager *lock_manager, LogManager *log_manager) -> bool;
 
   /** To be called on commit or abort. Actually perform the delete or rollback an insert. */
   void ApplyDelete(const RID &rid, Transaction *txn, LogManager *log_manager);
@@ -120,7 +120,7 @@ class TablePage : public Page {
    * @param lock_manager the lock manager
    * @return true if the read is successful (i.e. the tuple exists)
    */
-  bool GetTuple(const RID &rid, Tuple *tuple, Transaction *txn, LockManager *lock_manager);
+  auto GetTuple(const RID &rid, Tuple *tuple, Transaction *txn, LockManager *lock_manager) -> bool;
 
   /** @return the rid of the first tuple in this page */
 
@@ -128,14 +128,14 @@ class TablePage : public Page {
    * @param[out] first_rid the RID of the first tuple in this page
    * @return true if the first tuple exists, false otherwise
    */
-  bool GetFirstTupleRid(RID *first_rid);
+  auto GetFirstTupleRid(RID *first_rid) -> bool;
 
   /**
    * @param cur_rid the RID of the current tuple
    * @param[out] next_rid the RID of the tuple following the current tuple
    * @return true if the next tuple exists, false otherwise
    */
-  bool GetNextTupleRid(const RID &cur_rid, RID *next_rid);
+  auto GetNextTupleRid(const RID &cur_rid, RID *next_rid) -> bool;
 
  private:
   static_assert(sizeof(page_id_t) == 4);
@@ -150,7 +150,7 @@ class TablePage : public Page {
   static constexpr size_t OFFSET_TUPLE_SIZE = 28;
 
   /** @return pointer to the end of the current free space, see header comment */
-  uint32_t GetFreeSpacePointer() { return *reinterpret_cast<uint32_t *>(GetData() + OFFSET_FREE_SPACE); }
+  auto GetFreeSpacePointer() -> uint32_t { return *reinterpret_cast<uint32_t *>(GetData() + OFFSET_FREE_SPACE); }
 
   /** Sets the pointer, this should be the end of the current free space. */
   void SetFreeSpacePointer(uint32_t free_space_pointer) {
@@ -161,17 +161,17 @@ class TablePage : public Page {
    * @note returned tuple count may be an overestimate because some slots may be empty
    * @return at least the number of tuples in this page
    */
-  uint32_t GetTupleCount() { return *reinterpret_cast<uint32_t *>(GetData() + OFFSET_TUPLE_COUNT); }
+  auto GetTupleCount() -> uint32_t { return *reinterpret_cast<uint32_t *>(GetData() + OFFSET_TUPLE_COUNT); }
 
   /** Set the number of tuples in this page. */
   void SetTupleCount(uint32_t tuple_count) { memcpy(GetData() + OFFSET_TUPLE_COUNT, &tuple_count, sizeof(uint32_t)); }
 
-  uint32_t GetFreeSpaceRemaining() {
+  auto GetFreeSpaceRemaining() -> uint32_t {
     return GetFreeSpacePointer() - SIZE_TABLE_PAGE_HEADER - SIZE_TUPLE * GetTupleCount();
   }
 
   /** @return tuple offset at slot slot_num */
-  uint32_t GetTupleOffsetAtSlot(uint32_t slot_num) {
+  auto GetTupleOffsetAtSlot(uint32_t slot_num) -> uint32_t {
     return *reinterpret_cast<uint32_t *>(GetData() + OFFSET_TUPLE_OFFSET + SIZE_TUPLE * slot_num);
   }
 
@@ -181,7 +181,7 @@ class TablePage : public Page {
   }
 
   /** @return tuple size at slot slot_num */
-  uint32_t GetTupleSize(uint32_t slot_num) {
+  auto GetTupleSize(uint32_t slot_num) -> uint32_t {
     return *reinterpret_cast<uint32_t *>(GetData() + OFFSET_TUPLE_SIZE + SIZE_TUPLE * slot_num);
   }
 
@@ -191,12 +191,12 @@ class TablePage : public Page {
   }
 
   /** @return true if the tuple is deleted or empty */
-  static bool IsDeleted(uint32_t tuple_size) { return static_cast<bool>(tuple_size & DELETE_MASK) || tuple_size == 0; }
+  static auto IsDeleted(uint32_t tuple_size) -> bool { return static_cast<bool>(tuple_size & DELETE_MASK) || tuple_size == 0; }
 
   /** @return tuple size with the deleted flag set */
-  static uint32_t SetDeletedFlag(uint32_t tuple_size) { return static_cast<uint32_t>(tuple_size | DELETE_MASK); }
+  static auto SetDeletedFlag(uint32_t tuple_size) -> uint32_t { return static_cast<uint32_t>(tuple_size | DELETE_MASK); }
 
   /** @return tuple size with the deleted flag unset */
-  static uint32_t UnsetDeletedFlag(uint32_t tuple_size) { return static_cast<uint32_t>(tuple_size & (~DELETE_MASK)); }
+  static auto UnsetDeletedFlag(uint32_t tuple_size) -> uint32_t { return static_cast<uint32_t>(tuple_size & (~DELETE_MASK)); }
 };
 }  // namespace bustub

--- a/src/include/storage/page/tmp_tuple_page.h
+++ b/src/include/storage/page/tmp_tuple_page.h
@@ -25,9 +25,9 @@ class TmpTuplePage : public Page {
     memcpy(GetData() + sizeof(page_id_t), &page_size, sizeof(uint32_t));
   }
 
-  page_id_t GetTablePageId() { return INVALID_PAGE_ID; }
+  auto GetTablePageId() -> page_id_t { return INVALID_PAGE_ID; }
 
-  bool Insert(const Tuple &tuple, TmpTuple *out) { return false; }
+  auto Insert(const Tuple &tuple, TmpTuple *out) -> bool { return false; }
 
  private:
   static_assert(sizeof(page_id_t) == 4);

--- a/src/include/storage/table/table_heap.h
+++ b/src/include/storage/table/table_heap.h
@@ -57,7 +57,7 @@ class TableHeap {
    * @param txn the transaction performing the insert
    * @return true iff the insert is successful
    */
-  bool InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn);
+  auto InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) -> bool;
 
   /**
    * Mark the tuple as deleted. The actual delete will occur when ApplyDelete is called.
@@ -65,7 +65,7 @@ class TableHeap {
    * @param txn transaction performing the delete
    * @return true iff the delete is successful (i.e the tuple exists)
    */
-  bool MarkDelete(const RID &rid, Transaction *txn);  // for delete
+  auto MarkDelete(const RID &rid, Transaction *txn) -> bool;  // for delete
 
   /**
    * if the new tuple is too large to fit in the old page, return false (will delete and insert)
@@ -74,7 +74,7 @@ class TableHeap {
    * @param txn transaction performing the update
    * @return true is update is successful.
    */
-  bool UpdateTuple(const Tuple &tuple, const RID &rid, Transaction *txn);
+  auto UpdateTuple(const Tuple &tuple, const RID &rid, Transaction *txn) -> bool;
 
   /**
    * Called on Commit/Abort to actually delete a tuple or rollback an insert.
@@ -97,16 +97,16 @@ class TableHeap {
    * @param txn transaction performing the read
    * @return true if the read was successful (i.e. the tuple exists)
    */
-  bool GetTuple(const RID &rid, Tuple *tuple, Transaction *txn);
+  auto GetTuple(const RID &rid, Tuple *tuple, Transaction *txn) -> bool;
 
   /** @return the begin iterator of this table */
-  TableIterator Begin(Transaction *txn);
+  auto Begin(Transaction *txn) -> TableIterator;
 
   /** @return the end iterator of this table */
-  TableIterator End();
+  auto End() -> TableIterator;
 
   /** @return the id of the first page of this table */
-  inline page_id_t GetFirstPageId() const { return first_page_id_; }
+  inline auto GetFirstPageId() const -> page_id_t { return first_page_id_; }
 
  private:
   BufferPoolManager *buffer_pool_manager_;

--- a/src/include/storage/table/table_iterator.h
+++ b/src/include/storage/table/table_iterator.h
@@ -36,19 +36,19 @@ class TableIterator {
 
   ~TableIterator() { delete tuple_; }
 
-  inline bool operator==(const TableIterator &itr) const { return tuple_->rid_.Get() == itr.tuple_->rid_.Get(); }
+  inline auto operator==(const TableIterator &itr) const -> bool { return tuple_->rid_.Get() == itr.tuple_->rid_.Get(); }
 
-  inline bool operator!=(const TableIterator &itr) const { return !(*this == itr); }
+  inline auto operator!=(const TableIterator &itr) const -> bool { return !(*this == itr); }
 
-  const Tuple &operator*();
+  auto operator*() -> const Tuple &;
 
-  Tuple *operator->();
+  auto operator->() -> Tuple *;
 
-  TableIterator &operator++();
+  auto operator++() -> TableIterator &;
 
-  TableIterator operator++(int);
+  auto operator++(int) -> TableIterator;
 
-  TableIterator &operator=(const TableIterator &other) {
+  auto operator=(const TableIterator &other) -> TableIterator & {
     table_heap_ = other.table_heap_;
     *tuple_ = *other.tuple_;
     txn_ = other.txn_;

--- a/src/include/storage/table/tmp_tuple.h
+++ b/src/include/storage/table/tmp_tuple.h
@@ -10,10 +10,10 @@ class TmpTuple {
  public:
   TmpTuple(page_id_t page_id, size_t offset) : page_id_(page_id), offset_(offset) {}
 
-  inline bool operator==(const TmpTuple &rhs) const { return page_id_ == rhs.page_id_ && offset_ == rhs.offset_; }
+  inline auto operator==(const TmpTuple &rhs) const -> bool { return page_id_ == rhs.page_id_ && offset_ == rhs.offset_; }
 
-  page_id_t GetPageId() const { return page_id_; }
-  size_t GetOffset() const { return offset_; }
+  auto GetPageId() const -> page_id_t { return page_id_; }
+  auto GetOffset() const -> size_t { return offset_; }
 
  private:
   page_id_t page_id_;

--- a/src/include/storage/table/tuple.h
+++ b/src/include/storage/table/tuple.h
@@ -46,7 +46,7 @@ class Tuple {
   Tuple(const Tuple &other);
 
   // assign operator, deep copy
-  Tuple &operator=(const Tuple &other);
+  auto operator=(const Tuple &other) -> Tuple &;
 
   ~Tuple() {
     if (allocated_) {
@@ -62,33 +62,33 @@ class Tuple {
   void DeserializeFrom(const char *storage);
 
   // return RID of current tuple
-  inline RID GetRid() const { return rid_; }
+  inline auto GetRid() const -> RID { return rid_; }
 
   // Get the address of this tuple in the table's backing store
-  inline char *GetData() const { return data_; }
+  inline auto GetData() const -> char * { return data_; }
 
   // Get length of the tuple, including varchar legth
-  inline uint32_t GetLength() const { return size_; }
+  inline auto GetLength() const -> uint32_t { return size_; }
 
   // Get the value of a specified column (const)
   // checks the schema to see how to return the Value.
-  Value GetValue(const Schema *schema, uint32_t column_idx) const;
+  auto GetValue(const Schema *schema, uint32_t column_idx) const -> Value;
 
   // Generates a key tuple given schemas and attributes
-  Tuple KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs);
+  auto KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs) -> Tuple;
 
   // Is the column value null ?
-  inline bool IsNull(const Schema *schema, uint32_t column_idx) const {
+  inline auto IsNull(const Schema *schema, uint32_t column_idx) const -> bool {
     Value value = GetValue(schema, column_idx);
     return value.IsNull();
   }
-  inline bool IsAllocated() { return allocated_; }
+  inline auto IsAllocated() -> bool { return allocated_; }
 
-  std::string ToString(const Schema *schema) const;
+  auto ToString(const Schema *schema) const -> std::string;
 
  private:
   // Get the starting storage address of specific column
-  const char *GetDataPtr(const Schema *schema, uint32_t column_idx) const;
+  auto GetDataPtr(const Schema *schema, uint32_t column_idx) const -> const char *;
 
   bool allocated_{false};  // is allocated?
   RID rid_{};              // if pointing to the table heap, the rid is valid

--- a/src/include/type/abstract_pool.h
+++ b/src/include/type/abstract_pool.h
@@ -30,7 +30,7 @@ class AbstractPool {
    *
    * TODO: Provide good error codes for failure cases
    */
-  virtual void *Allocate(size_t size) = 0;
+  virtual auto Allocate(size_t size) -> void * = 0;
 
   /**
    * @brief Returns the provided chunk of memory back into the pool

--- a/src/include/type/bigint_type.h
+++ b/src/include/type/bigint_type.h
@@ -23,38 +23,38 @@ class BigintType : public IntegerParentType {
   BigintType();
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override;
-  Value Subtract(const Value &left, const Value &right) const override;
-  Value Multiply(const Value &left, const Value &right) const override;
-  Value Divide(const Value &left, const Value &right) const override;
-  Value Modulo(const Value &left, const Value &right) const override;
-  Value Sqrt(const Value &val) const override;
+  auto Add(const Value &left, const Value &right) const -> Value override;
+  auto Subtract(const Value &left, const Value &right) const -> Value override;
+  auto Multiply(const Value &left, const Value &right) const -> Value override;
+  auto Divide(const Value &left, const Value &right) const -> Value override;
+  auto Modulo(const Value &left, const Value &right) const -> Value override;
+  auto Sqrt(const Value &val) const -> Value override;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
  protected:
-  Value OperateNull(const Value &left, const Value &right) const override;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override;
 
-  bool IsZero(const Value &val) const override;
+  auto IsZero(const Value &val) const -> bool override;
 };
 }  // namespace bustub

--- a/src/include/type/boolean_type.h
+++ b/src/include/type/boolean_type.h
@@ -25,28 +25,28 @@ class BooleanType : public Type {
   BooleanType();
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
   // Decimal types are always inlined
-  bool IsInlined(const Value &val) const override { return true; }
+  auto IsInlined(const Value &val) const -> bool override { return true; }
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 };
 }  // namespace bustub

--- a/src/include/type/decimal_type.h
+++ b/src/include/type/decimal_type.h
@@ -21,42 +21,42 @@ class DecimalType : public NumericType {
   // DecimalValue(DecDef definition);
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override;
-  Value Subtract(const Value &left, const Value &right) const override;
-  Value Multiply(const Value &left, const Value &right) const override;
-  Value Divide(const Value &left, const Value &right) const override;
-  Value Modulo(const Value &left, const Value &right) const override;
-  Value Min(const Value &left, const Value &right) const override;
-  Value Max(const Value &left, const Value &right) const override;
-  Value Sqrt(const Value &val) const override;
-  bool IsZero(const Value &val) const override;
+  auto Add(const Value &left, const Value &right) const -> Value override;
+  auto Subtract(const Value &left, const Value &right) const -> Value override;
+  auto Multiply(const Value &left, const Value &right) const -> Value override;
+  auto Divide(const Value &left, const Value &right) const -> Value override;
+  auto Modulo(const Value &left, const Value &right) const -> Value override;
+  auto Min(const Value &left, const Value &right) const -> Value override;
+  auto Max(const Value &left, const Value &right) const -> Value override;
+  auto Sqrt(const Value &val) const -> Value override;
+  auto IsZero(const Value &val) const -> bool override;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 
   // Decimal types are always inlined
-  bool IsInlined(const Value &val) const override { return true; }
+  auto IsInlined(const Value &val) const -> bool override { return true; }
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
  private:
-  Value OperateNull(const Value &left, const Value &right) const override;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override;
 };
 }  // namespace bustub

--- a/src/include/type/integer_parent_type.h
+++ b/src/include/type/integer_parent_type.h
@@ -24,59 +24,59 @@ class IntegerParentType : public NumericType {
   explicit IntegerParentType(TypeId type);
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override = 0;
-  Value Subtract(const Value &left, const Value &right) const override = 0;
-  Value Multiply(const Value &left, const Value &right) const override = 0;
-  Value Divide(const Value &left, const Value &right) const override = 0;
-  Value Modulo(const Value &left, const Value &right) const override = 0;
-  Value Min(const Value &left, const Value &right) const override;
-  Value Max(const Value &left, const Value &right) const override;
-  Value Sqrt(const Value &val) const override = 0;
+  auto Add(const Value &left, const Value &right) const -> Value override = 0;
+  auto Subtract(const Value &left, const Value &right) const -> Value override = 0;
+  auto Multiply(const Value &left, const Value &right) const -> Value override = 0;
+  auto Divide(const Value &left, const Value &right) const -> Value override = 0;
+  auto Modulo(const Value &left, const Value &right) const -> Value override = 0;
+  auto Min(const Value &left, const Value &right) const -> Value override;
+  auto Max(const Value &left, const Value &right) const -> Value override;
+  auto Sqrt(const Value &val) const -> Value override = 0;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override = 0;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override = 0;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override = 0;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override = 0;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override = 0;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override = 0;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override = 0;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override = 0;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override = 0;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override = 0;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override = 0;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override = 0;
 
-  Value CastAs(const Value &val, TypeId type_id) const override = 0;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override = 0;
 
   // Integer types are always inlined
-  bool IsInlined(const Value &val) const override { return true; }
+  auto IsInlined(const Value &val) const -> bool override { return true; }
 
   // Debug
-  std::string ToString(const Value &val) const override = 0;
+  auto ToString(const Value &val) const -> std::string override = 0;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override = 0;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override = 0;
+  auto DeserializeFrom(const char *storage) const -> Value override = 0;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override = 0;
+  auto Copy(const Value &val) const -> Value override = 0;
 
  protected:
   template <class T1, class T2>
-  Value AddValue(const Value &left, const Value &right) const;
+  auto AddValue(const Value &left, const Value &right) const -> Value;
   template <class T1, class T2>
-  Value SubtractValue(const Value &left, const Value &right) const;
+  auto SubtractValue(const Value &left, const Value &right) const -> Value;
   template <class T1, class T2>
-  Value MultiplyValue(const Value &left, const Value &right) const;
+  auto MultiplyValue(const Value &left, const Value &right) const -> Value;
   template <class T1, class T2>
-  Value DivideValue(const Value &left, const Value &right) const;
+  auto DivideValue(const Value &left, const Value &right) const -> Value;
   template <class T1, class T2>
-  Value ModuloValue(const Value &left, const Value &right) const;
+  auto ModuloValue(const Value &left, const Value &right) const -> Value;
 
-  Value OperateNull(const Value &left, const Value &right) const override = 0;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override = 0;
 
-  bool IsZero(const Value &val) const override = 0;
+  auto IsZero(const Value &val) const -> bool override = 0;
 };
 
 template <class T1, class T2>
-Value IntegerParentType::AddValue(const Value &left, const Value &right) const {
+auto IntegerParentType::AddValue(const Value &left, const Value &right) const -> Value {
   auto x = left.GetAs<T1>();
   auto y = right.GetAs<T2>();
   auto sum1 = static_cast<T1>(x + y);
@@ -99,7 +99,7 @@ Value IntegerParentType::AddValue(const Value &left, const Value &right) const {
 }
 
 template <class T1, class T2>
-Value IntegerParentType::SubtractValue(const Value &left, const Value &right) const {
+auto IntegerParentType::SubtractValue(const Value &left, const Value &right) const -> Value {
   auto x = left.GetAs<T1>();
   auto y = right.GetAs<T2>();
   auto diff1 = static_cast<T1>(x - y);
@@ -121,7 +121,7 @@ Value IntegerParentType::SubtractValue(const Value &left, const Value &right) co
 }
 
 template <class T1, class T2>
-Value IntegerParentType::MultiplyValue(const Value &left, const Value &right) const {
+auto IntegerParentType::MultiplyValue(const Value &left, const Value &right) const -> Value {
   auto x = left.GetAs<T1>();
   auto y = right.GetAs<T2>();
   auto prod1 = static_cast<T1>(x * y);
@@ -143,7 +143,7 @@ Value IntegerParentType::MultiplyValue(const Value &left, const Value &right) co
 }
 
 template <class T1, class T2>
-Value IntegerParentType::DivideValue(const Value &left, const Value &right) const {
+auto IntegerParentType::DivideValue(const Value &left, const Value &right) const -> Value {
   auto x = left.GetAs<T1>();
   auto y = right.GetAs<T2>();
   if (y == 0) {
@@ -158,7 +158,7 @@ Value IntegerParentType::DivideValue(const Value &left, const Value &right) cons
 }
 
 template <class T1, class T2>
-Value IntegerParentType::ModuloValue(const Value &left, const Value &right) const {
+auto IntegerParentType::ModuloValue(const Value &left, const Value &right) const -> Value {
   auto x = left.GetAs<T1>();
   auto y = right.GetAs<T2>();
   if (y == 0) {

--- a/src/include/type/integer_type.h
+++ b/src/include/type/integer_type.h
@@ -23,38 +23,38 @@ class IntegerType : public IntegerParentType {
   explicit IntegerType(TypeId type);
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override;
-  Value Subtract(const Value &left, const Value &right) const override;
-  Value Multiply(const Value &left, const Value &right) const override;
-  Value Divide(const Value &left, const Value &right) const override;
-  Value Modulo(const Value &left, const Value &right) const override;
-  Value Sqrt(const Value &val) const override;
+  auto Add(const Value &left, const Value &right) const -> Value override;
+  auto Subtract(const Value &left, const Value &right) const -> Value override;
+  auto Multiply(const Value &left, const Value &right) const -> Value override;
+  auto Divide(const Value &left, const Value &right) const -> Value override;
+  auto Modulo(const Value &left, const Value &right) const -> Value override;
+  auto Sqrt(const Value &val) const -> Value override;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
  protected:
-  Value OperateNull(const Value &left, const Value &right) const override;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override;
 
-  bool IsZero(const Value &val) const override;
+  auto IsZero(const Value &val) const -> bool override;
 };
 }  // namespace bustub

--- a/src/include/type/numeric_type.h
+++ b/src/include/type/numeric_type.h
@@ -25,19 +25,19 @@ class NumericType : public Type {
   ~NumericType() override = default;
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override = 0;
-  Value Subtract(const Value &left, const Value &right) const override = 0;
-  Value Multiply(const Value &left, const Value &right) const override = 0;
-  Value Divide(const Value &left, const Value &right) const override = 0;
-  Value Modulo(const Value &left, const Value &right) const override = 0;
-  Value Min(const Value &left, const Value &right) const override = 0;
-  Value Max(const Value &left, const Value &right) const override = 0;
-  Value Sqrt(const Value &val) const override = 0;
-  Value OperateNull(const Value &left, const Value &right) const override = 0;
-  bool IsZero(const Value &val) const override = 0;
+  auto Add(const Value &left, const Value &right) const -> Value override = 0;
+  auto Subtract(const Value &left, const Value &right) const -> Value override = 0;
+  auto Multiply(const Value &left, const Value &right) const -> Value override = 0;
+  auto Divide(const Value &left, const Value &right) const -> Value override = 0;
+  auto Modulo(const Value &left, const Value &right) const -> Value override = 0;
+  auto Min(const Value &left, const Value &right) const -> Value override = 0;
+  auto Max(const Value &left, const Value &right) const -> Value override = 0;
+  auto Sqrt(const Value &val) const -> Value override = 0;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override = 0;
+  auto IsZero(const Value &val) const -> bool override = 0;
 
  protected:
-  static inline double ValMod(double x, double y) {
+  static inline auto ValMod(double x, double y) -> double {
     return x - std::trunc(static_cast<double>(x) / static_cast<double>(y)) * y;
   }
 };

--- a/src/include/type/smallint_type.h
+++ b/src/include/type/smallint_type.h
@@ -23,38 +23,38 @@ class SmallintType : public IntegerParentType {
   SmallintType();
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override;
-  Value Subtract(const Value &left, const Value &right) const override;
-  Value Multiply(const Value &left, const Value &right) const override;
-  Value Divide(const Value &left, const Value &right) const override;
-  Value Modulo(const Value &left, const Value &right) const override;
-  Value Sqrt(const Value &val) const override;
+  auto Add(const Value &left, const Value &right) const -> Value override;
+  auto Subtract(const Value &left, const Value &right) const -> Value override;
+  auto Multiply(const Value &left, const Value &right) const -> Value override;
+  auto Divide(const Value &left, const Value &right) const -> Value override;
+  auto Modulo(const Value &left, const Value &right) const -> Value override;
+  auto Sqrt(const Value &val) const -> Value override;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
  protected:
-  Value OperateNull(const Value &left, const Value &right) const override;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override;
 
-  bool IsZero(const Value &val) const override;
+  auto IsZero(const Value &val) const -> bool override;
 };
 }  // namespace bustub

--- a/src/include/type/timestamp_type.h
+++ b/src/include/type/timestamp_type.h
@@ -26,32 +26,32 @@ class TimestampType : public Type {
   TimestampType();
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
   // Other mathematical functions
-  Value Min(const Value &left, const Value &right) const override;
-  Value Max(const Value &left, const Value &right) const override;
+  auto Min(const Value &left, const Value &right) const -> Value override;
+  auto Max(const Value &left, const Value &right) const -> Value override;
 
-  bool IsInlined(const Value &val) const override { return true; }
+  auto IsInlined(const Value &val) const -> bool override { return true; }
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 };
 
 }  // namespace bustub

--- a/src/include/type/tinyint_type.h
+++ b/src/include/type/tinyint_type.h
@@ -23,38 +23,38 @@ class TinyintType : public IntegerParentType {
   TinyintType();
 
   // Other mathematical functions
-  Value Add(const Value &left, const Value &right) const override;
-  Value Subtract(const Value &left, const Value &right) const override;
-  Value Multiply(const Value &left, const Value &right) const override;
-  Value Divide(const Value &left, const Value &right) const override;
-  Value Modulo(const Value &left, const Value &right) const override;
-  Value Sqrt(const Value &val) const override;
+  auto Add(const Value &left, const Value &right) const -> Value override;
+  auto Subtract(const Value &left, const Value &right) const -> Value override;
+  auto Multiply(const Value &left, const Value &right) const -> Value override;
+  auto Divide(const Value &left, const Value &right) const -> Value override;
+  auto Modulo(const Value &left, const Value &right) const -> Value override;
+  auto Sqrt(const Value &val) const -> Value override;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
-  Value CastAs(const Value &val, TypeId type_id) const override;
+  auto CastAs(const Value &val, TypeId type_id) const -> Value override;
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 
  protected:
-  Value OperateNull(const Value &left, const Value &right) const override;
+  auto OperateNull(const Value &left, const Value &right) const -> Value override;
 
-  bool IsZero(const Value &val) const override;
+  auto IsZero(const Value &val) const -> bool override;
 };
 }  // namespace bustub

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -29,20 +29,20 @@ class Type {
 
   virtual ~Type() = default;
   // Get the size of this data type in bytes
-  static uint64_t GetTypeSize(TypeId type_id);
+  static auto GetTypeSize(TypeId type_id) -> uint64_t;
 
   // Is this type coercable from the other type
-  bool IsCoercableFrom(TypeId type_id) const;
+  auto IsCoercableFrom(TypeId type_id) const -> bool;
 
   // Debug info
-  static std::string TypeIdToString(TypeId type_id);
+  static auto TypeIdToString(TypeId type_id) -> std::string;
 
-  static Value GetMinValue(TypeId type_id);
-  static Value GetMaxValue(TypeId type_id);
+  static auto GetMinValue(TypeId type_id) -> Value;
+  static auto GetMaxValue(TypeId type_id) -> Value;
 
-  inline static Type *GetInstance(TypeId type_id) { return k_types[type_id]; }
+  inline static auto GetInstance(TypeId type_id) -> Type * { return k_types[type_id]; }
 
-  inline TypeId GetTypeId() const { return type_id_; }
+  inline auto GetTypeId() const -> TypeId { return type_id_; }
 
   // Comparison functions
   //
@@ -62,51 +62,51 @@ class Type {
   //     and since Value is a core component of the execution engine, we want to
   //     make it as performant as possible.
   // (2) Keep the interface consistent by making all functions purely virtual.
-  virtual CmpBool CompareEquals(const Value &left, const Value &right) const;
-  virtual CmpBool CompareNotEquals(const Value &left, const Value &right) const;
-  virtual CmpBool CompareLessThan(const Value &left, const Value &right) const;
-  virtual CmpBool CompareLessThanEquals(const Value &left, const Value &right) const;
-  virtual CmpBool CompareGreaterThan(const Value &left, const Value &right) const;
-  virtual CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const;
+  virtual auto CompareEquals(const Value &left, const Value &right) const -> CmpBool;
+  virtual auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool;
+  virtual auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool;
+  virtual auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool;
+  virtual auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool;
+  virtual auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool;
 
   // Other mathematical functions
-  virtual Value Add(const Value &left, const Value &right) const;
-  virtual Value Subtract(const Value &left, const Value &right) const;
-  virtual Value Multiply(const Value &left, const Value &right) const;
-  virtual Value Divide(const Value &left, const Value &right) const;
-  virtual Value Modulo(const Value &left, const Value &right) const;
-  virtual Value Min(const Value &left, const Value &right) const;
-  virtual Value Max(const Value &left, const Value &right) const;
-  virtual Value Sqrt(const Value &val) const;
-  virtual Value OperateNull(const Value &val, const Value &right) const;
-  virtual bool IsZero(const Value &val) const;
+  virtual auto Add(const Value &left, const Value &right) const -> Value;
+  virtual auto Subtract(const Value &left, const Value &right) const -> Value;
+  virtual auto Multiply(const Value &left, const Value &right) const -> Value;
+  virtual auto Divide(const Value &left, const Value &right) const -> Value;
+  virtual auto Modulo(const Value &left, const Value &right) const -> Value;
+  virtual auto Min(const Value &left, const Value &right) const -> Value;
+  virtual auto Max(const Value &left, const Value &right) const -> Value;
+  virtual auto Sqrt(const Value &val) const -> Value;
+  virtual auto OperateNull(const Value &val, const Value &right) const -> Value;
+  virtual auto IsZero(const Value &val) const -> bool;
 
   // Is the data inlined into this classes storage space, or must it be accessed
   // through an indirection/pointer?
-  virtual bool IsInlined(const Value &val) const;
+  virtual auto IsInlined(const Value &val) const -> bool;
 
   // Return a stringified version of this value
-  virtual std::string ToString(const Value &val) const;
+  virtual auto ToString(const Value &val) const -> std::string;
 
   // Serialize this value into the given storage space.
   virtual void SerializeTo(const Value &val, char *storage) const;
 
   // Deserialize a value of the given type from the given storage space.
-  virtual Value DeserializeFrom(const char *storage) const;
+  virtual auto DeserializeFrom(const char *storage) const -> Value;
 
   // Create a copy of this value
-  virtual Value Copy(const Value &val) const;
+  virtual auto Copy(const Value &val) const -> Value;
 
-  virtual Value CastAs(const Value &val, TypeId type_id) const;
+  virtual auto CastAs(const Value &val, TypeId type_id) const -> Value;
 
   // Access the raw variable length data
-  virtual const char *GetData(const Value &val) const;
+  virtual auto GetData(const Value &val) const -> const char *;
 
   // Get the length of the variable length data
-  virtual uint32_t GetLength(const Value &val) const;
+  virtual auto GetLength(const Value &val) const -> uint32_t;
 
   // Access the raw varlen data stored from the tuple storage
-  virtual char *GetData(char *storage);
+  virtual auto GetData(char *storage) -> char *;
 
  protected:
   // The actual type ID

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -28,7 +28,7 @@ class TypeUtil {
    * Use memcmp to evaluate two strings
    * This does not work with VARBINARY attributes.
    */
-  static inline int CompareStrings(const char *str1, int len1, const char *str2, int len2) {
+  static inline auto CompareStrings(const char *str1, int len1, const char *str2, int len2) -> int {
     assert(str1 != nullptr);
     assert(len1 >= 0);
     assert(str2 != nullptr);

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -21,7 +21,7 @@
 
 namespace bustub {
 
-inline CmpBool GetCmpBool(bool boolean) { return boolean ? CmpBool::CmpTrue : CmpBool::CmpFalse; }
+inline auto GetCmpBool(bool boolean) -> CmpBool { return boolean ? CmpBool::CmpTrue : CmpBool::CmpFalse; }
 
 // A value is an abstract class that represents a view over SQL data stored in
 // some materialized state. All values have a type and comparison functions, but
@@ -61,7 +61,7 @@ class Value {
 
   Value() : Value(TypeId::INVALID) {}
   Value(const Value &other);
-  Value &operator=(Value other);
+  auto operator=(Value other) -> Value &;
   ~Value();
   // NOLINTNEXTLINE
   friend void Swap(Value &first, Value &second) {
@@ -71,54 +71,54 @@ class Value {
     std::swap(first.type_id_, second.type_id_);
   }
   // check whether value is integer
-  bool CheckInteger() const;
-  bool CheckComparable(const Value &o) const;
+  auto CheckInteger() const -> bool;
+  auto CheckComparable(const Value &o) const -> bool;
 
   // Get the type of this value
-  inline TypeId GetTypeId() const { return type_id_; }
+  inline auto GetTypeId() const -> TypeId { return type_id_; }
 
   // Get the length of the variable length data
-  inline uint32_t GetLength() const { return Type::GetInstance(type_id_)->GetLength(*this); }
+  inline auto GetLength() const -> uint32_t { return Type::GetInstance(type_id_)->GetLength(*this); }
   // Access the raw variable length data
-  inline const char *GetData() const { return Type::GetInstance(type_id_)->GetData(*this); }
+  inline auto GetData() const -> const char * { return Type::GetInstance(type_id_)->GetData(*this); }
 
   template <class T>
-  inline T GetAs() const {
+  inline auto GetAs() const -> T {
     return *reinterpret_cast<const T *>(&value_);
   }
 
-  inline Value CastAs(const TypeId type_id) const { return Type::GetInstance(type_id_)->CastAs(*this, type_id); }
+  inline auto CastAs(const TypeId type_id) const -> Value { return Type::GetInstance(type_id_)->CastAs(*this, type_id); }
   // Comparison Methods
-  inline CmpBool CompareEquals(const Value &o) const { return Type::GetInstance(type_id_)->CompareEquals(*this, o); }
-  inline CmpBool CompareNotEquals(const Value &o) const {
+  inline auto CompareEquals(const Value &o) const -> CmpBool { return Type::GetInstance(type_id_)->CompareEquals(*this, o); }
+  inline auto CompareNotEquals(const Value &o) const -> CmpBool {
     return Type::GetInstance(type_id_)->CompareNotEquals(*this, o);
   }
-  inline CmpBool CompareLessThan(const Value &o) const {
+  inline auto CompareLessThan(const Value &o) const -> CmpBool {
     return Type::GetInstance(type_id_)->CompareLessThan(*this, o);
   }
-  inline CmpBool CompareLessThanEquals(const Value &o) const {
+  inline auto CompareLessThanEquals(const Value &o) const -> CmpBool {
     return Type::GetInstance(type_id_)->CompareLessThanEquals(*this, o);
   }
-  inline CmpBool CompareGreaterThan(const Value &o) const {
+  inline auto CompareGreaterThan(const Value &o) const -> CmpBool {
     return Type::GetInstance(type_id_)->CompareGreaterThan(*this, o);
   }
-  inline CmpBool CompareGreaterThanEquals(const Value &o) const {
+  inline auto CompareGreaterThanEquals(const Value &o) const -> CmpBool {
     return Type::GetInstance(type_id_)->CompareGreaterThanEquals(*this, o);
   }
 
   // Other mathematical functions
-  inline Value Add(const Value &o) const { return Type::GetInstance(type_id_)->Add(*this, o); }
-  inline Value Subtract(const Value &o) const { return Type::GetInstance(type_id_)->Subtract(*this, o); }
-  inline Value Multiply(const Value &o) const { return Type::GetInstance(type_id_)->Multiply(*this, o); }
-  inline Value Divide(const Value &o) const { return Type::GetInstance(type_id_)->Divide(*this, o); }
-  inline Value Modulo(const Value &o) const { return Type::GetInstance(type_id_)->Modulo(*this, o); }
-  inline Value Min(const Value &o) const { return Type::GetInstance(type_id_)->Min(*this, o); }
-  inline Value Max(const Value &o) const { return Type::GetInstance(type_id_)->Max(*this, o); }
-  inline Value Sqrt() const { return Type::GetInstance(type_id_)->Sqrt(*this); }
+  inline auto Add(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Add(*this, o); }
+  inline auto Subtract(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Subtract(*this, o); }
+  inline auto Multiply(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Multiply(*this, o); }
+  inline auto Divide(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Divide(*this, o); }
+  inline auto Modulo(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Modulo(*this, o); }
+  inline auto Min(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Min(*this, o); }
+  inline auto Max(const Value &o) const -> Value { return Type::GetInstance(type_id_)->Max(*this, o); }
+  inline auto Sqrt() const -> Value { return Type::GetInstance(type_id_)->Sqrt(*this); }
 
-  inline Value OperateNull(const Value &o) const { return Type::GetInstance(type_id_)->OperateNull(*this, o); }
-  inline bool IsZero() const { return Type::GetInstance(type_id_)->IsZero(*this); }
-  inline bool IsNull() const { return size_.len_ == BUSTUB_VALUE_NULL; }
+  inline auto OperateNull(const Value &o) const -> Value { return Type::GetInstance(type_id_)->OperateNull(*this, o); }
+  inline auto IsZero() const -> bool { return Type::GetInstance(type_id_)->IsZero(*this); }
+  inline auto IsNull() const -> bool { return size_.len_ == BUSTUB_VALUE_NULL; }
 
   // Serialize this value into the given storage space. The inlined parameter
   // indicates whether we are allowed to inline this value into the storage
@@ -128,14 +128,14 @@ class Value {
   inline void SerializeTo(char *storage) const { Type::GetInstance(type_id_)->SerializeTo(*this, storage); }
 
   // Deserialize a value of the given type from the given storage space.
-  inline static Value DeserializeFrom(const char *storage, const TypeId type_id) {
+  inline static auto DeserializeFrom(const char *storage, const TypeId type_id) -> Value {
     return Type::GetInstance(type_id)->DeserializeFrom(storage);
   }
 
   // Return a string version of this value
-  inline std::string ToString() const { return Type::GetInstance(type_id_)->ToString(*this); }
+  inline auto ToString() const -> std::string { return Type::GetInstance(type_id_)->ToString(*this); }
   // Create a copy of this value
-  inline Value Copy() const { return Type::GetInstance(type_id_)->Copy(*this); }
+  inline auto Copy() const -> Value { return Type::GetInstance(type_id_)->Copy(*this); }
 
  protected:
   // The actual value item

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -34,47 +34,47 @@ namespace bustub {
 
 class ValueFactory {
  public:
-  static inline Value Clone(const Value &src, __attribute__((__unused__)) AbstractPool *dataPool = nullptr) {
+  static inline auto Clone(const Value &src, __attribute__((__unused__)) AbstractPool *dataPool = nullptr) -> Value {
     return src.Copy();
   }
 
-  static inline Value GetTinyIntValue(int8_t value) { return Value(TypeId::TINYINT, value); }
+  static inline auto GetTinyIntValue(int8_t value) -> Value { return Value(TypeId::TINYINT, value); }
 
-  static inline Value GetSmallIntValue(int16_t value) { return Value(TypeId::SMALLINT, value); }
+  static inline auto GetSmallIntValue(int16_t value) -> Value { return Value(TypeId::SMALLINT, value); }
 
-  static inline Value GetIntegerValue(int32_t value) { return Value(TypeId::INTEGER, value); }
+  static inline auto GetIntegerValue(int32_t value) -> Value { return Value(TypeId::INTEGER, value); }
 
-  static inline Value GetBigIntValue(int64_t value) { return Value(TypeId::BIGINT, value); }
+  static inline auto GetBigIntValue(int64_t value) -> Value { return Value(TypeId::BIGINT, value); }
 
-  static inline Value GetTimestampValue(int64_t value) { return Value(TypeId::TIMESTAMP, value); }
+  static inline auto GetTimestampValue(int64_t value) -> Value { return Value(TypeId::TIMESTAMP, value); }
 
-  static inline Value GetDecimalValue(double value) { return Value(TypeId::DECIMAL, value); }
+  static inline auto GetDecimalValue(double value) -> Value { return Value(TypeId::DECIMAL, value); }
 
-  static inline Value GetBooleanValue(CmpBool value) {
+  static inline auto GetBooleanValue(CmpBool value) -> Value {
     return Value(TypeId::BOOLEAN, value == CmpBool::CmpNull ? BUSTUB_BOOLEAN_NULL : static_cast<int8_t>(value));
   }
 
-  static inline Value GetBooleanValue(bool value) { return Value(TypeId::BOOLEAN, static_cast<int8_t>(value)); }
+  static inline auto GetBooleanValue(bool value) -> Value { return Value(TypeId::BOOLEAN, static_cast<int8_t>(value)); }
 
-  static inline Value GetBooleanValue(int8_t value) { return Value(TypeId::BOOLEAN, value); }
+  static inline auto GetBooleanValue(int8_t value) -> Value { return Value(TypeId::BOOLEAN, value); }
 
-  static inline Value GetVarcharValue(const char *value, bool manage_data,
-                                      __attribute__((__unused__)) AbstractPool *pool = nullptr) {
+  static inline auto GetVarcharValue(const char *value, bool manage_data,
+                                      __attribute__((__unused__)) AbstractPool *pool = nullptr) -> Value {
     auto len = static_cast<uint32_t>(value == nullptr ? 0U : strlen(value) + 1);
     return GetVarcharValue(value, len, manage_data);
   }
 
-  static inline Value GetVarcharValue(const char *value, uint32_t len, bool manage_data,
-                                      __attribute__((__unused__)) AbstractPool *pool = nullptr) {
+  static inline auto GetVarcharValue(const char *value, uint32_t len, bool manage_data,
+                                      __attribute__((__unused__)) AbstractPool *pool = nullptr) -> Value {
     return Value(TypeId::VARCHAR, value, len, manage_data);
   }
 
-  static inline Value GetVarcharValue(const std::string &value,
-                                      __attribute__((__unused__)) AbstractPool *pool = nullptr) {
+  static inline auto GetVarcharValue(const std::string &value,
+                                      __attribute__((__unused__)) AbstractPool *pool = nullptr) -> Value {
     return Value(TypeId::VARCHAR, value);
   }
 
-  static inline Value GetNullValueByType(TypeId type_id) {
+  static inline auto GetNullValueByType(TypeId type_id) -> Value {
     Value ret_value;
     switch (type_id) {
       case TypeId::BOOLEAN:
@@ -105,7 +105,7 @@ class ValueFactory {
     return ret_value;
   }
 
-  static inline Value GetZeroValueByType(TypeId type_id) {
+  static inline auto GetZeroValueByType(TypeId type_id) -> Value {
     std::string zero_string("0");
 
     switch (type_id) {
@@ -129,7 +129,7 @@ class ValueFactory {
     throw Exception(ExceptionType::UNKNOWN_TYPE, "Unknown type for GetZeroValueType");
   }
 
-  static inline Value CastAsBigInt(const Value &value) {
+  static inline auto CastAsBigInt(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::BIGINT)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetBigIntValue(static_cast<int64_t>(BUSTUB_INT64_NULL));
@@ -172,7 +172,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to BIGINT.");
   }
 
-  static inline Value CastAsInteger(const Value &value) {
+  static inline auto CastAsInteger(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::INTEGER)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetIntegerValue(BUSTUB_INT32_NULL);
@@ -221,7 +221,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to INTEGER.");
   }
 
-  static inline Value CastAsSmallInt(const Value &value) {
+  static inline auto CastAsSmallInt(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::SMALLINT)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetSmallIntValue(static_cast<int16_t>(BUSTUB_INT16_NULL));
@@ -274,7 +274,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to SMALLINT.");
   }
 
-  static inline Value CastAsTinyInt(const Value &value) {
+  static inline auto CastAsTinyInt(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::TINYINT)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetTinyIntValue(BUSTUB_INT8_NULL);
@@ -332,7 +332,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to TINYINT.");
   }
 
-  static inline Value CastAsDecimal(const Value &value) {
+  static inline auto CastAsDecimal(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::DECIMAL)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetDecimalValue(static_cast<double>(BUSTUB_DECIMAL_NULL));
@@ -370,7 +370,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to DECIMAL.");
   }
 
-  static inline Value CastAsVarchar(const Value &value) {
+  static inline auto CastAsVarchar(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::VARCHAR)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetVarcharValue(nullptr, false);
@@ -391,7 +391,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to VARCHAR.");
   }
 
-  static inline Value CastAsTimestamp(const Value &value) {
+  static inline auto CastAsTimestamp(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::TIMESTAMP)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetTimestampValue(BUSTUB_TIMESTAMP_NULL);
@@ -471,7 +471,7 @@ class ValueFactory {
     throw Exception(Type::GetInstance(value.GetTypeId())->ToString(value) + " is not coercable to TIMESTAMP.");
   }
 
-  static inline Value CastAsBoolean(const Value &value) {
+  static inline auto CastAsBoolean(const Value &value) -> Value {
     if (Type::GetInstance(TypeId::BOOLEAN)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull()) {
         return ValueFactory::GetBooleanValue(BUSTUB_BOOLEAN_NULL);

--- a/src/include/type/varlen_type.h
+++ b/src/include/type/varlen_type.h
@@ -26,38 +26,38 @@ class VarlenType : public Type {
   ~VarlenType() override;
 
   // Access the raw variable length data
-  const char *GetData(const Value &val) const override;
+  auto GetData(const Value &val) const -> const char * override;
 
   // Get the length of the variable length data
-  uint32_t GetLength(const Value &val) const override;
+  auto GetLength(const Value &val) const -> uint32_t override;
 
   // Comparison functions
-  CmpBool CompareEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareNotEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThan(const Value &left, const Value &right) const override;
-  CmpBool CompareLessThanEquals(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThan(const Value &left, const Value &right) const override;
-  CmpBool CompareGreaterThanEquals(const Value &left, const Value &right) const override;
+  auto CompareEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareNotEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool override;
+  auto CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool override;
 
   // Other mathematical functions
-  Value Min(const Value &left, const Value &right) const override;
-  Value Max(const Value &left, const Value &right) const override;
+  auto Min(const Value &left, const Value &right) const -> Value override;
+  auto Max(const Value &left, const Value &right) const -> Value override;
 
-  Value CastAs(const Value &value, TypeId type_id) const override;
+  auto CastAs(const Value &value, TypeId type_id) const -> Value override;
 
   // Decimal types are always inlined
-  bool IsInlined(const Value & /*val*/) const override { return false; }
+  auto IsInlined(const Value & /*val*/) const -> bool override { return false; }
 
   // Debug
-  std::string ToString(const Value &val) const override;
+  auto ToString(const Value &val) const -> std::string override;
 
   // Serialize this value into the given storage space
   void SerializeTo(const Value &val, char *storage) const override;
 
   // Deserialize a value of the given type from the given storage space.
-  Value DeserializeFrom(const char *storage) const override;
+  auto DeserializeFrom(const char *storage) const -> Value override;
 
   // Create a copy of this value
-  Value Copy(const Value &val) const override;
+  auto Copy(const Value &val) const -> Value override;
 };
 }  // namespace bustub

--- a/src/recovery/log_manager.cpp
+++ b/src/recovery/log_manager.cpp
@@ -49,6 +49,6 @@ void LogManager::StopFlushThread() {}
  *  }
  *
  */
-lsn_t LogManager::AppendLogRecord(LogRecord *log_record) { return INVALID_LSN; }
+auto LogManager::AppendLogRecord(LogRecord *log_record) -> lsn_t { return INVALID_LSN; }
 
 }  // namespace bustub

--- a/src/recovery/log_recovery.cpp
+++ b/src/recovery/log_recovery.cpp
@@ -20,7 +20,7 @@ namespace bustub {
  * @return: true means deserialize succeed, otherwise can't deserialize cause
  * incomplete log record
  */
-bool LogRecovery::DeserializeLogRecord(const char *data, LogRecord *log_record) { return false; }
+auto LogRecovery::DeserializeLogRecord(const char *data, LogRecord *log_record) -> bool { return false; }
 
 /*
  *redo phase on TABLE PAGE level(table/table_page.h)

--- a/src/storage/disk/disk_manager.cpp
+++ b/src/storage/disk/disk_manager.cpp
@@ -168,7 +168,7 @@ void DiskManager::WriteLog(char *log_data, int size) {
  * Always read from the beginning and perform sequence read
  * @return: false means already reach the end
  */
-bool DiskManager::ReadLog(char *log_data, int size, int offset) {
+auto DiskManager::ReadLog(char *log_data, int size, int offset) -> bool {
   if (offset >= GetFileSize(log_name_)) {
     // LOG_DEBUG("end of log file");
     // LOG_DEBUG("file size is %d", GetFileSize(log_name_));
@@ -194,22 +194,22 @@ bool DiskManager::ReadLog(char *log_data, int size, int offset) {
 /**
  * Returns number of flushes made so far
  */
-int DiskManager::GetNumFlushes() const { return num_flushes_; }
+auto DiskManager::GetNumFlushes() const -> int { return num_flushes_; }
 
 /**
  * Returns number of Writes made so far
  */
-int DiskManager::GetNumWrites() const { return num_writes_; }
+auto DiskManager::GetNumWrites() const -> int { return num_writes_; }
 
 /**
  * Returns true if the log is currently being flushed
  */
-bool DiskManager::GetFlushState() const { return flush_log_; }
+auto DiskManager::GetFlushState() const -> bool { return flush_log_; }
 
 /**
  * Private helper function to get disk file size
  */
-int DiskManager::GetFileSize(const std::string &file_name) {
+auto DiskManager::GetFileSize(const std::string &file_name) -> int {
   struct stat stat_buf;
   int rc = stat(file_name.c_str(), &stat_buf);
   return rc == 0 ? static_cast<int>(stat_buf.st_size) : -1;

--- a/src/storage/index/b_plus_tree.cpp
+++ b/src/storage/index/b_plus_tree.cpp
@@ -32,7 +32,7 @@ BPLUSTREE_TYPE::BPlusTree(std::string name, BufferPoolManager *buffer_pool_manag
  * Helper function to decide whether current b+tree is empty
  */
 INDEX_TEMPLATE_ARGUMENTS
-bool BPLUSTREE_TYPE::IsEmpty() const { return true; }
+auto BPLUSTREE_TYPE::IsEmpty() const -> bool { return true; }
 /*****************************************************************************
  * SEARCH
  *****************************************************************************/
@@ -42,7 +42,7 @@ bool BPLUSTREE_TYPE::IsEmpty() const { return true; }
  * @return : true means key exists
  */
 INDEX_TEMPLATE_ARGUMENTS
-bool BPLUSTREE_TYPE::GetValue(const KeyType &key, std::vector<ValueType> *result, Transaction *transaction) {
+auto BPLUSTREE_TYPE::GetValue(const KeyType &key, std::vector<ValueType> *result, Transaction *transaction) -> bool {
   return false;
 }
 
@@ -57,7 +57,7 @@ bool BPLUSTREE_TYPE::GetValue(const KeyType &key, std::vector<ValueType> *result
  * keys return false, otherwise return true.
  */
 INDEX_TEMPLATE_ARGUMENTS
-bool BPLUSTREE_TYPE::Insert(const KeyType &key, const ValueType &value, Transaction *transaction) { return false; }
+auto BPLUSTREE_TYPE::Insert(const KeyType &key, const ValueType &value, Transaction *transaction) -> bool { return false; }
 /*
  * Insert constant key & value pair into an empty tree
  * User needs to first ask for new page from buffer pool manager(NOTICE: throw
@@ -76,7 +76,7 @@ void BPLUSTREE_TYPE::StartNewTree(const KeyType &key, const ValueType &value) {}
  * keys return false, otherwise return true.
  */
 INDEX_TEMPLATE_ARGUMENTS
-bool BPLUSTREE_TYPE::InsertIntoLeaf(const KeyType &key, const ValueType &value, Transaction *transaction) {
+auto BPLUSTREE_TYPE::InsertIntoLeaf(const KeyType &key, const ValueType &value, Transaction *transaction) -> bool {
   return false;
 }
 
@@ -89,7 +89,7 @@ bool BPLUSTREE_TYPE::InsertIntoLeaf(const KeyType &key, const ValueType &value, 
  */
 INDEX_TEMPLATE_ARGUMENTS
 template <typename N>
-N *BPLUSTREE_TYPE::Split(N *node) {
+auto BPLUSTREE_TYPE::Split(N *node) -> N * {
   return nullptr;
 }
 
@@ -128,7 +128,7 @@ void BPLUSTREE_TYPE::Remove(const KeyType &key, Transaction *transaction) {}
  */
 INDEX_TEMPLATE_ARGUMENTS
 template <typename N>
-bool BPLUSTREE_TYPE::CoalesceOrRedistribute(N *node, Transaction *transaction) {
+auto BPLUSTREE_TYPE::CoalesceOrRedistribute(N *node, Transaction *transaction) -> bool {
   return false;
 }
 
@@ -146,9 +146,9 @@ bool BPLUSTREE_TYPE::CoalesceOrRedistribute(N *node, Transaction *transaction) {
  */
 INDEX_TEMPLATE_ARGUMENTS
 template <typename N>
-bool BPLUSTREE_TYPE::Coalesce(N **neighbor_node, N **node,
+auto BPLUSTREE_TYPE::Coalesce(N **neighbor_node, N **node,
                               BPlusTreeInternalPage<KeyType, page_id_t, KeyComparator> **parent, int index,
-                              Transaction *transaction) {
+                              Transaction *transaction) -> bool {
   return false;
 }
 
@@ -175,7 +175,7 @@ void BPLUSTREE_TYPE::Redistribute(N *neighbor_node, N *node, int index) {}
  * happend
  */
 INDEX_TEMPLATE_ARGUMENTS
-bool BPLUSTREE_TYPE::AdjustRoot(BPlusTreePage *old_root_node) { return false; }
+auto BPLUSTREE_TYPE::AdjustRoot(BPlusTreePage *old_root_node) -> bool { return false; }
 
 /*****************************************************************************
  * INDEX ITERATOR
@@ -186,7 +186,7 @@ bool BPLUSTREE_TYPE::AdjustRoot(BPlusTreePage *old_root_node) { return false; }
  * @return : index iterator
  */
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE BPLUSTREE_TYPE::Begin() { return INDEXITERATOR_TYPE(); }
+auto BPLUSTREE_TYPE::Begin() -> INDEXITERATOR_TYPE { return INDEXITERATOR_TYPE(); }
 
 /*
  * Input parameter is low key, find the leaf page that contains the input key
@@ -194,7 +194,7 @@ INDEXITERATOR_TYPE BPLUSTREE_TYPE::Begin() { return INDEXITERATOR_TYPE(); }
  * @return : index iterator
  */
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE BPLUSTREE_TYPE::Begin(const KeyType &key) { return INDEXITERATOR_TYPE(); }
+auto BPLUSTREE_TYPE::Begin(const KeyType &key) -> INDEXITERATOR_TYPE { return INDEXITERATOR_TYPE(); }
 
 /*
  * Input parameter is void, construct an index iterator representing the end
@@ -202,7 +202,7 @@ INDEXITERATOR_TYPE BPLUSTREE_TYPE::Begin(const KeyType &key) { return INDEXITERA
  * @return : index iterator
  */
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE BPLUSTREE_TYPE::End() { return INDEXITERATOR_TYPE(); }
+auto BPLUSTREE_TYPE::End() -> INDEXITERATOR_TYPE { return INDEXITERATOR_TYPE(); }
 
 /*****************************************************************************
  * UTILITIES AND DEBUG
@@ -212,7 +212,7 @@ INDEXITERATOR_TYPE BPLUSTREE_TYPE::End() { return INDEXITERATOR_TYPE(); }
  * the left most leaf page
  */
 INDEX_TEMPLATE_ARGUMENTS
-Page *BPLUSTREE_TYPE::FindLeafPage(const KeyType &key, bool leftMost) {
+auto BPLUSTREE_TYPE::FindLeafPage(const KeyType &key, bool leftMost) -> Page * {
   throw Exception(ExceptionType::NOT_IMPLEMENTED, "Implement this for test");
 }
 

--- a/src/storage/index/b_plus_tree_index.cpp
+++ b/src/storage/index/b_plus_tree_index.cpp
@@ -49,13 +49,13 @@ void BPLUSTREE_INDEX_TYPE::ScanKey(const Tuple &key, std::vector<RID> *result, T
 }
 
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE BPLUSTREE_INDEX_TYPE::GetBeginIterator() { return container_.Begin(); }
+auto BPLUSTREE_INDEX_TYPE::GetBeginIterator() -> INDEXITERATOR_TYPE { return container_.Begin(); }
 
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE BPLUSTREE_INDEX_TYPE::GetBeginIterator(const KeyType &key) { return container_.Begin(key); }
+auto BPLUSTREE_INDEX_TYPE::GetBeginIterator(const KeyType &key) -> INDEXITERATOR_TYPE { return container_.Begin(key); }
 
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE BPLUSTREE_INDEX_TYPE::GetEndIterator() { return container_.End(); }
+auto BPLUSTREE_INDEX_TYPE::GetEndIterator() -> INDEXITERATOR_TYPE { return container_.End(); }
 
 template class BPlusTreeIndex<GenericKey<4>, RID, GenericComparator<4>>;
 template class BPlusTreeIndex<GenericKey<8>, RID, GenericComparator<8>>;

--- a/src/storage/index/index_iterator.cpp
+++ b/src/storage/index/index_iterator.cpp
@@ -18,13 +18,13 @@ INDEX_TEMPLATE_ARGUMENTS
 INDEXITERATOR_TYPE::~IndexIterator() = default;  // NOLINT
 
 INDEX_TEMPLATE_ARGUMENTS
-bool INDEXITERATOR_TYPE::IsEnd() { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::IsEnd() -> bool { throw std::runtime_error("unimplemented"); }
 
 INDEX_TEMPLATE_ARGUMENTS
-const MappingType &INDEXITERATOR_TYPE::operator*() { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::operator*() -> const MappingType & { throw std::runtime_error("unimplemented"); }
 
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE &INDEXITERATOR_TYPE::operator++() { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::operator++() -> INDEXITERATOR_TYPE & { throw std::runtime_error("unimplemented"); }
 
 template class IndexIterator<GenericKey<4>, RID, GenericComparator<4>>;
 

--- a/src/storage/page/b_plus_tree_internal_page.cpp
+++ b/src/storage/page/b_plus_tree_internal_page.cpp
@@ -31,7 +31,7 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Init(page_id_t page_id, page_id_t parent_id
  * array offset)
  */
 INDEX_TEMPLATE_ARGUMENTS
-KeyType B_PLUS_TREE_INTERNAL_PAGE_TYPE::KeyAt(int index) const {
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::KeyAt(int index) const -> KeyType {
   // replace with your own code
   KeyType key{};
   return key;
@@ -45,14 +45,14 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::SetKeyAt(int index, const KeyType &key) {}
  * equals to input "value"
  */
 INDEX_TEMPLATE_ARGUMENTS
-int B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueIndex(const ValueType &value) const { return 0; }
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueIndex(const ValueType &value) const -> int { return 0; }
 
 /*
  * Helper method to get the value associated with input "index"(a.k.a array
  * offset)
  */
 INDEX_TEMPLATE_ARGUMENTS
-ValueType B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const { return 0; }
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const -> ValueType { return 0; }
 
 /*****************************************************************************
  * LOOKUP
@@ -63,7 +63,7 @@ ValueType B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const { return 0; }
  * Start the search from the second key(the first key should always be invalid)
  */
 INDEX_TEMPLATE_ARGUMENTS
-ValueType B_PLUS_TREE_INTERNAL_PAGE_TYPE::Lookup(const KeyType &key, const KeyComparator &comparator) const {
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::Lookup(const KeyType &key, const KeyComparator &comparator) const -> ValueType {
   return INVALID_PAGE_ID;
 }
 
@@ -85,8 +85,8 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::PopulateNewRoot(const ValueType &old_value,
  * @return:  new size after insertion
  */
 INDEX_TEMPLATE_ARGUMENTS
-int B_PLUS_TREE_INTERNAL_PAGE_TYPE::InsertNodeAfter(const ValueType &old_value, const KeyType &new_key,
-                                                    const ValueType &new_value) {
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::InsertNodeAfter(const ValueType &old_value, const KeyType &new_key,
+                                                    const ValueType &new_value) -> int {
   return 0;
 }
 
@@ -123,7 +123,7 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Remove(int index) {}
  * NOTE: only call this method within AdjustRoot()(in b_plus_tree.cpp)
  */
 INDEX_TEMPLATE_ARGUMENTS
-ValueType B_PLUS_TREE_INTERNAL_PAGE_TYPE::RemoveAndReturnOnlyChild() { return INVALID_PAGE_ID; }
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::RemoveAndReturnOnlyChild() -> ValueType { return INVALID_PAGE_ID; }
 /*****************************************************************************
  * MERGE
  *****************************************************************************/

--- a/src/storage/page/b_plus_tree_leaf_page.cpp
+++ b/src/storage/page/b_plus_tree_leaf_page.cpp
@@ -33,7 +33,7 @@ void B_PLUS_TREE_LEAF_PAGE_TYPE::Init(page_id_t page_id, page_id_t parent_id, in
  * Helper methods to set/get next page id
  */
 INDEX_TEMPLATE_ARGUMENTS
-page_id_t B_PLUS_TREE_LEAF_PAGE_TYPE::GetNextPageId() const { return INVALID_PAGE_ID; }
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::GetNextPageId() const -> page_id_t { return INVALID_PAGE_ID; }
 
 INDEX_TEMPLATE_ARGUMENTS
 void B_PLUS_TREE_LEAF_PAGE_TYPE::SetNextPageId(page_id_t next_page_id) {}
@@ -43,14 +43,14 @@ void B_PLUS_TREE_LEAF_PAGE_TYPE::SetNextPageId(page_id_t next_page_id) {}
  * NOTE: This method is only used when generating index iterator
  */
 INDEX_TEMPLATE_ARGUMENTS
-int B_PLUS_TREE_LEAF_PAGE_TYPE::KeyIndex(const KeyType &key, const KeyComparator &comparator) const { return 0; }
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::KeyIndex(const KeyType &key, const KeyComparator &comparator) const -> int { return 0; }
 
 /*
  * Helper method to find and return the key associated with input "index"(a.k.a
  * array offset)
  */
 INDEX_TEMPLATE_ARGUMENTS
-KeyType B_PLUS_TREE_LEAF_PAGE_TYPE::KeyAt(int index) const {
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::KeyAt(int index) const -> KeyType {
   // replace with your own code
   KeyType key{};
   return key;
@@ -61,7 +61,7 @@ KeyType B_PLUS_TREE_LEAF_PAGE_TYPE::KeyAt(int index) const {
  * "index"(a.k.a array offset)
  */
 INDEX_TEMPLATE_ARGUMENTS
-const MappingType &B_PLUS_TREE_LEAF_PAGE_TYPE::GetItem(int index) {
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::GetItem(int index) -> const MappingType & {
   // replace with your own code
   return array_[0];
 }
@@ -74,7 +74,7 @@ const MappingType &B_PLUS_TREE_LEAF_PAGE_TYPE::GetItem(int index) {
  * @return  page size after insertion
  */
 INDEX_TEMPLATE_ARGUMENTS
-int B_PLUS_TREE_LEAF_PAGE_TYPE::Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator) {
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator) -> int {
   return 0;
 }
 
@@ -102,7 +102,7 @@ void B_PLUS_TREE_LEAF_PAGE_TYPE::CopyNFrom(MappingType *items, int size) {}
  * If the key does not exist, then return false
  */
 INDEX_TEMPLATE_ARGUMENTS
-bool B_PLUS_TREE_LEAF_PAGE_TYPE::Lookup(const KeyType &key, ValueType *value, const KeyComparator &comparator) const {
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::Lookup(const KeyType &key, ValueType *value, const KeyComparator &comparator) const -> bool {
   return false;
 }
 
@@ -116,7 +116,7 @@ bool B_PLUS_TREE_LEAF_PAGE_TYPE::Lookup(const KeyType &key, ValueType *value, co
  * @return   page size after deletion
  */
 INDEX_TEMPLATE_ARGUMENTS
-int B_PLUS_TREE_LEAF_PAGE_TYPE::RemoveAndDeleteRecord(const KeyType &key, const KeyComparator &comparator) { return 0; }
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::RemoveAndDeleteRecord(const KeyType &key, const KeyComparator &comparator) -> int { return 0; }
 
 /*****************************************************************************
  * MERGE

--- a/src/storage/page/b_plus_tree_page.cpp
+++ b/src/storage/page/b_plus_tree_page.cpp
@@ -17,40 +17,40 @@ namespace bustub {
  * Helper methods to get/set page type
  * Page type enum class is defined in b_plus_tree_page.h
  */
-bool BPlusTreePage::IsLeafPage() const { return false; }
-bool BPlusTreePage::IsRootPage() const { return false; }
+auto BPlusTreePage::IsLeafPage() const -> bool { return false; }
+auto BPlusTreePage::IsRootPage() const -> bool { return false; }
 void BPlusTreePage::SetPageType(IndexPageType page_type) {}
 
 /*
  * Helper methods to get/set size (number of key/value pairs stored in that
  * page)
  */
-int BPlusTreePage::GetSize() const { return 0; }
+auto BPlusTreePage::GetSize() const -> int { return 0; }
 void BPlusTreePage::SetSize(int size) {}
 void BPlusTreePage::IncreaseSize(int amount) {}
 
 /*
  * Helper methods to get/set max size (capacity) of the page
  */
-int BPlusTreePage::GetMaxSize() const { return 0; }
+auto BPlusTreePage::GetMaxSize() const -> int { return 0; }
 void BPlusTreePage::SetMaxSize(int size) {}
 
 /*
  * Helper method to get min page size
  * Generally, min page size == max page size / 2
  */
-int BPlusTreePage::GetMinSize() const { return 0; }
+auto BPlusTreePage::GetMinSize() const -> int { return 0; }
 
 /*
  * Helper methods to get/set parent page id
  */
-page_id_t BPlusTreePage::GetParentPageId() const { return 0; }
+auto BPlusTreePage::GetParentPageId() const -> page_id_t { return 0; }
 void BPlusTreePage::SetParentPageId(page_id_t parent_page_id) {}
 
 /*
  * Helper methods to get/set self page id
  */
-page_id_t BPlusTreePage::GetPageId() const { return 0; }
+auto BPlusTreePage::GetPageId() const -> page_id_t { return 0; }
 void BPlusTreePage::SetPageId(page_id_t page_id) {}
 
 /*

--- a/src/storage/page/hash_table_block_page.cpp
+++ b/src/storage/page/hash_table_block_page.cpp
@@ -16,17 +16,17 @@
 namespace bustub {
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-KeyType HASH_TABLE_BLOCK_TYPE::KeyAt(slot_offset_t bucket_ind) const {
+auto HASH_TABLE_BLOCK_TYPE::KeyAt(slot_offset_t bucket_ind) const -> KeyType {
   return {};
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-ValueType HASH_TABLE_BLOCK_TYPE::ValueAt(slot_offset_t bucket_ind) const {
+auto HASH_TABLE_BLOCK_TYPE::ValueAt(slot_offset_t bucket_ind) const -> ValueType {
   return {};
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BLOCK_TYPE::Insert(slot_offset_t bucket_ind, const KeyType &key, const ValueType &value) {
+auto HASH_TABLE_BLOCK_TYPE::Insert(slot_offset_t bucket_ind, const KeyType &key, const ValueType &value) -> bool {
   return false;
 }
 
@@ -34,12 +34,12 @@ template <typename KeyType, typename ValueType, typename KeyComparator>
 void HASH_TABLE_BLOCK_TYPE::Remove(slot_offset_t bucket_ind) {}
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BLOCK_TYPE::IsOccupied(slot_offset_t bucket_ind) const {
+auto HASH_TABLE_BLOCK_TYPE::IsOccupied(slot_offset_t bucket_ind) const -> bool {
   return false;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BLOCK_TYPE::IsReadable(slot_offset_t bucket_ind) const {
+auto HASH_TABLE_BLOCK_TYPE::IsReadable(slot_offset_t bucket_ind) const -> bool {
   return false;
 }
 

--- a/src/storage/page/hash_table_bucket_page.cpp
+++ b/src/storage/page/hash_table_bucket_page.cpp
@@ -20,27 +20,27 @@
 namespace bustub {
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::GetValue(KeyType key, KeyComparator cmp, std::vector<ValueType> *result) {
+auto HASH_TABLE_BUCKET_TYPE::GetValue(KeyType key, KeyComparator cmp, std::vector<ValueType> *result) -> bool {
   return false;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::Insert(KeyType key, ValueType value, KeyComparator cmp) {
+auto HASH_TABLE_BUCKET_TYPE::Insert(KeyType key, ValueType value, KeyComparator cmp) -> bool {
   return true;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::Remove(KeyType key, ValueType value, KeyComparator cmp) {
+auto HASH_TABLE_BUCKET_TYPE::Remove(KeyType key, ValueType value, KeyComparator cmp) -> bool {
   return false;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-KeyType HASH_TABLE_BUCKET_TYPE::KeyAt(uint32_t bucket_idx) const {
+auto HASH_TABLE_BUCKET_TYPE::KeyAt(uint32_t bucket_idx) const -> KeyType {
   return {};
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-ValueType HASH_TABLE_BUCKET_TYPE::ValueAt(uint32_t bucket_idx) const {
+auto HASH_TABLE_BUCKET_TYPE::ValueAt(uint32_t bucket_idx) const -> ValueType {
   return {};
 }
 
@@ -48,7 +48,7 @@ template <typename KeyType, typename ValueType, typename KeyComparator>
 void HASH_TABLE_BUCKET_TYPE::RemoveAt(uint32_t bucket_idx) {}
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::IsOccupied(uint32_t bucket_idx) const {
+auto HASH_TABLE_BUCKET_TYPE::IsOccupied(uint32_t bucket_idx) const -> bool {
   return false;
 }
 
@@ -56,7 +56,7 @@ template <typename KeyType, typename ValueType, typename KeyComparator>
 void HASH_TABLE_BUCKET_TYPE::SetOccupied(uint32_t bucket_idx) {}
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::IsReadable(uint32_t bucket_idx) const {
+auto HASH_TABLE_BUCKET_TYPE::IsReadable(uint32_t bucket_idx) const -> bool {
   return false;
 }
 
@@ -64,17 +64,17 @@ template <typename KeyType, typename ValueType, typename KeyComparator>
 void HASH_TABLE_BUCKET_TYPE::SetReadable(uint32_t bucket_idx) {}
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::IsFull() {
+auto HASH_TABLE_BUCKET_TYPE::IsFull() -> bool {
   return false;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-uint32_t HASH_TABLE_BUCKET_TYPE::NumReadable() {
+auto HASH_TABLE_BUCKET_TYPE::NumReadable() -> uint32_t {
   return 0;
 }
 
 template <typename KeyType, typename ValueType, typename KeyComparator>
-bool HASH_TABLE_BUCKET_TYPE::IsEmpty() {
+auto HASH_TABLE_BUCKET_TYPE::IsEmpty() -> bool {
   return false;
 }
 

--- a/src/storage/page/hash_table_directory_page.cpp
+++ b/src/storage/page/hash_table_directory_page.cpp
@@ -16,31 +16,31 @@
 #include "common/logger.h"
 
 namespace bustub {
-page_id_t HashTableDirectoryPage::GetPageId() const { return page_id_; }
+auto HashTableDirectoryPage::GetPageId() const -> page_id_t { return page_id_; }
 
 void HashTableDirectoryPage::SetPageId(bustub::page_id_t page_id) { page_id_ = page_id; }
 
-lsn_t HashTableDirectoryPage::GetLSN() const { return lsn_; }
+auto HashTableDirectoryPage::GetLSN() const -> lsn_t { return lsn_; }
 
 void HashTableDirectoryPage::SetLSN(lsn_t lsn) { lsn_ = lsn; }
 
-uint32_t HashTableDirectoryPage::GetGlobalDepth() { return global_depth_; }
+auto HashTableDirectoryPage::GetGlobalDepth() -> uint32_t { return global_depth_; }
 
-uint32_t HashTableDirectoryPage::GetGlobalDepthMask() { return 0; }
+auto HashTableDirectoryPage::GetGlobalDepthMask() -> uint32_t { return 0; }
 
 void HashTableDirectoryPage::IncrGlobalDepth() {}
 
 void HashTableDirectoryPage::DecrGlobalDepth() { global_depth_--; }
 
-page_id_t HashTableDirectoryPage::GetBucketPageId(uint32_t bucket_idx) { return 0; }
+auto HashTableDirectoryPage::GetBucketPageId(uint32_t bucket_idx) -> page_id_t { return 0; }
 
 void HashTableDirectoryPage::SetBucketPageId(uint32_t bucket_idx, page_id_t bucket_page_id) {}
 
-uint32_t HashTableDirectoryPage::Size() { return 0; }
+auto HashTableDirectoryPage::Size() -> uint32_t { return 0; }
 
-bool HashTableDirectoryPage::CanShrink() { return false; }
+auto HashTableDirectoryPage::CanShrink() -> bool { return false; }
 
-uint32_t HashTableDirectoryPage::GetLocalDepth(uint32_t bucket_idx) { return 0; }
+auto HashTableDirectoryPage::GetLocalDepth(uint32_t bucket_idx) -> uint32_t { return 0; }
 
 void HashTableDirectoryPage::SetLocalDepth(uint32_t bucket_idx, uint8_t local_depth) {}
 
@@ -48,7 +48,7 @@ void HashTableDirectoryPage::IncrLocalDepth(uint32_t bucket_idx) {}
 
 void HashTableDirectoryPage::DecrLocalDepth(uint32_t bucket_idx) {}
 
-uint32_t HashTableDirectoryPage::GetLocalHighBit(uint32_t bucket_idx) { return 0; }
+auto HashTableDirectoryPage::GetLocalHighBit(uint32_t bucket_idx) -> uint32_t { return 0; }
 
 /**
  * VerifyIntegrity - Use this for debugging but **DO NOT CHANGE**

--- a/src/storage/page/hash_table_header_page.cpp
+++ b/src/storage/page/hash_table_header_page.cpp
@@ -13,22 +13,22 @@
 #include "storage/page/hash_table_header_page.h"
 
 namespace bustub {
-page_id_t HashTableHeaderPage::GetBlockPageId(size_t index) { return 0; }
+auto HashTableHeaderPage::GetBlockPageId(size_t index) -> page_id_t { return 0; }
 
-page_id_t HashTableHeaderPage::GetPageId() const { return 0; }
+auto HashTableHeaderPage::GetPageId() const -> page_id_t { return 0; }
 
 void HashTableHeaderPage::SetPageId(bustub::page_id_t page_id) {}
 
-lsn_t HashTableHeaderPage::GetLSN() const { return 0; }
+auto HashTableHeaderPage::GetLSN() const -> lsn_t { return 0; }
 
 void HashTableHeaderPage::SetLSN(lsn_t lsn) {}
 
 void HashTableHeaderPage::AddBlockPageId(page_id_t page_id) {}
 
-size_t HashTableHeaderPage::NumBlocks() { return 0; }
+auto HashTableHeaderPage::NumBlocks() -> size_t { return 0; }
 
 void HashTableHeaderPage::SetSize(size_t size) {}
 
-size_t HashTableHeaderPage::GetSize() const { return 0; }
+auto HashTableHeaderPage::GetSize() const -> size_t { return 0; }
 
 }  // namespace bustub

--- a/src/storage/page/header_page.cpp
+++ b/src/storage/page/header_page.cpp
@@ -19,7 +19,7 @@ namespace bustub {
 /**
  * Record related
  */
-bool HeaderPage::InsertRecord(const std::string &name, const page_id_t root_id) {
+auto HeaderPage::InsertRecord(const std::string &name, const page_id_t root_id) -> bool {
   assert(name.length() < 32);
   assert(root_id > INVALID_PAGE_ID);
 
@@ -37,7 +37,7 @@ bool HeaderPage::InsertRecord(const std::string &name, const page_id_t root_id) 
   return true;
 }
 
-bool HeaderPage::DeleteRecord(const std::string &name) {
+auto HeaderPage::DeleteRecord(const std::string &name) -> bool {
   int record_num = GetRecordCount();
   assert(record_num > 0);
 
@@ -53,7 +53,7 @@ bool HeaderPage::DeleteRecord(const std::string &name) {
   return true;
 }
 
-bool HeaderPage::UpdateRecord(const std::string &name, const page_id_t root_id) {
+auto HeaderPage::UpdateRecord(const std::string &name, const page_id_t root_id) -> bool {
   assert(name.length() < 32);
 
   int index = FindRecord(name);
@@ -68,7 +68,7 @@ bool HeaderPage::UpdateRecord(const std::string &name, const page_id_t root_id) 
   return true;
 }
 
-bool HeaderPage::GetRootId(const std::string &name, page_id_t *root_id) {
+auto HeaderPage::GetRootId(const std::string &name, page_id_t *root_id) -> bool {
   assert(name.length() < 32);
 
   int index = FindRecord(name);
@@ -86,11 +86,11 @@ bool HeaderPage::GetRootId(const std::string &name, page_id_t *root_id) {
  * helper functions
  */
 // record count
-int HeaderPage::GetRecordCount() { return *reinterpret_cast<int *>(GetData()); }
+auto HeaderPage::GetRecordCount() -> int { return *reinterpret_cast<int *>(GetData()); }
 
 void HeaderPage::SetRecordCount(int record_count) { memcpy(GetData(), &record_count, 4); }
 
-int HeaderPage::FindRecord(const std::string &name) {
+auto HeaderPage::FindRecord(const std::string &name) -> int {
   int record_num = GetRecordCount();
 
   for (int i = 0; i < record_num; i++) {

--- a/src/storage/page/table_page.cpp
+++ b/src/storage/page/table_page.cpp
@@ -35,8 +35,8 @@ void TablePage::Init(page_id_t page_id, uint32_t page_size, page_id_t prev_page_
   SetTupleCount(0);
 }
 
-bool TablePage::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, LockManager *lock_manager,
-                            LogManager *log_manager) {
+auto TablePage::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, LockManager *lock_manager,
+                            LogManager *log_manager) -> bool {
   BUSTUB_ASSERT(tuple.size_ > 0, "Cannot have empty tuples.");
   // If there is not enough space, then return false.
   if (GetFreeSpaceRemaining() < tuple.size_ + SIZE_TUPLE) {
@@ -85,7 +85,7 @@ bool TablePage::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, Lock
   return true;
 }
 
-bool TablePage::MarkDelete(const RID &rid, Transaction *txn, LockManager *lock_manager, LogManager *log_manager) {
+auto TablePage::MarkDelete(const RID &rid, Transaction *txn, LockManager *lock_manager, LogManager *log_manager) -> bool {
   uint32_t slot_num = rid.GetSlotNum();
   // If the slot number is invalid, abort the transaction.
   if (slot_num >= GetTupleCount()) {
@@ -127,8 +127,8 @@ bool TablePage::MarkDelete(const RID &rid, Transaction *txn, LockManager *lock_m
   return true;
 }
 
-bool TablePage::UpdateTuple(const Tuple &new_tuple, Tuple *old_tuple, const RID &rid, Transaction *txn,
-                            LockManager *lock_manager, LogManager *log_manager) {
+auto TablePage::UpdateTuple(const Tuple &new_tuple, Tuple *old_tuple, const RID &rid, Transaction *txn,
+                            LockManager *lock_manager, LogManager *log_manager) -> bool {
   BUSTUB_ASSERT(new_tuple.size_ > 0, "Cannot have empty tuples.");
   uint32_t slot_num = rid.GetSlotNum();
   // If the slot number is invalid, abort the transaction.
@@ -265,7 +265,7 @@ void TablePage::RollbackDelete(const RID &rid, Transaction *txn, LogManager *log
   }
 }
 
-bool TablePage::GetTuple(const RID &rid, Tuple *tuple, Transaction *txn, LockManager *lock_manager) {
+auto TablePage::GetTuple(const RID &rid, Tuple *tuple, Transaction *txn, LockManager *lock_manager) -> bool {
   // Get the current slot number.
   uint32_t slot_num = rid.GetSlotNum();
   // If somehow we have more slots than tuples, abort the transaction.
@@ -305,7 +305,7 @@ bool TablePage::GetTuple(const RID &rid, Tuple *tuple, Transaction *txn, LockMan
   return true;
 }
 
-bool TablePage::GetFirstTupleRid(RID *first_rid) {
+auto TablePage::GetFirstTupleRid(RID *first_rid) -> bool {
   // Find and return the first valid tuple.
   for (uint32_t i = 0; i < GetTupleCount(); ++i) {
     if (!IsDeleted(GetTupleSize(i))) {
@@ -317,7 +317,7 @@ bool TablePage::GetFirstTupleRid(RID *first_rid) {
   return false;
 }
 
-bool TablePage::GetNextTupleRid(const RID &cur_rid, RID *next_rid) {
+auto TablePage::GetNextTupleRid(const RID &cur_rid, RID *next_rid) -> bool {
   BUSTUB_ASSERT(cur_rid.GetPageId() == GetTablePageId(), "Wrong table!");
   // Find and return the first valid tuple after our current slot number.
   for (auto i = cur_rid.GetSlotNum() + 1; i < GetTupleCount(); ++i) {

--- a/src/storage/table/table_heap.cpp
+++ b/src/storage/table/table_heap.cpp
@@ -36,7 +36,7 @@ TableHeap::TableHeap(BufferPoolManager *buffer_pool_manager, LockManager *lock_m
   buffer_pool_manager_->UnpinPage(first_page_id_, true);
 }
 
-bool TableHeap::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) {
+auto TableHeap::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) -> bool {
   if (tuple.size_ + 32 > PAGE_SIZE) {  // larger than one page size
     txn->SetState(TransactionState::ABORTED);
     return false;
@@ -90,7 +90,7 @@ bool TableHeap::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) {
   return true;
 }
 
-bool TableHeap::MarkDelete(const RID &rid, Transaction *txn) {
+auto TableHeap::MarkDelete(const RID &rid, Transaction *txn) -> bool {
   // TODO(Amadou): remove empty page
   // Find the page which contains the tuple.
   auto page = reinterpret_cast<TablePage *>(buffer_pool_manager_->FetchPage(rid.GetPageId()));
@@ -109,7 +109,7 @@ bool TableHeap::MarkDelete(const RID &rid, Transaction *txn) {
   return true;
 }
 
-bool TableHeap::UpdateTuple(const Tuple &tuple, const RID &rid, Transaction *txn) {
+auto TableHeap::UpdateTuple(const Tuple &tuple, const RID &rid, Transaction *txn) -> bool {
   // Find the page which contains the tuple.
   auto page = reinterpret_cast<TablePage *>(buffer_pool_manager_->FetchPage(rid.GetPageId()));
   // If the page could not be found, then abort the transaction.
@@ -153,7 +153,7 @@ void TableHeap::RollbackDelete(const RID &rid, Transaction *txn) {
   buffer_pool_manager_->UnpinPage(page->GetTablePageId(), true);
 }
 
-bool TableHeap::GetTuple(const RID &rid, Tuple *tuple, Transaction *txn) {
+auto TableHeap::GetTuple(const RID &rid, Tuple *tuple, Transaction *txn) -> bool {
   // Find the page which contains the tuple.
   auto page = static_cast<TablePage *>(buffer_pool_manager_->FetchPage(rid.GetPageId()));
   // If the page could not be found, then abort the transaction.
@@ -169,7 +169,7 @@ bool TableHeap::GetTuple(const RID &rid, Tuple *tuple, Transaction *txn) {
   return res;
 }
 
-TableIterator TableHeap::Begin(Transaction *txn) {
+auto TableHeap::Begin(Transaction *txn) -> TableIterator {
   // Start an iterator from the first page.
   // TODO(Wuwen): Hacky fix for now. Removing empty pages is a better way to handle this.
   RID rid;
@@ -189,6 +189,6 @@ TableIterator TableHeap::Begin(Transaction *txn) {
   return TableIterator(this, rid, txn);
 }
 
-TableIterator TableHeap::End() { return TableIterator(this, RID(INVALID_PAGE_ID, 0), nullptr); }
+auto TableHeap::End() -> TableIterator { return TableIterator(this, RID(INVALID_PAGE_ID, 0), nullptr); }
 
 }  // namespace bustub

--- a/src/storage/table/table_iterator.cpp
+++ b/src/storage/table/table_iterator.cpp
@@ -23,17 +23,17 @@ TableIterator::TableIterator(TableHeap *table_heap, RID rid, Transaction *txn)
   }
 }
 
-const Tuple &TableIterator::operator*() {
+auto TableIterator::operator*() -> const Tuple & {
   assert(*this != table_heap_->End());
   return *tuple_;
 }
 
-Tuple *TableIterator::operator->() {
+auto TableIterator::operator->() -> Tuple * {
   assert(*this != table_heap_->End());
   return tuple_;
 }
 
-TableIterator &TableIterator::operator++() {
+auto TableIterator::operator++() -> TableIterator & {
   BufferPoolManager *buffer_pool_manager = table_heap_->buffer_pool_manager_;
   auto cur_page = static_cast<TablePage *>(buffer_pool_manager->FetchPage(tuple_->rid_.GetPageId()));
   cur_page->RLatch();
@@ -64,7 +64,7 @@ TableIterator &TableIterator::operator++() {
   return *this;
 }
 
-TableIterator TableIterator::operator++(int) {
+auto TableIterator::operator++(int) -> TableIterator {
   TableIterator clone(*this);
   ++(*this);
   return clone;

--- a/src/storage/table/tuple.cpp
+++ b/src/storage/table/tuple.cpp
@@ -67,7 +67,7 @@ Tuple::Tuple(const Tuple &other) : allocated_(other.allocated_), rid_(other.rid_
   }
 }
 
-Tuple &Tuple::operator=(const Tuple &other) {
+auto Tuple::operator=(const Tuple &other) -> Tuple & {
   if (allocated_) {
     delete[] data_;
   }
@@ -87,7 +87,7 @@ Tuple &Tuple::operator=(const Tuple &other) {
   return *this;
 }
 
-Value Tuple::GetValue(const Schema *schema, const uint32_t column_idx) const {
+auto Tuple::GetValue(const Schema *schema, const uint32_t column_idx) const -> Value {
   assert(schema);
   assert(data_);
   const TypeId column_type = schema->GetColumn(column_idx).GetType();
@@ -96,7 +96,7 @@ Value Tuple::GetValue(const Schema *schema, const uint32_t column_idx) const {
   return Value::DeserializeFrom(data_ptr, column_type);
 }
 
-Tuple Tuple::KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs) {
+auto Tuple::KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs) -> Tuple {
   std::vector<Value> values;
   values.reserve(key_attrs.size());
   for (auto idx : key_attrs) {
@@ -105,7 +105,7 @@ Tuple Tuple::KeyFromTuple(const Schema &schema, const Schema &key_schema, const 
   return Tuple(values, &key_schema);
 }
 
-const char *Tuple::GetDataPtr(const Schema *schema, const uint32_t column_idx) const {
+auto Tuple::GetDataPtr(const Schema *schema, const uint32_t column_idx) const -> const char * {
   assert(schema);
   assert(data_);
   const auto &col = schema->GetColumn(column_idx);
@@ -120,7 +120,7 @@ const char *Tuple::GetDataPtr(const Schema *schema, const uint32_t column_idx) c
   return (data_ + offset);
 }
 
-std::string Tuple::ToString(const Schema *schema) const {
+auto Tuple::ToString(const Schema *schema) const -> std::string {
   std::stringstream os;
 
   int column_count = schema->GetColumnCount();

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -65,9 +65,9 @@ namespace bustub {
 
 BigintType::BigintType() : IntegerParentType(BIGINT) {}
 
-bool BigintType::IsZero(const Value &val) const { return (val.value_.bigint_ == 0); }
+auto BigintType::IsZero(const Value &val) const -> bool { return (val.value_.bigint_ == 0); }
 
-Value BigintType::Add(const Value &left, const Value &right) const {
+auto BigintType::Add(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -79,7 +79,7 @@ Value BigintType::Add(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value BigintType::Subtract(const Value &left, const Value &right) const {
+auto BigintType::Subtract(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -91,7 +91,7 @@ Value BigintType::Subtract(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value BigintType::Multiply(const Value &left, const Value &right) const {
+auto BigintType::Multiply(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -103,7 +103,7 @@ Value BigintType::Multiply(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value BigintType::Divide(const Value &left, const Value &right) const {
+auto BigintType::Divide(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -118,7 +118,7 @@ Value BigintType::Divide(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value BigintType::Modulo(const Value &left, const Value &right) const {
+auto BigintType::Modulo(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -150,7 +150,7 @@ Value BigintType::Modulo(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value BigintType::Sqrt(const Value &val) const {
+auto BigintType::Sqrt(const Value &val) const -> Value {
   assert(val.CheckInteger());
   if (val.IsNull()) {
     return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
@@ -162,7 +162,7 @@ Value BigintType::Sqrt(const Value &val) const {
   return Value(TypeId::DECIMAL, std::sqrt(val.value_.bigint_));
 }
 
-Value BigintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
+auto BigintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const -> Value {
   switch (right.GetTypeId()) {
     case TypeId::TINYINT:
     case TypeId::SMALLINT:
@@ -177,7 +177,7 @@ Value BigintType::OperateNull(const Value &left __attribute__((unused)), const V
   throw Exception("type error");
 }
 
-CmpBool BigintType::CompareEquals(const Value &left, const Value &right) const {
+auto BigintType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
 
@@ -190,7 +190,7 @@ CmpBool BigintType::CompareEquals(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-CmpBool BigintType::CompareNotEquals(const Value &left, const Value &right) const {
+auto BigintType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -202,7 +202,7 @@ CmpBool BigintType::CompareNotEquals(const Value &left, const Value &right) cons
   throw Exception("type error");
 }
 
-CmpBool BigintType::CompareLessThan(const Value &left, const Value &right) const {
+auto BigintType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -214,7 +214,7 @@ CmpBool BigintType::CompareLessThan(const Value &left, const Value &right) const
   throw Exception("type error");
 }
 
-CmpBool BigintType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto BigintType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -226,7 +226,7 @@ CmpBool BigintType::CompareLessThanEquals(const Value &left, const Value &right)
   throw Exception("type error");
 }
 
-CmpBool BigintType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto BigintType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -238,7 +238,7 @@ CmpBool BigintType::CompareGreaterThan(const Value &left, const Value &right) co
   throw Exception("type error");
 }
 
-CmpBool BigintType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto BigintType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -249,7 +249,7 @@ CmpBool BigintType::CompareGreaterThanEquals(const Value &left, const Value &rig
   throw Exception("type error");
 }
 
-std::string BigintType::ToString(const Value &val) const {
+auto BigintType::ToString(const Value &val) const -> std::string {
   assert(val.CheckInteger());
 
   if (val.IsNull()) {
@@ -263,14 +263,14 @@ void BigintType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value BigintType::DeserializeFrom(const char *storage) const {
+auto BigintType::DeserializeFrom(const char *storage) const -> Value {
   int64_t val = *reinterpret_cast<const int64_t *>(storage);
   return Value(type_id_, val);
 }
 
-Value BigintType::Copy(const Value &val) const { return Value(TypeId::BIGINT, val.value_.bigint_); }
+auto BigintType::Copy(const Value &val) const -> Value { return Value(TypeId::BIGINT, val.value_.bigint_); }
 
-Value BigintType::CastAs(const Value &val, const TypeId type_id) const {
+auto BigintType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::TINYINT: {
       if (val.IsNull()) {

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -20,7 +20,7 @@ namespace bustub {
 
 BooleanType::BooleanType() : Type(TypeId::BOOLEAN) {}
 
-CmpBool BooleanType::CompareEquals(const Value &left, const Value &right) const {
+auto BooleanType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::BOOLEAN);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -29,7 +29,7 @@ CmpBool BooleanType::CompareEquals(const Value &left, const Value &right) const 
   return BOOLEAN_COMPARE_FUNC(==);  // NOLINT
 }
 
-CmpBool BooleanType::CompareNotEquals(const Value &left, const Value &right) const {
+auto BooleanType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::BOOLEAN);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -38,7 +38,7 @@ CmpBool BooleanType::CompareNotEquals(const Value &left, const Value &right) con
   return BOOLEAN_COMPARE_FUNC(!=);  // NOLINT
 }
 
-CmpBool BooleanType::CompareLessThan(const Value &left, const Value &right) const {
+auto BooleanType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::BOOLEAN);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -47,7 +47,7 @@ CmpBool BooleanType::CompareLessThan(const Value &left, const Value &right) cons
   return BOOLEAN_COMPARE_FUNC(<);  // NOLINT
 }
 
-CmpBool BooleanType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto BooleanType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::BOOLEAN);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -56,7 +56,7 @@ CmpBool BooleanType::CompareLessThanEquals(const Value &left, const Value &right
   return BOOLEAN_COMPARE_FUNC(<=);  // NOLINT
 }
 
-CmpBool BooleanType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto BooleanType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::BOOLEAN);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -65,7 +65,7 @@ CmpBool BooleanType::CompareGreaterThan(const Value &left, const Value &right) c
   return BOOLEAN_COMPARE_FUNC(>);  // NOLINT
 }
 
-CmpBool BooleanType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto BooleanType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::BOOLEAN);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -74,7 +74,7 @@ CmpBool BooleanType::CompareGreaterThanEquals(const Value &left, const Value &ri
   return BOOLEAN_COMPARE_FUNC(>=);  // NOLINT
 }
 
-std::string BooleanType::ToString(const Value &val) const {
+auto BooleanType::ToString(const Value &val) const -> std::string {
   assert(GetTypeId() == TypeId::BOOLEAN);
   if (val.value_.boolean_ == 1) {
     return "true";
@@ -90,14 +90,14 @@ void BooleanType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value BooleanType::DeserializeFrom(const char *storage) const {
+auto BooleanType::DeserializeFrom(const char *storage) const -> Value {
   int8_t val = *reinterpret_cast<const int8_t *>(storage);
   return Value(TypeId::BOOLEAN, val);
 }
 
-Value BooleanType::Copy(const Value &val) const { return Value(TypeId::BOOLEAN, val.value_.boolean_); }
+auto BooleanType::Copy(const Value &val) const -> Value { return Value(TypeId::BOOLEAN, val.value_.boolean_); }
 
-Value BooleanType::CastAs(const Value &val, const TypeId type_id) const {
+auto BooleanType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::BOOLEAN:
       return Copy(val);

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -65,12 +65,12 @@ namespace bustub {
 
 DecimalType::DecimalType() : NumericType(TypeId::DECIMAL) {}
 
-bool DecimalType::IsZero(const Value &val) const {
+auto DecimalType::IsZero(const Value &val) const -> bool {
   assert(GetTypeId() == TypeId::DECIMAL);
   return (val.value_.decimal_ == 0);
 }
 
-Value DecimalType::Add(const Value &left, const Value &right) const {
+auto DecimalType::Add(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -81,7 +81,7 @@ Value DecimalType::Add(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value DecimalType::Subtract(const Value &left, const Value &right) const {
+auto DecimalType::Subtract(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -93,7 +93,7 @@ Value DecimalType::Subtract(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value DecimalType::Multiply(const Value &left, const Value &right) const {
+auto DecimalType::Multiply(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -104,7 +104,7 @@ Value DecimalType::Multiply(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value DecimalType::Divide(const Value &left, const Value &right) const {
+auto DecimalType::Divide(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -120,7 +120,7 @@ Value DecimalType::Divide(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value DecimalType::Modulo(const Value &left, const Value &right) const {
+auto DecimalType::Modulo(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -151,7 +151,7 @@ Value DecimalType::Modulo(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value DecimalType::Min(const Value &left, const Value &right) const {
+auto DecimalType::Min(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -164,7 +164,7 @@ Value DecimalType::Min(const Value &left, const Value &right) const {
   return right.Copy();
 }
 
-Value DecimalType::Max(const Value &left, const Value &right) const {
+auto DecimalType::Max(const Value &left, const Value &right) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -177,7 +177,7 @@ Value DecimalType::Max(const Value &left, const Value &right) const {
   return right.Copy();
 }
 
-Value DecimalType::Sqrt(const Value &val) const {
+auto DecimalType::Sqrt(const Value &val) const -> Value {
   assert(GetTypeId() == TypeId::DECIMAL);
   if (val.IsNull()) {
     return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
@@ -188,12 +188,12 @@ Value DecimalType::Sqrt(const Value &val) const {
   return Value(TypeId::DECIMAL, std::sqrt(val.value_.decimal_));
 }
 
-Value DecimalType::OperateNull(const Value &left __attribute__((unused)),
-                               const Value &right __attribute__((unused))) const {
+auto DecimalType::OperateNull(const Value &left __attribute__((unused)),
+                               const Value &right __attribute__((unused))) const -> Value {
   return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
 }
 
-CmpBool DecimalType::CompareEquals(const Value &left, const Value &right) const {
+auto DecimalType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -205,7 +205,7 @@ CmpBool DecimalType::CompareEquals(const Value &left, const Value &right) const 
   throw Exception("type error");
 }
 
-CmpBool DecimalType::CompareNotEquals(const Value &left, const Value &right) const {
+auto DecimalType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -217,7 +217,7 @@ CmpBool DecimalType::CompareNotEquals(const Value &left, const Value &right) con
   throw Exception("type error");
 }
 
-CmpBool DecimalType::CompareLessThan(const Value &left, const Value &right) const {
+auto DecimalType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -229,7 +229,7 @@ CmpBool DecimalType::CompareLessThan(const Value &left, const Value &right) cons
   throw Exception("type error");
 }
 
-CmpBool DecimalType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto DecimalType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -241,7 +241,7 @@ CmpBool DecimalType::CompareLessThanEquals(const Value &left, const Value &right
   throw Exception("type error");
 }
 
-CmpBool DecimalType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto DecimalType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -253,7 +253,7 @@ CmpBool DecimalType::CompareGreaterThan(const Value &left, const Value &right) c
   throw Exception("type error");
 }
 
-CmpBool DecimalType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto DecimalType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(GetTypeId() == TypeId::DECIMAL);
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -265,7 +265,7 @@ CmpBool DecimalType::CompareGreaterThanEquals(const Value &left, const Value &ri
   throw Exception("type error");
 }
 
-Value DecimalType::CastAs(const Value &val, const TypeId type_id) const {
+auto DecimalType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::TINYINT: {
       if (val.IsNull()) {
@@ -318,7 +318,7 @@ Value DecimalType::CastAs(const Value &val, const TypeId type_id) const {
   throw Exception("DECIMAL is not coercable to " + Type::TypeIdToString(type_id));
 }
 
-std::string DecimalType::ToString(const Value &val) const {
+auto DecimalType::ToString(const Value &val) const -> std::string {
   if (val.IsNull()) {
     return "decimal_null";
   }
@@ -330,10 +330,10 @@ void DecimalType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value DecimalType::DeserializeFrom(const char *storage) const {
+auto DecimalType::DeserializeFrom(const char *storage) const -> Value {
   double val = *reinterpret_cast<const double *>(storage);
   return Value(type_id_, val);
 }
 
-Value DecimalType::Copy(const Value &val) const { return Value(TypeId::DECIMAL, val.value_.decimal_); }
+auto DecimalType::Copy(const Value &val) const -> Value { return Value(TypeId::DECIMAL, val.value_.decimal_); }
 }  // namespace bustub

--- a/src/type/integer_parent_type.cpp
+++ b/src/type/integer_parent_type.cpp
@@ -18,7 +18,7 @@
 namespace bustub {
 IntegerParentType::IntegerParentType(TypeId type) : NumericType(type) {}
 
-Value IntegerParentType::Min(const Value &left, const Value &right) const {
+auto IntegerParentType::Min(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -31,7 +31,7 @@ Value IntegerParentType::Min(const Value &left, const Value &right) const {
   return right.Copy();
 }
 
-Value IntegerParentType::Max(const Value &left, const Value &right) const {
+auto IntegerParentType::Max(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -65,9 +65,9 @@ namespace bustub {
 
 IntegerType::IntegerType(TypeId type) : IntegerParentType(type) {}
 
-bool IntegerType::IsZero(const Value &val) const { return (val.value_.integer_ == 0); }
+auto IntegerType::IsZero(const Value &val) const -> bool { return (val.value_.integer_ == 0); }
 
-Value IntegerType::Add(const Value &left, const Value &right) const {
+auto IntegerType::Add(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -78,7 +78,7 @@ Value IntegerType::Add(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value IntegerType::Subtract(const Value &left, const Value &right) const {
+auto IntegerType::Subtract(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -90,7 +90,7 @@ Value IntegerType::Subtract(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value IntegerType::Multiply(const Value &left, const Value &right) const {
+auto IntegerType::Multiply(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -102,7 +102,7 @@ Value IntegerType::Multiply(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value IntegerType::Divide(const Value &left, const Value &right) const {
+auto IntegerType::Divide(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -118,7 +118,7 @@ Value IntegerType::Divide(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value IntegerType::Modulo(const Value &left, const Value &right) const {
+auto IntegerType::Modulo(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -151,7 +151,7 @@ Value IntegerType::Modulo(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value IntegerType::Sqrt(const Value &val) const {
+auto IntegerType::Sqrt(const Value &val) const -> Value {
   assert(val.CheckInteger());
   if (val.IsNull()) {
     return OperateNull(val, val);
@@ -163,7 +163,7 @@ Value IntegerType::Sqrt(const Value &val) const {
   return Value(TypeId::DECIMAL, std::sqrt(val.value_.integer_));
 }
 
-Value IntegerType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
+auto IntegerType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const -> Value {
   switch (right.GetTypeId()) {
     case TypeId::TINYINT:
     case TypeId::SMALLINT:
@@ -180,7 +180,7 @@ Value IntegerType::OperateNull(const Value &left __attribute__((unused)), const 
   throw Exception("type error");
 }
 
-CmpBool IntegerType::CompareEquals(const Value &left, const Value &right) const {
+auto IntegerType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
 
@@ -193,7 +193,7 @@ CmpBool IntegerType::CompareEquals(const Value &left, const Value &right) const 
   throw Exception("type error");
 }
 
-CmpBool IntegerType::CompareNotEquals(const Value &left, const Value &right) const {
+auto IntegerType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -205,7 +205,7 @@ CmpBool IntegerType::CompareNotEquals(const Value &left, const Value &right) con
   throw Exception("type error");
 }
 
-CmpBool IntegerType::CompareLessThan(const Value &left, const Value &right) const {
+auto IntegerType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -217,7 +217,7 @@ CmpBool IntegerType::CompareLessThan(const Value &left, const Value &right) cons
   throw Exception("type error");
 }
 
-CmpBool IntegerType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto IntegerType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -229,7 +229,7 @@ CmpBool IntegerType::CompareLessThanEquals(const Value &left, const Value &right
   throw Exception("type error");
 }
 
-CmpBool IntegerType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto IntegerType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -241,7 +241,7 @@ CmpBool IntegerType::CompareGreaterThan(const Value &left, const Value &right) c
   throw Exception("type error");
 }
 
-CmpBool IntegerType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto IntegerType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -253,7 +253,7 @@ CmpBool IntegerType::CompareGreaterThanEquals(const Value &left, const Value &ri
   throw Exception("type error");
 }
 
-std::string IntegerType::ToString(const Value &val) const {
+auto IntegerType::ToString(const Value &val) const -> std::string {
   assert(val.CheckInteger());
 
   if (val.IsNull()) {
@@ -267,17 +267,17 @@ void IntegerType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value IntegerType::DeserializeFrom(const char *storage) const {
+auto IntegerType::DeserializeFrom(const char *storage) const -> Value {
   int32_t val = *reinterpret_cast<const int32_t *>(storage);
   return Value(type_id_, val);
 }
 
-Value IntegerType::Copy(const Value &val) const {
+auto IntegerType::Copy(const Value &val) const -> Value {
   assert(val.CheckInteger());
   return Value(val.GetTypeId(), val.value_.integer_);
 }
 
-Value IntegerType::CastAs(const Value &val, const TypeId type_id) const {
+auto IntegerType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::TINYINT: {
       if (val.IsNull()) {

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -65,9 +65,9 @@ namespace bustub {
 
 SmallintType::SmallintType() : IntegerParentType(TypeId::SMALLINT) {}
 
-bool SmallintType::IsZero(const Value &val) const { return (val.value_.smallint_ == 0); }
+auto SmallintType::IsZero(const Value &val) const -> bool { return (val.value_.smallint_ == 0); }
 
-Value SmallintType::Add(const Value &left, const Value &right) const {
+auto SmallintType::Add(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -79,7 +79,7 @@ Value SmallintType::Add(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value SmallintType::Subtract(const Value &left, const Value &right) const {
+auto SmallintType::Subtract(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -91,7 +91,7 @@ Value SmallintType::Subtract(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value SmallintType::Multiply(const Value &left, const Value &right) const {
+auto SmallintType::Multiply(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -103,7 +103,7 @@ Value SmallintType::Multiply(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value SmallintType::Divide(const Value &left, const Value &right) const {
+auto SmallintType::Divide(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -119,7 +119,7 @@ Value SmallintType::Divide(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value SmallintType::Modulo(const Value &left, const Value &right) const {
+auto SmallintType::Modulo(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -151,7 +151,7 @@ Value SmallintType::Modulo(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value SmallintType::Sqrt(const Value &val) const {
+auto SmallintType::Sqrt(const Value &val) const -> Value {
   assert(val.CheckInteger());
   if (val.IsNull()) {
     return Value(TypeId::DECIMAL, static_cast<double>(BUSTUB_DECIMAL_NULL));
@@ -163,7 +163,7 @@ Value SmallintType::Sqrt(const Value &val) const {
   return Value(TypeId::DECIMAL, std::sqrt(val.value_.smallint_));
 }
 
-Value SmallintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
+auto SmallintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const -> Value {
   switch (right.GetTypeId()) {
     case TypeId::TINYINT:
     case TypeId::SMALLINT:
@@ -181,7 +181,7 @@ Value SmallintType::OperateNull(const Value &left __attribute__((unused)), const
   throw Exception("type error");
 }
 
-CmpBool SmallintType::CompareEquals(const Value &left, const Value &right) const {
+auto SmallintType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
 
@@ -194,7 +194,7 @@ CmpBool SmallintType::CompareEquals(const Value &left, const Value &right) const
   throw Exception("type error");
 }
 
-CmpBool SmallintType::CompareNotEquals(const Value &left, const Value &right) const {
+auto SmallintType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -206,7 +206,7 @@ CmpBool SmallintType::CompareNotEquals(const Value &left, const Value &right) co
   throw Exception("type error");
 }
 
-CmpBool SmallintType::CompareLessThan(const Value &left, const Value &right) const {
+auto SmallintType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -218,7 +218,7 @@ CmpBool SmallintType::CompareLessThan(const Value &left, const Value &right) con
   throw Exception("type error");
 }
 
-CmpBool SmallintType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto SmallintType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -230,7 +230,7 @@ CmpBool SmallintType::CompareLessThanEquals(const Value &left, const Value &righ
   throw Exception("type error");
 }
 
-CmpBool SmallintType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto SmallintType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -242,7 +242,7 @@ CmpBool SmallintType::CompareGreaterThan(const Value &left, const Value &right) 
   throw Exception("type error");
 }
 
-CmpBool SmallintType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto SmallintType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -254,7 +254,7 @@ CmpBool SmallintType::CompareGreaterThanEquals(const Value &left, const Value &r
   throw Exception("type error");
 }
 
-std::string SmallintType::ToString(const Value &val) const {
+auto SmallintType::ToString(const Value &val) const -> std::string {
   assert(val.CheckInteger());
   switch (val.GetTypeId()) {
     case TypeId::TINYINT:
@@ -288,12 +288,12 @@ void SmallintType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value SmallintType::DeserializeFrom(const char *storage) const {
+auto SmallintType::DeserializeFrom(const char *storage) const -> Value {
   int16_t val = *reinterpret_cast<const int16_t *>(storage);
   return Value(type_id_, val);
 }
 
-Value SmallintType::Copy(const Value &val) const {
+auto SmallintType::Copy(const Value &val) const -> Value {
   assert(val.CheckInteger());
 
   return Value(TypeId::SMALLINT, val.value_.smallint_);
@@ -301,7 +301,7 @@ Value SmallintType::Copy(const Value &val) const {
   throw Exception("type error");
 }
 
-Value SmallintType::CastAs(const Value &val, const TypeId type_id) const {
+auto SmallintType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::TINYINT: {
       if (val.IsNull()) {

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -21,7 +21,7 @@ namespace bustub {
 
 TimestampType::TimestampType() : Type(TypeId::TIMESTAMP) {}
 
-CmpBool TimestampType::CompareEquals(const Value &left, const Value &right) const {
+auto TimestampType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -29,7 +29,7 @@ CmpBool TimestampType::CompareEquals(const Value &left, const Value &right) cons
   return GetCmpBool(left.GetAs<uint64_t>() == right.GetAs<uint64_t>());
 }
 
-CmpBool TimestampType::CompareNotEquals(const Value &left, const Value &right) const {
+auto TimestampType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (right.IsNull()) {
     return CmpBool::CmpNull;
@@ -37,7 +37,7 @@ CmpBool TimestampType::CompareNotEquals(const Value &left, const Value &right) c
   return GetCmpBool(left.GetAs<uint64_t>() != right.GetAs<uint64_t>());
 }
 
-CmpBool TimestampType::CompareLessThan(const Value &left, const Value &right) const {
+auto TimestampType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -45,7 +45,7 @@ CmpBool TimestampType::CompareLessThan(const Value &left, const Value &right) co
   return GetCmpBool(left.GetAs<uint64_t>() < right.GetAs<uint64_t>());
 }
 
-CmpBool TimestampType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto TimestampType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -53,7 +53,7 @@ CmpBool TimestampType::CompareLessThanEquals(const Value &left, const Value &rig
   return GetCmpBool(left.GetAs<uint64_t>() <= right.GetAs<uint64_t>());
 }
 
-CmpBool TimestampType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto TimestampType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -61,7 +61,7 @@ CmpBool TimestampType::CompareGreaterThan(const Value &left, const Value &right)
   return GetCmpBool(left.GetAs<int64_t>() > right.GetAs<int64_t>());
 }
 
-CmpBool TimestampType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto TimestampType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -69,7 +69,7 @@ CmpBool TimestampType::CompareGreaterThanEquals(const Value &left, const Value &
   return GetCmpBool(left.GetAs<uint64_t>() >= right.GetAs<uint64_t>());
 }
 
-Value TimestampType::Min(const Value &left, const Value &right) const {
+auto TimestampType::Min(const Value &left, const Value &right) const -> Value {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return left.OperateNull(right);
@@ -80,7 +80,7 @@ Value TimestampType::Min(const Value &left, const Value &right) const {
   return right.Copy();
 }
 
-Value TimestampType::Max(const Value &left, const Value &right) const {
+auto TimestampType::Max(const Value &left, const Value &right) const -> Value {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return left.OperateNull(right);
@@ -92,7 +92,7 @@ Value TimestampType::Max(const Value &left, const Value &right) const {
 }
 
 // Debug
-std::string TimestampType::ToString(const Value &val) const {
+auto TimestampType::ToString(const Value &val) const -> std::string {
   if (val.IsNull()) {
     return "timestamp_null";
   }
@@ -135,15 +135,15 @@ void TimestampType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value TimestampType::DeserializeFrom(const char *storage) const {
+auto TimestampType::DeserializeFrom(const char *storage) const -> Value {
   uint64_t val = *reinterpret_cast<const uint64_t *>(storage);
   return Value(type_id_, val);
 }
 
 // Create a copy of this value
-Value TimestampType::Copy(const Value &val) const { return Value(val); }
+auto TimestampType::Copy(const Value &val) const -> Value { return Value(val); }
 
-Value TimestampType::CastAs(const Value &val, const TypeId type_id) const {
+auto TimestampType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::TIMESTAMP:
       return Copy(val);

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -66,9 +66,9 @@ namespace bustub {
 
 TinyintType::TinyintType() : IntegerParentType(TINYINT) {}
 
-bool TinyintType::IsZero(const Value &val) const { return (val.value_.tinyint_ == 0); }
+auto TinyintType::IsZero(const Value &val) const -> bool { return (val.value_.tinyint_ == 0); }
 
-Value TinyintType::Add(const Value &left, const Value &right) const {
+auto TinyintType::Add(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -80,7 +80,7 @@ Value TinyintType::Add(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value TinyintType::Subtract(const Value &left, const Value &right) const {
+auto TinyintType::Subtract(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -92,7 +92,7 @@ Value TinyintType::Subtract(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value TinyintType::Multiply(const Value &left, const Value &right) const {
+auto TinyintType::Multiply(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -104,7 +104,7 @@ Value TinyintType::Multiply(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value TinyintType::Divide(const Value &left, const Value &right) const {
+auto TinyintType::Divide(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -120,7 +120,7 @@ Value TinyintType::Divide(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value TinyintType::Modulo(const Value &left, const Value &right) const {
+auto TinyintType::Modulo(const Value &left, const Value &right) const -> Value {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -153,7 +153,7 @@ Value TinyintType::Modulo(const Value &left, const Value &right) const {
   throw Exception("type error");
 }
 
-Value TinyintType::Sqrt(const Value &val) const {
+auto TinyintType::Sqrt(const Value &val) const -> Value {
   assert(val.CheckInteger());
   if (val.IsNull()) {
     return Value(TypeId::DECIMAL, BUSTUB_DECIMAL_NULL);
@@ -167,7 +167,7 @@ Value TinyintType::Sqrt(const Value &val) const {
   throw Exception("type error");
 }
 
-Value TinyintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const {
+auto TinyintType::OperateNull(const Value &left __attribute__((unused)), const Value &right) const -> Value {
   switch (right.GetTypeId()) {
     case TypeId::TINYINT:
       return Value(TypeId::TINYINT, static_cast<int8_t>(BUSTUB_INT8_NULL));
@@ -185,7 +185,7 @@ Value TinyintType::OperateNull(const Value &left __attribute__((unused)), const 
   throw Exception("type error");
 }
 
-CmpBool TinyintType::CompareEquals(const Value &left, const Value &right) const {
+auto TinyintType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
 
@@ -198,7 +198,7 @@ CmpBool TinyintType::CompareEquals(const Value &left, const Value &right) const 
   throw Exception("type error");
 }
 
-CmpBool TinyintType::CompareNotEquals(const Value &left, const Value &right) const {
+auto TinyintType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -210,7 +210,7 @@ CmpBool TinyintType::CompareNotEquals(const Value &left, const Value &right) con
   throw Exception("type error");
 }
 
-CmpBool TinyintType::CompareLessThan(const Value &left, const Value &right) const {
+auto TinyintType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -222,7 +222,7 @@ CmpBool TinyintType::CompareLessThan(const Value &left, const Value &right) cons
   throw Exception("type error");
 }
 
-CmpBool TinyintType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto TinyintType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -234,7 +234,7 @@ CmpBool TinyintType::CompareLessThanEquals(const Value &left, const Value &right
   throw Exception("type error");
 }
 
-CmpBool TinyintType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto TinyintType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -246,7 +246,7 @@ CmpBool TinyintType::CompareGreaterThan(const Value &left, const Value &right) c
   throw Exception("type error");
 }
 
-CmpBool TinyintType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto TinyintType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckInteger());
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
@@ -258,7 +258,7 @@ CmpBool TinyintType::CompareGreaterThanEquals(const Value &left, const Value &ri
   throw Exception("type error");
 }
 
-std::string TinyintType::ToString(const Value &val) const {
+auto TinyintType::ToString(const Value &val) const -> std::string {
   assert(val.CheckInteger());
   if (val.IsNull()) {
     return "tinyint_null";
@@ -271,17 +271,17 @@ void TinyintType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value TinyintType::DeserializeFrom(const char *storage) const {
+auto TinyintType::DeserializeFrom(const char *storage) const -> Value {
   int8_t val = *reinterpret_cast<const int8_t *>(storage);
   return Value(type_id_, val);
 }
 
-Value TinyintType::Copy(const Value &val) const {
+auto TinyintType::Copy(const Value &val) const -> Value {
   assert(val.CheckInteger());
   return Value(TypeId::TINYINT, val.value_.tinyint_);
 }
 
-Value TinyintType::CastAs(const Value &val, const TypeId type_id) const {
+auto TinyintType::CastAs(const Value &val, const TypeId type_id) const -> Value {
   switch (type_id) {
     case TypeId::TINYINT: {
       if (val.IsNull()) {

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -29,7 +29,7 @@ Type *Type::k_types[] = {
 };
 
 // Get the size of this data type in bytes
-uint64_t Type::GetTypeSize(const TypeId type_id) {
+auto Type::GetTypeSize(const TypeId type_id) -> uint64_t {
   switch (type_id) {
     case BOOLEAN:
     case TINYINT:
@@ -50,7 +50,7 @@ uint64_t Type::GetTypeSize(const TypeId type_id) {
   throw Exception(ExceptionType::UNKNOWN_TYPE, "Unknown type.");
 }
 
-bool Type::IsCoercableFrom(const TypeId type_id) const {
+auto Type::IsCoercableFrom(const TypeId type_id) const -> bool {
   switch (type_id_) {
     case INVALID:
       return false;
@@ -95,7 +95,7 @@ bool Type::IsCoercableFrom(const TypeId type_id) const {
   }  // END SWITCH
 }
 
-std::string Type::TypeIdToString(const TypeId type_id) {
+auto Type::TypeIdToString(const TypeId type_id) -> std::string {
   switch (type_id) {
     case INVALID:
       return "INVALID";
@@ -120,7 +120,7 @@ std::string Type::TypeIdToString(const TypeId type_id) {
   }
 }
 
-Value Type::GetMinValue(TypeId type_id) {
+auto Type::GetMinValue(TypeId type_id) -> Value {
   switch (type_id) {
     case BOOLEAN:
       return Value(type_id, 0);
@@ -144,7 +144,7 @@ Value Type::GetMinValue(TypeId type_id) {
   throw Exception(ExceptionType::MISMATCH_TYPE, "Cannot get minimal value.");
 }
 
-Value Type::GetMaxValue(TypeId type_id) {
+auto Type::GetMaxValue(TypeId type_id) -> Value {
   switch (type_id) {
     case BOOLEAN:
       return Value(type_id, 1);
@@ -168,81 +168,81 @@ Value Type::GetMaxValue(TypeId type_id) {
   throw Exception(ExceptionType::MISMATCH_TYPE, "Cannot get max value.");
 }
 
-CmpBool Type::CompareEquals(const Value &left __attribute__((unused)),
-                            const Value &right __attribute__((unused))) const {
+auto Type::CompareEquals(const Value &left __attribute__((unused)),
+                            const Value &right __attribute__((unused))) const -> CmpBool {
   throw NotImplementedException("CompareEquals not implemented");
 }
 
-CmpBool Type::CompareNotEquals(const Value &left __attribute__((unused)),
-                               const Value &right __attribute__((unused))) const {
+auto Type::CompareNotEquals(const Value &left __attribute__((unused)),
+                               const Value &right __attribute__((unused))) const -> CmpBool {
   throw NotImplementedException("CompareNotEquals not implemented");
 }
 
-CmpBool Type::CompareLessThan(const Value &left __attribute__((unused)),
-                              const Value &right __attribute__((unused))) const {
+auto Type::CompareLessThan(const Value &left __attribute__((unused)),
+                              const Value &right __attribute__((unused))) const -> CmpBool {
   throw NotImplementedException("CompareLessThan not implemented");
 }
-CmpBool Type::CompareLessThanEquals(const Value &left __attribute__((unused)),
-                                    const Value &right __attribute__((unused))) const {
+auto Type::CompareLessThanEquals(const Value &left __attribute__((unused)),
+                                    const Value &right __attribute__((unused))) const -> CmpBool {
   throw NotImplementedException("CompareLessThanEqual not implemented");
 }
-CmpBool Type::CompareGreaterThan(const Value &left __attribute__((unused)),
-                                 const Value &right __attribute__((unused))) const {
+auto Type::CompareGreaterThan(const Value &left __attribute__((unused)),
+                                 const Value &right __attribute__((unused))) const -> CmpBool {
   throw NotImplementedException("CompareGreaterThan not implemented");
 }
-CmpBool Type::CompareGreaterThanEquals(const Value &left __attribute__((unused)),
-                                       const Value &right __attribute__((unused))) const {
+auto Type::CompareGreaterThanEquals(const Value &left __attribute__((unused)),
+                                       const Value &right __attribute__((unused))) const -> CmpBool {
   throw NotImplementedException("CompareGreaterThanEqual not implemented");
 }
 
 // Other mathematical functions
-Value Type::Add(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Add(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Add not implemented");
 }
 
-Value Type::Subtract(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Subtract(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Subtract not implemented");
 }
 
-Value Type::Multiply(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Multiply(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Multiply not implemented");
 }
 
-Value Type::Divide(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Divide(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Divide not implemented");
 }
 
-Value Type::Modulo(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Modulo(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Modulo not implemented");
 }
 
-Value Type::Min(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Min(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Min not implemented");
 }
 
-Value Type::Max(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::Max(const Value &left __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("Max not implemented");
 }
 
-Value Type::Sqrt(const Value &val __attribute__((unused))) const {
+auto Type::Sqrt(const Value &val __attribute__((unused))) const -> Value {
   throw NotImplementedException("Sqrt not implemented");
 }
 
-Value Type::OperateNull(const Value &val __attribute__((unused)), const Value &right __attribute__((unused))) const {
+auto Type::OperateNull(const Value &val __attribute__((unused)), const Value &right __attribute__((unused))) const -> Value {
   throw NotImplementedException("OperateNull not implemented");
 }
 
-bool Type::IsZero(const Value &val __attribute__((unused))) const {
+auto Type::IsZero(const Value &val __attribute__((unused))) const -> bool {
   throw NotImplementedException("isZero not implemented");
 }
 // Is the data inlined into this classes storage space, or must it be accessed
 // through an indirection/pointer?
-bool Type::IsInlined(const Value &val __attribute__((unused))) const {
+auto Type::IsInlined(const Value &val __attribute__((unused))) const -> bool {
   throw NotImplementedException("IsLined not implemented");
 }
 
 // Return a stringified version of this value
-std::string Type::ToString(const Value &val __attribute__((unused))) const {
+auto Type::ToString(const Value &val __attribute__((unused))) const -> std::string {
   throw NotImplementedException("ToString not implemented");
 }
 
@@ -256,30 +256,30 @@ void Type::SerializeTo(const Value &val __attribute__((unused)), char *storage _
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value Type::DeserializeFrom(const char *storage __attribute__((unused))) const {
+auto Type::DeserializeFrom(const char *storage __attribute__((unused))) const -> Value {
   throw NotImplementedException("DeserializeFrom not implemented");
 }
 
 // Create a copy of this value
-Value Type::Copy(const Value &val __attribute__((unused))) const {
+auto Type::Copy(const Value &val __attribute__((unused))) const -> Value {
   throw NotImplementedException("Copy not implemented");
 }
 
-Value Type::CastAs(const Value &val __attribute__((unused)), const TypeId type_id __attribute__((unused))) const {
+auto Type::CastAs(const Value &val __attribute__((unused)), const TypeId type_id __attribute__((unused))) const -> Value {
   throw NotImplementedException("CastAs not implemented");
 }
 
 // Access the raw variable length data
-const char *Type::GetData(const Value &val __attribute__((unused))) const {
+auto Type::GetData(const Value &val __attribute__((unused))) const -> const char * {
   throw NotImplementedException("GetData from value not implemented");
 }
 
 // Get the length of the variable length data
-uint32_t Type::GetLength(const Value &val __attribute__((unused))) const {
+auto Type::GetLength(const Value &val __attribute__((unused))) const -> uint32_t {
   throw NotImplementedException("GetLength not implemented");
 }
 
 // Access the raw varlen data stored from the tuple storage
-char *Type::GetData(char *storage __attribute__((unused))) { throw NotImplementedException("GetData not implemented"); }
+auto Type::GetData(char *storage __attribute__((unused))) -> char * { throw NotImplementedException("GetData not implemented"); }
 
 }  // namespace bustub

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -41,7 +41,7 @@ Value::Value(const Value &other) {
   }
 }
 
-Value &Value::operator=(Value other) {
+auto Value::operator=(Value other) -> Value & {
   Swap(*this, other);
   return *this;
 }
@@ -267,7 +267,7 @@ Value::~Value() {
   }
 }
 
-bool Value::CheckComparable(const Value &o) const {
+auto Value::CheckComparable(const Value &o) const -> bool {
   switch (GetTypeId()) {
     case TypeId::BOOLEAN:
       return (o.GetTypeId() == TypeId::BOOLEAN || o.GetTypeId() == TypeId::VARCHAR);
@@ -298,7 +298,7 @@ bool Value::CheckComparable(const Value &o) const {
   return false;
 }
 
-bool Value::CheckInteger() const {
+auto Value::CheckInteger() const -> bool {
   switch (GetTypeId()) {
     case TypeId::TINYINT:
     case TypeId::SMALLINT:

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -41,12 +41,12 @@ VarlenType::VarlenType(TypeId type) : Type(type) {}
 VarlenType::~VarlenType() = default;
 
 // Access the raw variable length data
-const char *VarlenType::GetData(const Value &val) const { return val.value_.varlen_; }
+auto VarlenType::GetData(const Value &val) const -> const char * { return val.value_.varlen_; }
 
 // Get the length of the variable length data (including the length field)
-uint32_t VarlenType::GetLength(const Value &val) const { return val.size_.len_; }
+auto VarlenType::GetLength(const Value &val) const -> uint32_t { return val.size_.len_; }
 
-CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
+auto VarlenType::CompareEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -58,7 +58,7 @@ CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
   VARLEN_COMPARE_FUNC(==);  // NOLINT
 }
 
-CmpBool VarlenType::CompareNotEquals(const Value &left, const Value &right) const {
+auto VarlenType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -70,7 +70,7 @@ CmpBool VarlenType::CompareNotEquals(const Value &left, const Value &right) cons
   VARLEN_COMPARE_FUNC(!=);  // NOLINT
 }
 
-CmpBool VarlenType::CompareLessThan(const Value &left, const Value &right) const {
+auto VarlenType::CompareLessThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -82,7 +82,7 @@ CmpBool VarlenType::CompareLessThan(const Value &left, const Value &right) const
   VARLEN_COMPARE_FUNC(<);  // NOLINT
 }
 
-CmpBool VarlenType::CompareLessThanEquals(const Value &left, const Value &right) const {
+auto VarlenType::CompareLessThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -94,7 +94,7 @@ CmpBool VarlenType::CompareLessThanEquals(const Value &left, const Value &right)
   VARLEN_COMPARE_FUNC(<=);  // NOLINT
 }
 
-CmpBool VarlenType::CompareGreaterThan(const Value &left, const Value &right) const {
+auto VarlenType::CompareGreaterThan(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -106,7 +106,7 @@ CmpBool VarlenType::CompareGreaterThan(const Value &left, const Value &right) co
   VARLEN_COMPARE_FUNC(>);  // NOLINT
 }
 
-CmpBool VarlenType::CompareGreaterThanEquals(const Value &left, const Value &right) const {
+auto VarlenType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
@@ -118,7 +118,7 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left, const Value &rig
   VARLEN_COMPARE_FUNC(>=);  // NOLINT
 }
 
-Value VarlenType::Min(const Value &left, const Value &right) const {
+auto VarlenType::Min(const Value &left, const Value &right) const -> Value {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return left.OperateNull(right);
@@ -129,7 +129,7 @@ Value VarlenType::Min(const Value &left, const Value &right) const {
   return right.Copy();
 }
 
-Value VarlenType::Max(const Value &left, const Value &right) const {
+auto VarlenType::Max(const Value &left, const Value &right) const -> Value {
   assert(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) {
     return left.OperateNull(right);
@@ -140,7 +140,7 @@ Value VarlenType::Max(const Value &left, const Value &right) const {
   return right.Copy();
 }
 
-std::string VarlenType::ToString(const Value &val) const {
+auto VarlenType::ToString(const Value &val) const -> std::string {
   uint32_t len = GetLength(val);
 
   if (val.IsNull()) {
@@ -166,7 +166,7 @@ void VarlenType::SerializeTo(const Value &val, char *storage) const {
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value VarlenType::DeserializeFrom(const char *storage) const {
+auto VarlenType::DeserializeFrom(const char *storage) const -> Value {
   uint32_t len = *reinterpret_cast<const uint32_t *>(storage);
   if (len == BUSTUB_VALUE_NULL) {
     return Value(type_id_, nullptr, len, false);
@@ -175,9 +175,9 @@ Value VarlenType::DeserializeFrom(const char *storage) const {
   return Value(type_id_, storage + sizeof(uint32_t), len, true);
 }
 
-Value VarlenType::Copy(const Value &val) const { return Value(val); }
+auto VarlenType::Copy(const Value &val) const -> Value { return Value(val); }
 
-Value VarlenType::CastAs(const Value &value, const TypeId type_id) const {
+auto VarlenType::CastAs(const Value &value, const TypeId type_id) const -> Value {
   std::string str;
   // switch begins
   switch (type_id) {

--- a/test/common/rwlatch_test.cpp
+++ b/test/common/rwlatch_test.cpp
@@ -26,7 +26,7 @@ class Counter {
     count_ += num;
     mutex_.WUnlock();
   }
-  int Read() {
+  auto Read() -> int {
     int res;
     mutex_.RLock();
     res = count_;

--- a/test/concurrency/transaction_test.cpp
+++ b/test/concurrency/transaction_test.cpp
@@ -83,42 +83,42 @@ class TransactionTest : public ::testing::Test {
   };
 
   /** @return the executor context in our test class */
-  ExecutorContext *GetExecutorContext() { return exec_ctx_.get(); }
-  ExecutionEngine *GetExecutionEngine() { return execution_engine_.get(); }
-  Transaction *GetTxn() { return txn_; }
-  TransactionManager *GetTxnManager() { return txn_mgr_.get(); }
-  Catalog *GetCatalog() { return catalog_.get(); }
-  BufferPoolManager *GetBPM() { return bpm_.get(); }
-  LockManager *GetLockManager() { return lock_manager_.get(); }
+  auto GetExecutorContext() -> ExecutorContext * { return exec_ctx_.get(); }
+  auto GetExecutionEngine() -> ExecutionEngine * { return execution_engine_.get(); }
+  auto GetTxn() -> Transaction * { return txn_; }
+  auto GetTxnManager() -> TransactionManager * { return txn_mgr_.get(); }
+  auto GetCatalog() -> Catalog * { return catalog_.get(); }
+  auto GetBPM() -> BufferPoolManager * { return bpm_.get(); }
+  auto GetLockManager() -> LockManager * { return lock_manager_.get(); }
 
   // The below helper functions are useful for testing.
 
-  const AbstractExpression *MakeColumnValueExpression(const Schema &schema, uint32_t tuple_idx,
-                                                      const std::string &col_name) {
+  auto MakeColumnValueExpression(const Schema &schema, uint32_t tuple_idx,
+                                                      const std::string &col_name) -> const AbstractExpression * {
     uint32_t col_idx = schema.GetColIdx(col_name);
     auto col_type = schema.GetColumn(col_idx).GetType();
     allocated_exprs_.emplace_back(std::make_unique<ColumnValueExpression>(tuple_idx, col_idx, col_type));
     return allocated_exprs_.back().get();
   }
 
-  const AbstractExpression *MakeConstantValueExpression(const Value &val) {
+  auto MakeConstantValueExpression(const Value &val) -> const AbstractExpression * {
     allocated_exprs_.emplace_back(std::make_unique<ConstantValueExpression>(val));
     return allocated_exprs_.back().get();
   }
 
-  const AbstractExpression *MakeComparisonExpression(const AbstractExpression *lhs, const AbstractExpression *rhs,
-                                                     ComparisonType comp_type) {
+  auto MakeComparisonExpression(const AbstractExpression *lhs, const AbstractExpression *rhs,
+                                                     ComparisonType comp_type) -> const AbstractExpression * {
     allocated_exprs_.emplace_back(std::make_unique<ComparisonExpression>(lhs, rhs, comp_type));
     return allocated_exprs_.back().get();
   }
 
-  const AbstractExpression *MakeAggregateValueExpression(bool is_group_by_term, uint32_t term_idx) {
+  auto MakeAggregateValueExpression(bool is_group_by_term, uint32_t term_idx) -> const AbstractExpression * {
     allocated_exprs_.emplace_back(
         std::make_unique<AggregateValueExpression>(is_group_by_term, term_idx, TypeId::INTEGER));
     return allocated_exprs_.back().get();
   }
 
-  const Schema *MakeOutputSchema(const std::vector<std::pair<std::string, const AbstractExpression *>> &exprs) {
+  auto MakeOutputSchema(const std::vector<std::pair<std::string, const AbstractExpression *>> &exprs) -> const Schema * {
     std::vector<Column> cols;
     cols.reserve(exprs.size());
     for (const auto &input : exprs) {

--- a/test/include/logging/common.h
+++ b/test/include/logging/common.h
@@ -23,7 +23,7 @@
 namespace bustub {
 
 // use a fixed schema to construct a random tuple
-Tuple ConstructTuple(Schema *schema) {
+auto ConstructTuple(Schema *schema) -> Tuple {
   std::vector<Value> values;
   Value v(TypeId::INVALID);
 

--- a/test/include/test_util.h
+++ b/test/include/test_util.h
@@ -28,7 +28,7 @@
 
 namespace bustub {
 
-std::unique_ptr<Schema> ParseCreateStatement(const std::string &sql_base) {
+auto ParseCreateStatement(const std::string &sql_base) -> std::unique_ptr<Schema> {
   std::string::size_type n;
   std::vector<Column> v{};
   std::string column_name;

--- a/test/primer/starter_test.cpp
+++ b/test/primer/starter_test.cpp
@@ -26,7 +26,7 @@ namespace bustub {
  * @param type The expected exception type
  * @return `true` if expected type is throw by `function`, `false` otherwise
  */
-static bool ThrowsBustubException(const std::function<void()> &function, ExceptionType type) {
+static auto ThrowsBustubException(const std::function<void()> &function, ExceptionType type) -> bool {
   bool expected_type_thrown = false;
   try {
     function();

--- a/test/storage/b_plus_tree_print_test.cpp
+++ b/test/storage/b_plus_tree_print_test.cpp
@@ -21,7 +21,7 @@
 
 namespace bustub {
 
-std::string UsageMessage() {
+auto UsageMessage() -> std::string {
   std::string message =
       "Enter any of the following commands after the prompt > :\n"
       "\ti <k>  -- Insert <k> (int64_t) as both key and value).\n"


### PR DESCRIPTION
This PR converts all function signatures to use a trailing return type.  Trailing return types were introduced in C++11 and are a new check included in the upgrade from clang-8 to clang-12.