### PR TITLE
feat(binder): bind join and cross join

### DIFF
--- a/src/binder/statement/select_statement.cpp
+++ b/src/binder/statement/select_statement.cpp
@@ -8,6 +8,8 @@
 #include "binder/expressions/bound_star.h"
 #include "binder/expressions/bound_unary_op.h"
 #include "binder/table_ref/bound_base_table_ref.h"
+#include "binder/table_ref/bound_cross_product_ref.h"
+#include "binder/table_ref/bound_join_ref.h"
 #include "binder/tokens.h"
 #include "catalog/catalog.h"
 #include "common/util/string_util.h"
@@ -24,29 +26,13 @@ SelectStatement::SelectStatement(const Catalog &catalog, duckdb_libpgquery::PGSe
       having_(std::make_unique<BoundExpression>()),
       catalog_(catalog) {
   // Bind FROM clause.
-  if (pg_stmt->fromClause != nullptr) {
-    // Extract the table name from the FROM clause.
-    for (auto c = pg_stmt->fromClause->head; c != nullptr; c = lnext(c)) {
-      auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
-      switch (node->type) {
-        case duckdb_libpgquery::T_PGRangeVar: {
-          auto *table_ref = reinterpret_cast<duckdb_libpgquery::PGRangeVar *>(node);
-          table_ = std::make_unique<BoundBaseTableRef>(table_ref->relname);
-          break;
-        }
-        default:
-          throw Exception(fmt::format("unsupported node type: {}", Binder::NodeTagToString(node->type)));
-      }
-    }
-  } else {
-    table_ = std::make_unique<BoundTableRef>(TableReferenceType::EMPTY);
-  }
+  table_ = BindFrom(pg_stmt->fromClause);
 
   // Bind SELECT list.
   if (pg_stmt->targetList != nullptr) {
     BindSelectList(pg_stmt->targetList);
   } else {
-    throw Exception("no select list");
+    throw bustub::Exception("no select list");
   }
 
   if (pg_stmt->whereClause != nullptr) {
@@ -67,6 +53,98 @@ SelectStatement::SelectStatement(const Catalog &catalog, duckdb_libpgquery::PGSe
   // in project write-ups / READMEs.
 }
 
+auto SelectStatement::BindFrom(duckdb_libpgquery::PGList *list) -> std::unique_ptr<BoundTableRef> {
+  if (list == nullptr) {
+    return std::make_unique<BoundTableRef>(TableReferenceType::EMPTY);
+  }
+  if (list->length > 1) {
+    // Bind cross join.
+
+    // Extract the first node.
+    auto c = list->head;
+    auto lnode = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
+    auto ltable = BindTableRef(lnode);
+    c = lnext(c);
+
+    // Extract the second node.
+    auto rnode = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
+    auto rtable = BindTableRef(rnode);
+    c = lnext(c);
+
+    auto result = std::make_unique<BoundCrossProductRef>(std::move(ltable), std::move(rtable));
+
+    // Extract the remaining nodes.
+    for (; c != nullptr; c = lnext(c)) {
+      auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
+      auto table = BindTableRef(node);
+      result = std::make_unique<BoundCrossProductRef>(std::move(result), std::move(table));
+    }
+
+    // The result bound tree will be like:
+    // ```
+    //     O
+    //    / \
+    //   O   3
+    //  / \
+    // 1   2
+    // ```
+
+    return result;
+  }
+
+  auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(list->head->data.ptr_value);
+  return BindTableRef(node);
+}
+
+auto SelectStatement::BindJoin(duckdb_libpgquery::PGJoinExpr *root) -> std::unique_ptr<BoundTableRef> {
+  JoinType join_type;
+  switch (root->jointype) {
+    case duckdb_libpgquery::PG_JOIN_INNER: {
+      join_type = JoinType::INNER;
+      break;
+    }
+    case duckdb_libpgquery::PG_JOIN_LEFT: {
+      join_type = JoinType::LEFT;
+      break;
+    }
+    case duckdb_libpgquery::PG_JOIN_FULL: {
+      join_type = JoinType::OUTER;
+      break;
+    }
+    case duckdb_libpgquery::PG_JOIN_RIGHT: {
+      join_type = JoinType::RIGHT;
+      break;
+    }
+    default: {
+      throw bustub::Exception(fmt::format("Join type {} not supported", static_cast<int>(root->jointype)));
+    }
+  }
+  auto left_table = BindTableRef(root->larg);
+  auto right_table = BindTableRef(root->rarg);
+  auto join_ref = std::make_unique<BoundJoinRef>(join_type, std::move(left_table), std::move(right_table), nullptr);
+  auto condition = BindExpressionWithScope(root->quals, *join_ref);
+  join_ref->condition_ = std::move(condition);
+  return join_ref;
+}
+
+auto SelectStatement::BindTableRef(duckdb_libpgquery::PGNode *node) -> std::unique_ptr<BoundTableRef> {
+  switch (node->type) {
+    case duckdb_libpgquery::T_PGRangeVar: {
+      auto *table_ref = reinterpret_cast<duckdb_libpgquery::PGRangeVar *>(node);
+      auto table_info = catalog_.GetTable(table_ref->relname);
+      if (table_info == nullptr) {
+        throw bustub::Exception(fmt::format("invalid table {}", table_ref->relname));
+      }
+      return std::make_unique<BoundBaseTableRef>(table_ref->relname, table_info->schema_);
+    }
+    case duckdb_libpgquery::T_PGJoinExpr: {
+      return BindJoin(reinterpret_cast<duckdb_libpgquery::PGJoinExpr *>(node));
+    }
+    default:
+      throw bustub::Exception(fmt::format("unsupported node type: {}", Binder::NodeTagToString(node->type)));
+  }
+}
+
 auto SelectStatement::ToString() const -> std::string {
   std::vector<std::string> columns;
   for (const auto &expr : select_list_) {
@@ -74,6 +152,34 @@ auto SelectStatement::ToString() const -> std::string {
   }
   return fmt::format("Select {{ table={}, columns=[{}], groupBy=[{}], having={}, where={} }}", table_,
                      fmt::join(columns, ", "), fmt::join(group_by_, ", "), having_, where_);
+}
+
+void SelectStatement::AddAllColumnsToList(const BoundTableRef &table_ref) {
+  switch (table_ref.type_) {
+    case TableReferenceType::BASE_TABLE: {
+      const auto &base_table_ref = dynamic_cast<const BoundBaseTableRef &>(table_ref);
+      const auto &table_name = base_table_ref.table_;
+      const auto &schema = base_table_ref.schema_;
+      for (const auto &column : schema.GetColumns()) {
+        select_list_.push_back(std::make_unique<BoundColumnRef>(table_name, column.GetName()));
+      }
+      return;
+    }
+    case TableReferenceType::CROSS_PRODUCT: {
+      const auto &cross_product_ref = dynamic_cast<const BoundCrossProductRef &>(table_ref);
+      AddAllColumnsToList(*cross_product_ref.left_);
+      AddAllColumnsToList(*cross_product_ref.right_);
+      return;
+    }
+    case TableReferenceType::JOIN: {
+      const auto &join_ref = dynamic_cast<const BoundJoinRef &>(table_ref);
+      AddAllColumnsToList(*join_ref.left_);
+      AddAllColumnsToList(*join_ref.right_);
+      return;
+    }
+    default:
+      throw bustub::Exception("select * cannot be used with this TableReferenceType");
+  }
 }
 
 void SelectStatement::BindSelectList(duckdb_libpgquery::PGList *list) {
@@ -87,28 +193,12 @@ void SelectStatement::BindSelectList(duckdb_libpgquery::PGList *list) {
     // Process `SELECT *`.
     if (expr->type_ == ExpressionType::STAR) {
       if (select_list_.empty()) {
-        switch (table_->type_) {
-          case TableReferenceType::BASE_TABLE: {
-            auto base_table_ref = dynamic_cast<BoundBaseTableRef *>(table_.get());
-            const auto &table_name = base_table_ref->table_;
-            auto table_info = catalog_.GetTable(table_name);
-            if (table_info == nullptr) {
-              throw Exception(fmt::format("invalid table {}", table_name));
-            }
-
-            for (const auto &column : table_info->schema_.GetColumns()) {
-              select_list_.push_back(std::make_unique<BoundColumnRef>(table_name, column.GetName()));
-            }
-            return;
-          }
-          default:
-            throw Exception("select * cannot be used with this TableReferenceType");
-        }
+        AddAllColumnsToList(*table_);
       } else {
-        throw Exception("select * cannot have other expressions in list");
+        throw bustub::Exception("select * cannot have other expressions in list");
       }
     } else {
-      select_list_.push_back(move(expr));
+      select_list_.push_back(std::move(expr));
     }
   }
 }
@@ -123,19 +213,20 @@ auto SelectStatement::BindConstant(duckdb_libpgquery::PGAConst *node) -> std::un
       bound_val = Value(TypeId::INTEGER, static_cast<int32_t>(val.val.ival));
       break;
     default:
-      throw Exception(fmt::format("unsupported pg value: {}", Binder::NodeTagToString(val.type)));
+      throw bustub::Exception(fmt::format("unsupported pg value: {}", Binder::NodeTagToString(val.type)));
   }
   return std::make_unique<BoundConstant>(std::move(bound_val));
 }
 
-auto SelectStatement::BindColumnRef(duckdb_libpgquery::PGColumnRef *node) -> std::unique_ptr<BoundExpression> {
+auto SelectStatement::BindColumnRef(duckdb_libpgquery::PGColumnRef *node, const bustub::BoundTableRef &scope)
+    -> std::unique_ptr<BoundExpression> {
   BUSTUB_ASSERT(node, "nullptr");
   auto fields = node->fields;
   auto head_node = static_cast<duckdb_libpgquery::PGNode *>(fields->head->data.ptr_value);
   switch (head_node->type) {
     case duckdb_libpgquery::T_PGString: {
       if (fields->length < 1) {
-        throw Exception("Unexpected field length");
+        throw bustub::Exception("Unexpected field length");
       }
       std::vector<std::string> column_names;
       for (auto node = fields->head; node != nullptr; node = node->next) {
@@ -143,19 +234,20 @@ auto SelectStatement::BindColumnRef(duckdb_libpgquery::PGColumnRef *node) -> std
       }
       if (column_names.size() == 1) {
         // Bind `SELECT col`.
-        return ResolveColumn(column_names[0]);
+        return ResolveColumn(scope, column_names);
       }
       if (column_names.size() == 2) {
         // Bind `SELECT table.col`.
-        return ResolveColumnWithTable(column_names[0], column_names[1]);
+        return ResolveColumn(scope, column_names);
       }
-      throw Exception(fmt::format("unsupported ColumnRef: zero or multiple elements found"));
+      throw bustub::Exception(fmt::format("unsupported ColumnRef: zero or multiple elements found"));
     }
     case duckdb_libpgquery::T_PGAStar: {
       return BindStar(reinterpret_cast<duckdb_libpgquery::PGAStar *>(head_node));
     }
     default:
-      throw Exception(fmt::format("ColumnRef type {} not implemented!", Binder::NodeTagToString(head_node->type)));
+      throw bustub::Exception(
+          fmt::format("ColumnRef type {} not implemented!", Binder::NodeTagToString(head_node->type)));
   }
 }
 
@@ -183,7 +275,7 @@ auto SelectStatement::BindFuncCall(duckdb_libpgquery::PGFuncCall *root) -> std::
   if (root->args != nullptr) {
     for (auto node = root->args->head; node != nullptr; node = node->next) {
       auto child_expr = BindExpression(static_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value));
-      children.push_back(move(child_expr));
+      children.push_back(std::move(child_expr));
     }
   }
 
@@ -197,76 +289,70 @@ auto SelectStatement::BindFuncCall(duckdb_libpgquery::PGFuncCall *root) -> std::
     // Bind function as agg call.
     return std::make_unique<BoundAggCall>(function_name, move(children));
   }
-  throw Exception(fmt::format("unsupported func call {}", function_name));
+  throw bustub::Exception(fmt::format("unsupported func call {}", function_name));
 }
 
