### PR TITLE
refactor(build): use separate CMakeLists for each component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,6 @@ execute_process(COMMAND "${CMAKE_COMMAND}" --build .
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)  # don't override our compiler/linker options when building gtest
 add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src" "${CMAKE_BINARY_DIR}/googletest-build")
 
-function(disable_target_warnings NAME)
-        target_compile_options(${NAME} PRIVATE "-w")
-endfunction()
-
 ######################################################################################################################
 # COMPILER SETUP
 ######################################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ execute_process(COMMAND "${CMAKE_COMMAND}" --build .
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)  # don't override our compiler/linker options when building gtest
 add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src" "${CMAKE_BINARY_DIR}/googletest-build")
 
+function(disable_target_warnings NAME)
+        target_compile_options(${NAME} PRIVATE "-w")
+endfunction()
+
 ######################################################################################################################
 # COMPILER SETUP
 ######################################################################################################################
@@ -101,6 +105,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+
 # Includes.
 set(BUSTUB_SRC_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/src/include)
 set(BUSTUB_TEST_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/test/include)
@@ -110,6 +115,8 @@ include_directories(BEFORE src) # This is needed for gtest.
 
 add_subdirectory(src)
 add_subdirectory(test)
+add_subdirectory(third_party)
+
 ######################################################################################################################
 # MAKE TARGETS
 ######################################################################################################################
@@ -173,4 +180,4 @@ add_custom_target(check-clang-tidy
         -clang-tidy-binary ${CLANG_TIDY_BIN}                              # using our clang-tidy binary
         -p ${CMAKE_BINARY_DIR}                                            # using cmake's generated compile commands
         )
