### PR TITLE
Fix compilation on Clang 14

### DIFF
--- a/src/include/common/util/hash_util.h
+++ b/src/include/common/util/hash_util.h
@@ -97,6 +97,7 @@ class HashUtil {
       }
       default: {
         BUSTUB_ASSERT(false, "Unsupported type.");
+        return 0;
       }
     }
   }

--- a/src/storage/page/hash_table_bucket_page.cpp
+++ b/src/storage/page/hash_table_bucket_page.cpp
@@ -97,7 +97,7 @@ void HASH_TABLE_BUCKET_TYPE::PrintBucket() {
     }
   }
 
-  LOG_INFO("Bucket Capacity: %lu, Size: %u, Taken: %u, Free: %u", BUCKET_ARRAY_SIZE, size, taken, free);
+  LOG_INFO("Bucket Capacity: %llu, Size: %u, Taken: %u, Free: %u", BUCKET_ARRAY_SIZE, size, taken, free);
 }
 
 // DO NOT REMOVE ANYTHING BELOW THIS LINE


### PR DESCRIPTION
Fixes the following two compilation errors using Clang 14:

```cpp
FAILED: src/execution/CMakeFiles/bustub_execution.dir/aggregation_executor.cpp.obj 
C:\msys64\clang64\bin\clang++.exe  -IC:/Users/rayga/WindowsProjects/bustub/src -IC:/Users/rayga/WindowsProjects/bustub/src/include -IC:/Users/rayga/WindowsProjects/bustub/test/include -IC:/Users/rayga/WindowsProjects/bustub/third_party -IC:/Users/rayga/WindowsProjects/bustub/third_party/fmt/include -Wall -Wextra -Werror -Wno-unused-parameter -Wno-attributes -g -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -std=gnu++2b -MD -MT src/execution/CMakeFiles/bustub_execution.dir/aggregation_executor.cpp.obj -MF src\execution\CMakeFiles\bustub_execution.dir\aggregation_executor.cpp.obj.d -o src/execution/CMakeFiles/bustub_execution.dir/aggregation_executor.cpp.obj -c C:/Users/rayga/WindowsProjects/bustub/src/execution/aggregation_executor.cpp
In file included from C:/Users/rayga/WindowsProjects/bustub/src/execution/aggregation_executor.cpp:15:
In file included from C:/Users/rayga/WindowsProjects/bustub/src/include/execution/executors/aggregation_executor.h:20:
C:/Users/rayga/WindowsProjects/bustub/src/include/common/util/hash_util.h:102:3: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]
  }
  ^


FAILED: src/storage/page/CMakeFiles/bustub_storage_page.dir/hash_table_bucket_page.cpp.obj 
C:\msys64\clang64\bin\clang++.exe  -IC:/Users/rayga/WindowsProjects/bustub/src -IC:/Users/rayga/WindowsProjects/bustub/src/include -IC:/Users/rayga/WindowsProjects/bustub/test/include -IC:/Users/rayga/WindowsProjects/bustub/third_party -IC:/Users/rayga/WindowsProjects/bustub/third_party/fmt/include -Wall -Wextra -Werror -Wno-unused-parameter -Wno-attributes -g -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -std=gnu++2b -MD -MT src/storage/page/CMakeFiles/bustub_storage_page.dir/hash_table_bucket_page.cpp.obj -MF src\storage\page\CMakeFiles\bustub_storage_page.dir\hash_table_bucket_page.cpp.obj.d -o src/storage/page/CMakeFiles/bustub_storage_page.dir/hash_table_bucket_page.cpp.obj -c C:/Users/rayga/WindowsProjects/bustub/src/storage/page/hash_table_bucket_page.cpp
C:/Users/rayga/WindowsProjects/bustub/src/storage/page/hash_table_bucket_page.cpp:100:67: error: format specifies type 'unsigned long' but the argument has type 'unsigned long long' [-Werror,-Wformat]
  LOG_INFO("Bucket Capacity: %lu, Size: %u, Taken: %u, Free: %u", BUCKET_ARRAY_SIZE, size, taken, free);
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```