-auto SelectStatement::ResolveColumn(const std::string &col_name) -> std::unique_ptr<BoundExpression> {
-  switch (table_->type_) {
+static auto ResolveColumnInternal(const BoundTableRef &table_ref, const std::vector<std::string> &col_name)
+    -> std::unique_ptr<BoundExpression> {
+  switch (table_ref.type_) {
     case TableReferenceType::BASE_TABLE: {
-      auto base_table_ref = dynamic_cast<BoundBaseTableRef *>(table_.get());
+      const auto &base_table_ref = dynamic_cast<const BoundBaseTableRef &>(table_ref);
       // TODO(chi): handle case-insensitive table / column names
-      const auto &table_name = base_table_ref->table_;
-      auto table_info = catalog_.GetTable(table_name);
-      if (table_info == nullptr) {
-        throw Exception(fmt::format("invalid table {}", table_name));
-      }
-      bool found = false;
+      const auto &table_name = base_table_ref.table_;
       auto expr = std::make_unique<BoundExpression>();
-      for (const auto &column : table_info->schema_.GetColumns()) {
-        auto name = column.GetName();
-        if (StringUtil::Lower(name) == col_name) {
-          if (!found) {
-            expr = std::make_unique<BoundColumnRef>(table_name, name);
-            found = true;
-          } else {
-            throw Exception(fmt::format("column {} appears in multiple tables", col_name));
+      for (const auto &column : base_table_ref.schema_.GetColumns()) {
+        auto table_col_name = column.GetName();
+        if (col_name.size() == 1) {
+          if (StringUtil::Lower(table_col_name) == col_name[0]) {
+            return std::make_unique<BoundColumnRef>(table_name, table_col_name);
           }
+        } else if (col_name.size() == 2) {
+          if (StringUtil::Lower(table_name) == col_name[0] && StringUtil::Lower(table_col_name) == col_name[1]) {
+            return std::make_unique<BoundColumnRef>(table_name, table_col_name);
+          }
+        } else {
+          throw Exception(fmt::format("unsupported column name: {}", fmt::join(col_name, ".")));
         }
       }
-      if (found) {
-        return expr;
+      return nullptr;
+    }
+    case TableReferenceType::CROSS_PRODUCT: {
+      const auto &cross_product_ref = dynamic_cast<const BoundCrossProductRef &>(table_ref);
+      auto left_column = ResolveColumnInternal(*cross_product_ref.left_, col_name);
+      auto right_column = ResolveColumnInternal(*cross_product_ref.right_, col_name);
+      if (left_column && right_column) {
+        throw Exception(fmt::format("{} is ambiguous", fmt::join(col_name, ".")));
       }
-      throw Exception(fmt::format("column {} not found", col_name));
+      if (left_column != nullptr) {
+        return left_column;
+      }
+      return right_column;
+    }
+    case TableReferenceType::JOIN: {
+      const auto &join_ref = dynamic_cast<const BoundJoinRef &>(table_ref);
+      auto left_column = ResolveColumnInternal(*join_ref.left_, col_name);
+      auto right_column = ResolveColumnInternal(*join_ref.right_, col_name);
+      if (left_column != nullptr && right_column != nullptr) {
+        throw Exception(fmt::format("{} is ambiguous", fmt::join(col_name, ".")));
+      }
+      if (left_column != nullptr) {
+        return left_column;
+      }
+      return right_column;
     }
     default:
-      throw Exception("unsupported TableReferenceType");
+      throw bustub::Exception("unsupported TableReferenceType");
   }
 }
 
-auto SelectStatement::ResolveColumnWithTable(const std::string &table_name, const std::string &col_name)
+auto SelectStatement::ResolveColumn(const BoundTableRef &table_ref, const std::vector<std::string> &col_name)
     -> std::unique_ptr<BoundExpression> {
-  switch (table_->type_) {
-    case TableReferenceType::BASE_TABLE: {
-      auto base_table_ref = dynamic_cast<BoundBaseTableRef *>(table_.get());
-      if (base_table_ref->table_ != table_name) {
-        throw Exception("table not in from clause");
-      }
-      break;
-    }
-    default:
-      throw Exception("unsupported TableReferenceType");
+  BUSTUB_ASSERT(!table_ref.IsInvalid(), "invalid table");
+  auto expr = ResolveColumnInternal(table_ref, col_name);
+  if (!expr) {
+    throw bustub::Exception(fmt::format("column {} not found", fmt::join(col_name, ".")));
   }
-  auto table_info = catalog_.GetTable(table_name);
-  if (table_info == nullptr) {
-    throw Exception(fmt::format("invalid table {}", table_name));
-  }
-  bool found = false;
-  auto expr = std::make_unique<BoundExpression>();
-  for (const auto &column : table_info->schema_.GetColumns()) {
-    auto name = column.GetName();
-    if (StringUtil::Lower(name) == col_name) {
-      if (!found) {
-        expr = std::make_unique<BoundColumnRef>(table_name, name);
-        found = true;
-      } else {
-        throw Exception(fmt::format("column {} appears in multiple tables", col_name));
-      }
-    }
-  }
-  if (found) {
-    return expr;
-  }
-  throw Exception(fmt::format("column {} not found", col_name));
+  return expr;
 }
 
 void SelectStatement::BindWhere(duckdb_libpgquery::PGNode *root) { where_ = BindExpression(root); }
@@ -280,38 +366,44 @@ void SelectStatement::BindGroupBy(duckdb_libpgquery::PGList *list) {
 
 void SelectStatement::BindHaving(duckdb_libpgquery::PGNode *root) { having_ = BindExpression(root); }
 
-auto SelectStatement::BindAExpr(duckdb_libpgquery::PGAExpr *root) -> std::unique_ptr<BoundExpression> {
+auto SelectStatement::BindAExpr(duckdb_libpgquery::PGAExpr *root, const bustub::BoundTableRef &scope)
+    -> std::unique_ptr<BoundExpression> {
   BUSTUB_ASSERT(root, "nullptr");
   auto name = std::string((reinterpret_cast<duckdb_libpgquery::PGValue *>(root->name->head->data.ptr_value))->val.str);
 
   if (root->kind != duckdb_libpgquery::PG_AEXPR_OP) {
-    throw Exception("unsupported op in AExpr");
+    throw bustub::Exception("unsupported op in AExpr");
   }
 
   std::unique_ptr<BoundExpression> left_expr = nullptr;
   std::unique_ptr<BoundExpression> right_expr = nullptr;
 
   if (root->lexpr != nullptr) {
-    left_expr = BindExpression(root->lexpr);
+    left_expr = BindExpressionWithScope(root->lexpr, scope);
   }
   if (root->rexpr != nullptr) {
-    right_expr = BindExpression(root->rexpr);
+    right_expr = BindExpressionWithScope(root->rexpr, scope);
   }
 
   if (left_expr && right_expr) {
-    return std::make_unique<BoundBinaryOp>(name, move(left_expr), move(right_expr));
+    return std::make_unique<BoundBinaryOp>(name, std::move(left_expr), std::move(right_expr));
   }
   if (!left_expr && right_expr) {
-    return std::make_unique<BoundUnaryOp>(name, move(right_expr));
+    return std::make_unique<BoundUnaryOp>(name, std::move(right_expr));
   }
-  throw Exception("unsupported AExpr: left == null while right != null");
+  throw bustub::Exception("unsupported AExpr: left == null while right != null");
 }
 
 auto SelectStatement::BindExpression(duckdb_libpgquery::PGNode *node) -> std::unique_ptr<BoundExpression> {
+  return BindExpressionWithScope(node, *table_);
+}
+
+auto SelectStatement::BindExpressionWithScope(duckdb_libpgquery::PGNode *node, const bustub::BoundTableRef &scope)
+    -> std::unique_ptr<BoundExpression> {
   BUSTUB_ASSERT(node, "nullptr");
   switch (node->type) {
     case duckdb_libpgquery::T_PGColumnRef:
-      return BindColumnRef(reinterpret_cast<duckdb_libpgquery::PGColumnRef *>(node));
+      return BindColumnRef(reinterpret_cast<duckdb_libpgquery::PGColumnRef *>(node), scope);
     case duckdb_libpgquery::T_PGAConst:
       return BindConstant(reinterpret_cast<duckdb_libpgquery::PGAConst *>(node));
     case duckdb_libpgquery::T_PGResTarget:
@@ -321,9 +413,9 @@ auto SelectStatement::BindExpression(duckdb_libpgquery::PGNode *node) -> std::un
     case duckdb_libpgquery::T_PGFuncCall:
       return BindFuncCall(reinterpret_cast<duckdb_libpgquery::PGFuncCall *>(node));
     case duckdb_libpgquery::T_PGAExpr:
-      return BindAExpr(reinterpret_cast<duckdb_libpgquery::PGAExpr *>(node));
+      return BindAExpr(reinterpret_cast<duckdb_libpgquery::PGAExpr *>(node), scope);
     default:
-      throw Exception(fmt::format("Expr of type {} not implemented", Binder::NodeTagToString(node->type)));
+      throw bustub::Exception(fmt::format("Expr of type {} not implemented", Binder::NodeTagToString(node->type)));
   }
 }
 

--- a/src/binder/statement/select_statement.cpp
+++ b/src/binder/statement/select_statement.cpp
@@ -80,15 +80,16 @@ auto SelectStatement::BindFrom(duckdb_libpgquery::PGList *list) -> std::unique_p
       result = std::make_unique<BoundCrossProductRef>(std::move(result), std::move(table));
     }
 
-    // The result bound tree will be like:
-    // ```
-    //     O
-    //    / \
-    //   O   3
-    //  / \
-    // 1   2
-    // ```
-
+    /**
+     * The result bound tree will be like:
+     * ```
+     *     O
+     *    / \
+     *   O   3
+     *  / \
+     * 1   2
+     * ```
+     */
     return result;
   }
 

--- a/src/include/binder/bound_expression.h
+++ b/src/include/binder/bound_expression.h
@@ -32,7 +32,7 @@ class BoundExpression {
 
   virtual auto ToString() const -> std::string { return "<invalid>"; };
 
-  auto IsInvalid() -> bool { return type_ == ExpressionType::INVALID; }
+  auto IsInvalid() const -> bool { return type_ == ExpressionType::INVALID; }
 
   /** The type of this expression. */
   ExpressionType type_{ExpressionType::INVALID};

--- a/src/include/binder/bound_table_ref.h
+++ b/src/include/binder/bound_table_ref.h
@@ -39,6 +39,8 @@ class BoundTableRef {
     }
   }
 
+  auto IsInvalid() const -> bool { return type_ == TableReferenceType::INVALID; }
+
   /** The type of table reference. */
   TableReferenceType type_{TableReferenceType::INVALID};
 };

--- a/src/include/binder/statement/select_statement.h
+++ b/src/include/binder/statement/select_statement.h
@@ -24,6 +24,7 @@ struct PGNode;
 struct PGColumnRef;
 struct PGResTarget;
 struct PGAExpr;
+struct PGJoinExpr;
 }  // namespace duckdb_libpgquery
 
 namespace bustub {
@@ -49,9 +50,13 @@ class SelectStatement : public BoundStatement {
 
   auto BindExpression(duckdb_libpgquery::PGNode *node) -> std::unique_ptr<BoundExpression>;
 
+  auto BindExpressionWithScope(duckdb_libpgquery::PGNode *node, const BoundTableRef &scope)
+      -> std::unique_ptr<BoundExpression>;
+
   auto BindConstant(duckdb_libpgquery::PGAConst *node) -> std::unique_ptr<BoundExpression>;
 
-  auto BindColumnRef(duckdb_libpgquery::PGColumnRef *node) -> std::unique_ptr<BoundExpression>;
+  auto BindColumnRef(duckdb_libpgquery::PGColumnRef *node, const bustub::BoundTableRef &scope)
+      -> std::unique_ptr<BoundExpression>;
 
   auto BindResTarget(duckdb_libpgquery::PGResTarget *root) -> std::unique_ptr<BoundExpression>;
 
@@ -59,11 +64,18 @@ class SelectStatement : public BoundStatement {
 
   auto BindFuncCall(duckdb_libpgquery::PGFuncCall *root) -> std::unique_ptr<BoundExpression>;
 
-  auto BindAExpr(duckdb_libpgquery::PGAExpr *root) -> std::unique_ptr<BoundExpression>;
+  auto BindAExpr(duckdb_libpgquery::PGAExpr *root, const bustub::BoundTableRef &scope)
+      -> std::unique_ptr<BoundExpression>;
 
-  auto ResolveColumn(const std::string &col_name) -> std::unique_ptr<BoundExpression>;
+  auto BindFrom(duckdb_libpgquery::PGList *list) -> std::unique_ptr<BoundTableRef>;
 
-  auto ResolveColumnWithTable(const std::string &table_name, const std::string &col_name)
+  auto BindTableRef(duckdb_libpgquery::PGNode *node) -> std::unique_ptr<BoundTableRef>;
+
+  auto BindJoin(duckdb_libpgquery::PGJoinExpr *root) -> std::unique_ptr<BoundTableRef>;
+
+  void AddAllColumnsToList(const BoundTableRef &table_ref);
+
+  auto ResolveColumn(const BoundTableRef &table_ref, const std::vector<std::string> &col_name)
       -> std::unique_ptr<BoundExpression>;
 
   /** Bound FROM clause. */

--- a/src/include/binder/table_ref/bound_base_table_ref.h
+++ b/src/include/binder/table_ref/bound_base_table_ref.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include "binder/bound_table_ref.h"
+#include "catalog/schema.h"
 #include "fmt/core.h"
 
 namespace bustub {
@@ -12,12 +13,15 @@ namespace bustub {
  */
 class BoundBaseTableRef : public BoundTableRef {
  public:
-  explicit BoundBaseTableRef(std::string table)
-      : BoundTableRef(TableReferenceType::BASE_TABLE), table_(std::move(table)) {}
+  explicit BoundBaseTableRef(std::string table, Schema schema)
+      : BoundTableRef(TableReferenceType::BASE_TABLE), table_(std::move(table)), schema_(std::move(schema)) {}
 
   auto ToString() const -> std::string override { return fmt::format("BoundBaseTableRef {{ table={} }}", table_); }
 
   /** The name of the table. */
   std::string table_;
+
+  /** The schema of the table. */
+  Schema schema_;
 };
 }  // namespace bustub

--- a/src/include/binder/table_ref/bound_cross_product_ref.h
+++ b/src/include/binder/table_ref/bound_cross_product_ref.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "binder/bound_table_ref.h"
+#include "fmt/core.h"
+
+namespace bustub {
+
+/**
+ * A cross product. e.g., `SELECT * FROM x, y`, where `x, y` is `CrossProduct`.
+ */
+class BoundCrossProductRef : public BoundTableRef {
+ public:
+  explicit BoundCrossProductRef(std::unique_ptr<BoundTableRef> left, std::unique_ptr<BoundTableRef> right)
+      : BoundTableRef(TableReferenceType::CROSS_PRODUCT), left_(std::move(left)), right_(std::move(right)) {}
+
+  auto ToString() const -> std::string override {
+    return fmt::format("BoundCrossProductRef {{ left={}, right={} }}", left_, right_);
+  }
+
+  /** The left side of the cross product. */
+  std::unique_ptr<BoundTableRef> left_;
+
+  /** The right side of the cross product. */
+  std::unique_ptr<BoundTableRef> right_;
+};
+}  // namespace bustub

--- a/src/include/binder/table_ref/bound_join_ref.h
+++ b/src/include/binder/table_ref/bound_join_ref.h
@@ -47,7 +47,7 @@ class BoundJoinRef : public BoundTableRef {
   /** The right side of the join. */
   std::unique_ptr<BoundTableRef> right_;
 
-  /** Join condition */
+  /** Join condition. */
   std::unique_ptr<BoundExpression> condition_;
 };
 }  // namespace bustub

--- a/src/include/binder/table_ref/bound_join_ref.h
+++ b/src/include/binder/table_ref/bound_join_ref.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "binder/bound_expression.h"
+#include "binder/bound_table_ref.h"
+#include "fmt/core.h"
+
+namespace bustub {
+
+/**
+ * Join types.
+ */
+enum class JoinType : uint8_t {
+  INVALID = 0, /**< Invalid join type. */
+  LEFT = 1,    /**< Left join. */
+  RIGHT = 3,   /**< Right join. */
+  INNER = 4,   /**< Inner join. */
+  OUTER = 5    /**< Outer join. */
+};
+
+/**
+ * A join. e.g., `SELECT * FROM x INNER JOIN y ON ...`, where `x INNER JOIN y ON ...` is `BoundJoinRef`.
+ */
+class BoundJoinRef : public BoundTableRef {
+ public:
+  explicit BoundJoinRef(JoinType join_type, std::unique_ptr<BoundTableRef> left, std::unique_ptr<BoundTableRef> right,
+                        std::unique_ptr<BoundExpression> condition)
+      : BoundTableRef(TableReferenceType::JOIN),
+        join_type_(join_type),
+        left_(std::move(left)),
+        right_(std::move(right)),
+        condition_(std::move(condition)) {}
+
+  auto ToString() const -> std::string override {
+    return fmt::format("BoundJoin {{ type={}, left={}, right={}, condition={} }}", type_, left_, right_, condition_);
+  }
+
+  /** Type of join. */
+  JoinType join_type_;
+
+  /** The left side of the join. */
+  std::unique_ptr<BoundTableRef> left_;
+
+  /** The right side of the join. */
+  std::unique_ptr<BoundTableRef> right_;
+
+  /** Join condition */
+  std::unique_ptr<BoundExpression> condition_;
+};
+}  // namespace bustub
+
+template <>
+struct fmt::formatter<bustub::JoinType> : formatter<string_view> {
+  template <typename FormatContext>
+  auto format(bustub::JoinType c, FormatContext &ctx) const {
+    string_view name;
+    switch (c) {
+      case bustub::JoinType::INVALID:
+        name = "Invalid";
+        break;
+      case bustub::JoinType::LEFT:
+        name = "Left";
+        break;
+      case bustub::JoinType::RIGHT:
+        name = "Right";
+        break;
+      case bustub::JoinType::INNER:
+        name = "Inner";
+        break;
+      case bustub::JoinType::OUTER:
+        name = "Outer";
+        break;
+      default:
+        name = "Unknown";
+        break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,10 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
     gtest_discover_tests(${bustub_test_name}
             EXTRA_ARGS
             --gtest_color=yes
-            --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${bustub_test_name}.xml)
+            --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${bustub_test_name}.xml
+            --gtest_catch_exceptions=0
+            )
+    
     target_link_libraries(${bustub_test_name} bustub gtest gmock_main)
 
     # Set test target properties and dependencies.

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -86,14 +86,12 @@ TEST(BinderTest, BindAgg) {
   PrintStatements(statements);
 }
 
-// TODO(chi): join is not supported yet
-TEST(BinderTest, DISABLED_BindCrossJoin) {
+TEST(BinderTest, BindCrossJoin) {
   auto statements = TryBind("select * from a, b where a.x = b.y");
   PrintStatements(statements);
 }
 
-// TODO(chi): join is not supported yet
-TEST(BinderTest, DISABLED_BindJoin) {
+TEST(BinderTest, BindJoin) {
   auto statements = TryBind("select * from a INNER JOIN b ON a.x = b.y");
   PrintStatements(statements);
 }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

In this PR, we added support for bind `from A inner join B on Condition` and `from A, B where Condition`.