### PR TITLE
chore(build): discover tools after being installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,7 @@ enable_testing()
 # attempt to find the binary if user did not specify
 find_program(CLANG_FORMAT_BIN
         NAMES clang-format clang-format-12
-        HINTS ${BUSTUB_CLANG_SEARCH_PATH}
-        NO_CACHE)
+        HINTS ${BUSTUB_CLANG_SEARCH_PATH})
 
 if ("${CLANG_FORMAT_BIN}" STREQUAL "CLANG_FORMAT_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find clang-format.")
@@ -60,8 +59,7 @@ endif ()
 # attempt to find the binary if user did not specify
 find_program(CLANG_TIDY_BIN
         NAMES clang-tidy clang-tidy-12
-        HINTS ${BUSTUB_CLANG_SEARCH_PATH}
-        NO_CACHE)
+        HINTS ${BUSTUB_CLANG_SEARCH_PATH})
 
 if ("${CLANG_TIDY_BIN}" STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find clang-tidy.")
@@ -74,8 +72,7 @@ endif ()
 # cpplint
 find_program(CPPLINT_BIN
         NAMES cpplint cpplint.py
-        HINTS "${BUSTUB_BUILD_SUPPORT_DIR}"
-        NO_CACHE)
+        HINTS "${BUSTUB_BUILD_SUPPORT_DIR}")
 
 if ("${CPPLINT_BIN}" STREQUAL "CPPLINT_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find cpplint.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,25 +44,25 @@ endif ()
 enable_testing()
 
 # clang-format
-if (NOT DEFINED CLANG_FORMAT_BIN)
-    # attempt to find the binary if user did not specify
-    find_program(CLANG_FORMAT_BIN
-            NAMES clang-format clang-format-12
-            HINTS ${BUSTUB_CLANG_SEARCH_PATH})
-endif ()
+
+# attempt to find the binary if user did not specify
+find_program(CLANG_FORMAT_BIN
+        NAMES clang-format clang-format-12
+        HINTS ${BUSTUB_CLANG_SEARCH_PATH}
+        NO_CACHE)
+
 if ("${CLANG_FORMAT_BIN}" STREQUAL "CLANG_FORMAT_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find clang-format.")
 else ()
     message(STATUS "BusTub/main found clang-format at ${CLANG_FORMAT_BIN}")
 endif ()
 
-# clang-tidy
-if (NOT DEFINED CLANG_TIDY_BIN)
-    # attempt to find the binary if user did not specify
-    find_program(CLANG_TIDY_BIN
-            NAMES clang-tidy clang-tidy-12
-            HINTS ${BUSTUB_CLANG_SEARCH_PATH})
-endif ()
+# attempt to find the binary if user did not specify
+find_program(CLANG_TIDY_BIN
+        NAMES clang-tidy clang-tidy-12
+        HINTS ${BUSTUB_CLANG_SEARCH_PATH}
+        NO_CACHE)
+
 if ("${CLANG_TIDY_BIN}" STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find clang-tidy.")
 else ()
@@ -74,7 +74,9 @@ endif ()
 # cpplint
 find_program(CPPLINT_BIN
         NAMES cpplint cpplint.py
-        HINTS "${BUSTUB_BUILD_SUPPORT_DIR}")
+        HINTS "${BUSTUB_BUILD_SUPPORT_DIR}"
+        NO_CACHE)
+
 if ("${CPPLINT_BIN}" STREQUAL "CPPLINT_BIN-NOTFOUND")
     message(WARNING "BusTub/main couldn't find cpplint.")
 else ()


### PR DESCRIPTION
Students won't need to remove the build directory, though this is recommended.