### PR TITLE
chore(type): use snprintf instead of sprint

### DIFF
--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -114,11 +114,11 @@ auto TimestampType::ToString(const Value &val) const -> std::string {
   auto day = static_cast<uint16_t>(tm % 32);
   tm /= 32;
   auto month = static_cast<uint16_t>(tm);
-  const size_t dateStrLen = 30;
-  const size_t zoneLen = 5;
-  char str[dateStrLen];
-  char zone[zoneLen];
-  snprintf(str, dateStrLen, "%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, min, sec, micro);
+  const size_t date_str_len = 30;
+  const size_t zone_len = 5;
+  char str[date_str_len];
+  char zone[zone_len];
+  snprintf(str, date_str_len, "%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, min, sec, micro);
   if (tz >= 0) {
     str[26] = '+';
   } else {
@@ -127,7 +127,7 @@ auto TimestampType::ToString(const Value &val) const -> std::string {
   if (tz < 0) {
     tz = -tz;
   }
-  snprintf(zone, zoneLen, "%02d", tz);  // NOLINT
+  snprintf(zone, zone_len, "%02d", tz);  // NOLINT
   str[27] = 0;
   return std::string(std::string(str) + std::string(zone));
 }

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -114,9 +114,11 @@ auto TimestampType::ToString(const Value &val) const -> std::string {
   auto day = static_cast<uint16_t>(tm % 32);
   tm /= 32;
   auto month = static_cast<uint16_t>(tm);
-  char str[30];
-  char zone[5];
-  sprintf(str, "%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, min, sec, micro);  // NOLINT
+  const size_t dateStrLen = 30;
+  const size_t zoneLen = 5;
+  char str[dateStrLen];
+  char zone[zoneLen];
+  snprintf(str, dateStrLen, "%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, min, sec, micro);
   if (tz >= 0) {
     str[26] = '+';
   } else {
@@ -125,7 +127,7 @@ auto TimestampType::ToString(const Value &val) const -> std::string {
   if (tz < 0) {
     tz = -tz;
   }
-  sprintf(zone, "%02d", tz);  // NOLINT
+  snprintf(zone, zoneLen, "%02d", tz);  // NOLINT
   str[27] = 0;
   return std::string(std::string(str) + std::string(zone));
 }


### PR DESCRIPTION
timestamp_type.cpp should use snprintf, not sprintf #322. This change allows building on recent versions of MacOS, and should be safer besides.

close #322
