### PR TITLE
feat(build): add check-clang-tidy-p0 for p0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,4 +180,18 @@ add_custom_target(check-clang-tidy-diff
         -p ${CMAKE_BINARY_DIR}                                            # using cmake's generated compile commands
         -only-diff                                                        # only check diff files to master
         )
+
+###########################################################
+# "make check-clang-tidy" target for projects
+# check clang-tidy on the whole projects is slow, so we
+# hardcode some files to check here for each project.
+###########################################################
+add_custom_target(check-clang-tidy-p0
+        ${BUSTUB_BUILD_SUPPORT_DIR}/run_clang_tidy.py                     # run LLVM's clang-tidy script
+        -clang-tidy-binary ${CLANG_TIDY_BIN}                              # using our clang-tidy binary
+        -p ${CMAKE_BINARY_DIR}                                            # using cmake's generated compile commands
+        -j 1
+        "src/primer/p0_trie.cpp"
+)
+
 add_dependencies(check-clang-tidy gtest bustub)                    # needs gtest headers, compile_commands.json

--- a/build_support/run_clang_tidy.py
+++ b/build_support/run_clang_tidy.py
@@ -342,16 +342,16 @@ def main():
 
         # Fill the queue with files.
         for i, name in enumerate(files):
-            put_file = False
-            while not put_file:
-                try:
-                    if file_name_re.search(name):
+            if file_name_re.search(name):
+                put_file = False
+                while not put_file:
+                    try:
                         task_queue.put(name, block=True, timeout=300)
                         put_file = True
-                    # update_progress(i, len(files))
-                except queue.Full:
-                    print('Still waiting to put files into clang-tidy queue.')
-                    sys.stdout.flush()
+                        # update_progress(i, len(files))
+                    except queue.Full:
+                        print('Still waiting to put files into clang-tidy queue.')
+                        sys.stdout.flush()
 
         # Wait for all threads to be done.
         task_queue.join()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(execution)
 add_subdirectory(recovery)
 add_subdirectory(storage)
 add_subdirectory(type)
+add_subdirectory(primer)
 
 add_library(bustub STATIC ${ALL_OBJECT_FILES})
 
@@ -25,6 +26,7 @@ set(BUSTUB_LIBS
     bustub_storage_index
     bustub_storage_page
     bustub_storage_table
+    bustub_primer
 )
 
 set(BUSTUB_THIRDPARTY_LIBS

--- a/src/primer/CMakeLists.txt
+++ b/src/primer/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(
+  bustub_primer
+  OBJECT
+  p0_trie.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_primer>
+    PARENT_SCOPE)

--- a/src/primer/p0_trie.cpp
+++ b/src/primer/p0_trie.cpp
@@ -1,0 +1,9 @@
+#include "primer/p0_trie.h"
+
+// This is a placeholder file for clang-tidy check.
+//
+// With this file, we can fire run_clang_tidy.py to check `p0_trie.h`,
+// as it will filter out all header files and won't check header-only code.
+//
+// This file is not part of the submission. All of the modifications should
+// be done in `src/include/primer/p0_trie.h`.


### PR DESCRIPTION
Add a new Makefile entry for checking 2022 Fall's p0. Will check only one file so it's significantly faster. Will use this Makefile entry in gradescope. <del>Can merge before https://github.com/cmu-db/bustub/pull/287.</del>