### PR TITLE
fix(executor): add sum column for test

### DIFF
--- a/test/execution/executor_test.cpp
+++ b/test/execution/executor_test.cpp
@@ -581,7 +581,8 @@ TEST_F(ExecutorTest, DISABLED_SimpleGroupByAggregation) {
   for (const auto &tuple : result_set) {
     // Should have count_a > 100
     ASSERT_GT(tuple.GetValue(agg_schema, agg_schema->GetColIdx("countA")).GetAs<int32_t>(), 100);
-    // Should have sum_c >= 0
+    // Should have sum_c >= 0. Data for test_1 table is randomly generated, where colC is uniformly distributed from
+    // 0 to 9999. So we can only ensure sumC column exists by checking if it's >= 0 here.
     ASSERT_GE(tuple.GetValue(agg_schema, agg_schema->GetColIdx("sumC")).GetAs<int32_t>(), 0);
     // Should have unique col_bs.
     auto col_b = tuple.GetValue(agg_schema, agg_schema->GetColIdx("colB")).GetAs<int32_t>();

--- a/test/execution/executor_test.cpp
+++ b/test/execution/executor_test.cpp
@@ -563,12 +563,13 @@ TEST_F(ExecutorTest, DISABLED_SimpleGroupByAggregation) {
     std::vector<const AbstractExpression *> aggregate_cols{col_a, col_c};
     std::vector<AggregationType> agg_types{AggregationType::CountAggregate, AggregationType::SumAggregate};
     const AbstractExpression *count_a = MakeAggregateValueExpression(false, 0);
+    const AbstractExpression *sum_c = MakeAggregateValueExpression(false, 1);
     // Make having clause
     const AbstractExpression *having = MakeComparisonExpression(
         count_a, MakeConstantValueExpression(ValueFactory::GetIntegerValue(100)), ComparisonType::GreaterThan);
 
     // Create plan
-    agg_schema = MakeOutputSchema({{"countA", count_a}, {"colB", groupby_b}});
+    agg_schema = MakeOutputSchema({{"countA", count_a}, {"colB", groupby_b}, {"sumC", sum_c}});
     agg_plan = std::make_unique<AggregationPlanNode>(agg_schema, scan_plan.get(), having, std::move(group_by_cols),
                                                      std::move(aggregate_cols), std::move(agg_types));
   }
@@ -580,6 +581,8 @@ TEST_F(ExecutorTest, DISABLED_SimpleGroupByAggregation) {
   for (const auto &tuple : result_set) {
     // Should have count_a > 100
     ASSERT_GT(tuple.GetValue(agg_schema, agg_schema->GetColIdx("countA")).GetAs<int32_t>(), 100);
+    // Should have sum_c >= 0
+    ASSERT_GE(tuple.GetValue(agg_schema, agg_schema->GetColIdx("sumC")).GetAs<int32_t>(), 0);
     // Should have unique col_bs.
     auto col_b = tuple.GetValue(agg_schema, agg_schema->GetColIdx("colB")).GetAs<int32_t>();
     ASSERT_EQ(encountered.count(col_b), 0);


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

close https://github.com/cmu-db/bustub/issues/260

tested with sample solution, which works fine.

By the way, it seems that all our execution tests' test data are randomly generated (table_generator.cpp), which might make things hard when someone want to debug their code and see what's wrong. I will look into the possibility of having some tables of fixed value in our tests in the future if possible.