-add_dependencies(check-clang-tidy gtest bustub_shared)                    # needs gtest headers, compile_commands.json
+add_dependencies(check-clang-tidy gtest bustub)                    # needs gtest headers, compile_commands.json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,38 @@
-# This is hacky :(
-file(GLOB_RECURSE bustub_sources ${PROJECT_SOURCE_DIR}/src/*/*.cpp ${PROJECT_SOURCE_DIR}/src/*/*/*.cpp)
-add_library(bustub_shared SHARED ${bustub_sources})
+add_subdirectory(buffer)
+add_subdirectory(catalog)
+add_subdirectory(common)
+add_subdirectory(concurrency)
+add_subdirectory(container)
+add_subdirectory(execution)
+add_subdirectory(recovery)
+add_subdirectory(storage)
+add_subdirectory(type)
 
-######################################################################################################################
-# THIRD-PARTY SOURCES
-######################################################################################################################
+add_library(bustub SHARED ${ALL_OBJECT_FILES})
 
-# murmur3
-file(GLOB_RECURSE murmur3_sources
-        ${PROJECT_SOURCE_DIR}/third_party/murmur3/*.cpp ${PROJECT_SOURCE_DIR}/third_party/murmur3/*.h)
-add_library(thirdparty_murmur3 SHARED ${murmur3_sources})
-target_link_libraries(bustub_shared thirdparty_murmur3)
+set(BUSTUB_LIBS
+    bustub_buffer 
+    bustub_catalog 
+    bustub_common 
+    bustub_concurrency 
+    bustub_execution 
+    bustub_recovery 
+    bustub_type
+    bustub_container_hash
+    bustub_storage_disk
+    bustub_storage_index
+    bustub_storage_page
+    bustub_storage_table
+)
+
+set(BUSTUB_THIRDPARTY_LIBS
+    bustub_murmur3)
+
+target_link_libraries(
+    bustub 
+    ${BUSTUB_LIBS}
+    ${BUSTUB_THIRDPARTY_LIBS})
+
+target_include_directories(
+bustub PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/src/buffer/CMakeLists.txt
+++ b/src/buffer/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(
+  bustub_buffer 
+  OBJECT
+  buffer_pool_manager_instance.cpp
+  clock_replacer.cpp
+  lru_replacer.cpp
+  parallel_buffer_pool_manager.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_buffer>
+    PARENT_SCOPE)

--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(
+  bustub_catalog
+  OBJECT
+  column.cpp
+  table_generator.cpp
+  schema.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_catalog>
+    PARENT_SCOPE)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(
+  bustub_common
+  OBJECT
+  util/string_util.cpp
+  config.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_common>
+    PARENT_SCOPE)

--- a/src/concurrency/CMakeLists.txt
+++ b/src/concurrency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(
+  bustub_concurrency
+  OBJECT
+  lock_manager.cpp
+  transaction_manager.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_concurrency>
+    PARENT_SCOPE)

--- a/src/container/CMakeLists.txt
+++ b/src/container/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(hash)

--- a/src/container/hash/CMakeLists.txt
+++ b/src/container/hash/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(
+  bustub_container_hash
+  OBJECT
+  extendible_hash_table.cpp
+  linear_probe_hash_table.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_container_hash>
+    PARENT_SCOPE)

--- a/src/execution/CMakeLists.txt
+++ b/src/execution/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(
+  bustub_execution
+  OBJECT
+  aggregation_executor.cpp
+  delete_executor.cpp
+  distinct_executor.cpp
+  hash_join_executor.cpp
+  index_scan_executor.cpp
+  insert_executor.cpp
+  limit_executor.cpp
+  nested_index_join_executor.cpp
+  nested_loop_join_executor.cpp
+  seq_scan_executor.cpp
+  update_executor.cpp
+  executor_factory.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_execution>
+    PARENT_SCOPE)

--- a/src/recovery/CMakeLists.txt
+++ b/src/recovery/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(
+  bustub_recovery
+  OBJECT
+  checkpoint_manager.cpp
+  log_manager.cpp
+  log_recovery.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_recovery>
+    PARENT_SCOPE)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(disk)
+add_subdirectory(index)
+add_subdirectory(page)
+add_subdirectory(table)

--- a/src/storage/disk/CMakeLists.txt
+++ b/src/storage/disk/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(
+    bustub_storage_disk 
+    OBJECT
+    disk_manager.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_storage_disk>
+    PARENT_SCOPE)

--- a/src/storage/index/CMakeLists.txt
+++ b/src/storage/index/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+    bustub_storage_index
+    OBJECT
+    b_plus_tree_index.cpp
+    b_plus_tree.cpp
+    extendible_hash_table_index.cpp
+    index_iterator.cpp
+    linear_probe_hash_table_index.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_storage_disk>
+    PARENT_SCOPE)

--- a/src/storage/page/CMakeLists.txt
+++ b/src/storage/page/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(
+    bustub_storage_page
+    OBJECT
+    b_plus_tree_internal_page.cpp
+    b_plus_tree_leaf_page.cpp
+    b_plus_tree_page.cpp
+    hash_table_block_page.cpp
+    hash_table_bucket_page.cpp
+    hash_table_directory_page.cpp
+    header_page.cpp
+    table_page.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_storage_page>
+    PARENT_SCOPE)

--- a/src/storage/table/CMakeLists.txt
+++ b/src/storage/table/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(
+    bustub_storage_table
+    OBJECT
+    table_heap.cpp
+    table_iterator.cpp
+    tuple.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_storage_table>
+    PARENT_SCOPE)

--- a/src/type/CMakeLists.txt
+++ b/src/type/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(
+    bustub_type
+    OBJECT
+    bigint_type.cpp
+    boolean_type.cpp
+    decimal_type.cpp
+    integer_parent_type.cpp
+    integer_type.cpp
+    smallint_type.cpp
+    timestamp_type.cpp
+    tinyint_type.cpp
+    type.cpp
+    value.cpp
+    varlen_type.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_type>
+    PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_custom_target(check-tests COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
 ##########################################
 # "make XYZ_test"
 ##########################################
+
 foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
     # Create a human readable name.
     get_filename_component(bustub_test_filename ${bustub_test_source} NAME)
@@ -45,7 +46,8 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
     add_dependencies(build-tests ${bustub_test_name})
     add_dependencies(check-tests ${bustub_test_name})
 
-    target_link_libraries(${bustub_test_name} bustub_shared gtest gmock_main)
+    # target_link_libraries(${bustub_test_name} bustub bustub_buffer bustub_catalog bustub_common_util bustub_common bustub_concurrency bustub_execution bustub_parser bustub_recovery bustub_type bustub_murmur3 bustub_pg_query bustub_sqlite3 gtest gmock_main)
+    target_link_libraries(${bustub_test_name} bustub gtest gmock_main)
 
     # Set test target properties and dependencies.
     set_target_properties(${bustub_test_name}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,6 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
     add_dependencies(build-tests ${bustub_test_name})
     add_dependencies(check-tests ${bustub_test_name})
 
-    # target_link_libraries(${bustub_test_name} bustub bustub_buffer bustub_catalog bustub_common_util bustub_common bustub_concurrency bustub_execution bustub_parser bustub_recovery bustub_type bustub_murmur3 bustub_pg_query bustub_sqlite3 gtest gmock_main)
     target_link_libraries(${bustub_test_name} bustub gtest gmock_main)
 
     # Set test target properties and dependencies.

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,4 +1,1 @@
-# don't export any symbols from the third party stuff
-# set(CMAKE_C_VISIBILITY_PRESET hidden)
-
 add_subdirectory(murmur3)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,4 @@
+# don't export any symbols from the third party stuff
+# set(CMAKE_C_VISIBILITY_PRESET hidden)
+
+add_subdirectory(murmur3)

--- a/third_party/murmur3/CMakeLists.txt
+++ b/third_party/murmur3/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.0)
+# project(bustub_murmur3 CXX C)
+
+# set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+add_library(bustub_murmur3 SHARED MurmurHash3.cpp)
+
+# install(TARGETS bustub_murmur3
+#         EXPORT "${BUSTUB_EXPORT_SET}"
+#         LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+#         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+
+# disable_target_warnings(bustub_murmur3)
+
+# set_target_properties(bustub_murmur3 PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/third_party/murmur3/CMakeLists.txt
+++ b/third_party/murmur3/CMakeLists.txt
@@ -1,15 +1,3 @@
 cmake_minimum_required(VERSION 3.0)
-# project(bustub_murmur3 CXX C)
-
-# set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 add_library(bustub_murmur3 SHARED MurmurHash3.cpp)
-
-# install(TARGETS bustub_murmur3
-#         EXPORT "${BUSTUB_EXPORT_SET}"
-#         LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-#         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
-
-# disable_target_warnings(bustub_murmur3)
-
-# set_target_properties(bustub_murmur3 PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This is part of https://github.com/garrisonhess/bustub-public/pull/20, which will eventually make us easier to introduce DuckDB's parser. <del>Still working on integrating it with our ref solutions.</del>