### PR TITLE
chore(build): enable leak sanitizer in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,7 +38,7 @@ jobs:
             name: "Ubuntu 22.04 Clang",
             os: "ubuntu-22.04",
             cc: "/usr/bin/clang-12",
-            cxx: "/usr/bin/clang++12",
+            cxx: "/usr/bin/clang++-12",
             format: "/usr/bin/clang-format-12",
             tidy: "/usr/bin/clang-tidy-12"
           }
@@ -46,7 +46,7 @@ jobs:
             name: "Ubuntu 20.04 Clang",
             os: "ubuntu-20.04",
             cc: "/usr/bin/clang-12",
-            cxx: "/usr/bin/clang++12",
+            cxx: "/usr/bin/clang++-12",
             format: "/usr/bin/clang-format-12",
             tidy: "/usr/bin/clang-tidy-12"
           }
@@ -84,7 +84,7 @@ jobs:
         run: bash ./build_support/packages.sh -y
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCC=${{matrix.config.cc}} -DCXX=${{matrix.config.cxx}} -DCLANG_FORMAT_BIN=${{matrix.config.format}} -DCLANG_TIDY_BIN=${{matrix.config.tidy}}
+        run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCLANG_FORMAT_BIN=${{matrix.config.format}} -DCLANG_TIDY_BIN=${{matrix.config.tidy}}
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
@@ -104,10 +104,10 @@ jobs:
       - name: Check Tests (Ubuntu)
         if: runner.os == 'Linux'
         working-directory: ${{github.workspace}}/build
-        run: make check-tests
+        run: ASAN_OPTIONS=detect_leaks=1 make check-tests
 
       - name: Check Tests (OSX)
         if: runner.os == 'macOS'
         working-directory: ${{github.workspace}}/build
-        # Disable container overflow checks on OSX
-        run: ASAN_OPTIONS=detect_container_overflow=0 make check-tests
+        # Disable leak checks on OSX
+        run: ASAN_OPTIONS=detect_leaks=0 make check-tests


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

Follow up to deprecating valgrind https://github.com/cmu-db/bustub/pull/280, we should enable leak sanitizer (along with memory sanitizer) in ASAN.