### PR TITLE
chore(build): support thread sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,17 @@ endif ()
 # COMPILER SETUP
 ######################################################################################################################
 
+if(NOT BUSTUB_SANITIZER)
+    set(BUSTUB_SANITIZER address)
+endif()
+
+message("Build mode: ${CMAKE_BUILD_TYPE}")
+message("${BUSTUB_SANITIZER} sanitizer enabled in debug mode.")
+
 # Compiler flags.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-attributes") #TODO: remove
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -fsanitize=${BUSTUB_SANITIZER} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/README.md
+++ b/README.md
@@ -88,9 +88,17 @@ Debug mode:
 
 ```
 $ cmake -DCMAKE_BUILD_TYPE=Debug ..
-$ make
+$ make -j
 ```
-This enables [AddressSanitizer](https://github.com/google/sanitizers).
+This enables [AddressSanitizer](https://github.com/google/sanitizers) by default.
+
+If you want to use other sanitizers,
+
+
+```
+$ cmake -DCMAKE_BUILD_TYPE=Debug -DBUSTUB_SANITIZER=thread ..
+$ make -j
+```
 
 ### Windows (Not Guaranteed to Work)
 


### PR DESCRIPTION
Thread sanitizer can help check potential race conditions. By default, thread sanitizers print warnings. We can modify it to exit with code 1 if any race condition is detected in the future.

Instructions on enabling thread sanitizer is described in readme.

macOS users will need to use AppleClang to build thread sanitizer. So I'm going to change some descriptions in README and cmake build scripts to recommend macOS users to use AppleClang instead of homebrew clang if they want to use thread sanitizer.

close https://github.com/cmu-db/bustub/issues/288