### PR TITLE
fix(disk_manager): remove redundant open file

### DIFF
--- a/src/storage/disk/disk_manager.cpp
+++ b/src/storage/disk/disk_manager.cpp
@@ -44,10 +44,7 @@ DiskManager::DiskManager(const std::string &db_file)
   if (!log_io_.is_open()) {
     log_io_.clear();
     // create a new file
-    log_io_.open(log_name_, std::ios::binary | std::ios::trunc | std::ios::app | std::ios::out);
-    log_io_.close();
-    // reopen with original mode
-    log_io_.open(log_name_, std::ios::binary | std::ios::in | std::ios::app | std::ios::out);
+    log_io_.open(log_name_, std::ios::binary | std::ios::trunc | std::ios::out | std::ios::in);
     if (!log_io_.is_open()) {
       throw Exception("can't open dblog file");
     }
@@ -59,10 +56,7 @@ DiskManager::DiskManager(const std::string &db_file)
   if (!db_io_.is_open()) {
     db_io_.clear();
     // create a new file
-    db_io_.open(db_file, std::ios::binary | std::ios::trunc | std::ios::out);
-    db_io_.close();
-    // reopen with original mode
-    db_io_.open(db_file, std::ios::binary | std::ios::in | std::ios::out);
+    db_io_.open(db_file, std::ios::binary | std::ios::trunc | std::ios::out | std::ios::in);
     if (!db_io_.is_open()) {
       throw Exception("can't open db file");
     }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

close https://github.com/cmu-db/bustub/issues/150

```
log_io_.open(log_name_, std::ios::binary | std::ios::trunc | std::ios::app | std::ios::out);
```

This line will always fail and doesn't take effect at all. We can directly create (or truncate) a file if we can't open it.