### PR TITLE
Add a comment for  flexible array member

### DIFF
--- a/src/include/storage/page/hash_table_bucket_page.h
+++ b/src/include/storage/page/hash_table_bucket_page.h
@@ -142,6 +142,7 @@ class HashTableBucketPage {
   char occupied_[(BUCKET_ARRAY_SIZE - 1) / 8 + 1];
   // 0 if tombstone/brand new (never occupied), 1 otherwise.
   char readable_[(BUCKET_ARRAY_SIZE - 1) / 8 + 1];
+  // Flexible array member for page data.
   MappingType array_[1];
 };
 


### PR DESCRIPTION
In #151, comments for flexible array member were added. But the comment was missed in `hash_table_bucket_page.h`, which confuse me a lot.