### PR TITLE
Disable 2 clang rules for refsol compliance

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,9 @@ Checks:     '
             -bugprone-unhandled-self-assignment,
             -clang-analyzer-cplusplus.NewDelete,
             -clang-analyzer-cplusplus.NewDeleteLeaks,
+            -clang-analyzer-security.insecureAPI.rand
             -clang-diagnostic-implicit-int-float-conversion,
+            -google-readability-avoid-underscore-in-googletest-name,
             -modernize-avoid-c-arrays,
             -modernize-use-nodiscard,
             -modernize-use-auto,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,7 @@ Checks:     '
             -bugprone-unhandled-self-assignment,
             -clang-analyzer-cplusplus.NewDelete,
             -clang-analyzer-cplusplus.NewDeleteLeaks,
-            -clang-analyzer-security.insecureAPI.rand
+            -clang-analyzer-security.insecureAPI.rand,
             -clang-diagnostic-implicit-int-float-conversion,
             -google-readability-avoid-underscore-in-googletest-name,
             -modernize-avoid-c-arrays,


### PR DESCRIPTION
This PR brings the reference solution into compliance with newer versions of clang-tidy.  Compliance with these rules would only involve changing test names and the random number generation API, so it can be done reasonably quickly in the future.