### PR TITLE
feat(binder): bind and plan alias

### DIFF
--- a/src/binder/bind_select.cpp
+++ b/src/binder/bind_select.cpp
@@ -4,6 +4,7 @@
 #include "binder/bound_expression.h"
 #include "binder/bound_statement.h"
 #include "binder/expressions/bound_agg_call.h"
+#include "binder/expressions/bound_alias.h"
 #include "binder/expressions/bound_binary_op.h"
 #include "binder/expressions/bound_column_ref.h"
 #include "binder/expressions/bound_constant.h"
@@ -292,6 +293,9 @@ auto Binder::BindResTarget(duckdb_libpgquery::PGResTarget *root) -> std::unique_
   auto expr = BindExpression(root->val);
   if (!expr) {
     return nullptr;
+  }
+  if (root->name != nullptr) {
+    return std::make_unique<BoundAlias>(root->name, std::move(expr));
   }
   return expr;
 }

--- a/src/include/binder/bound_expression.h
+++ b/src/include/binder/bound_expression.h
@@ -18,7 +18,8 @@ enum class ExpressionType : uint8_t {
   AGG_CALL = 6,   /**< Aggregation function expression type. */
   STAR = 7,       /**< Star expression type, will be rewritten by binder and won't appear in plan. */
   UNARY_OP = 8,   /**< Unary expression type. */
-  BINARY_OP = 9   /**< Binary expression type. */
+  BINARY_OP = 9,  /**< Binary expression type. */
+  ALIAS = 10,     /**< Alias expression type. */
 };
 
 /**
@@ -90,6 +91,9 @@ struct fmt::formatter<bustub::ExpressionType> : formatter<string_view> {
         break;
       case bustub::ExpressionType::BINARY_OP:
         name = "BinaryOperation";
+        break;
+      case bustub::ExpressionType::ALIAS:
+        name = "Alias";
         break;
       default:
         name = "Unknown";

--- a/src/include/binder/expressions/bound_alias.h
+++ b/src/include/binder/expressions/bound_alias.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include "binder/bound_expression.h"
+
+namespace bustub {
+
+/**
+ * The alias in SELECT list, e.g. `SELECT count(x) AS y`, the `y` is an alias.
+ */
+class BoundAlias : public BoundExpression {
+ public:
+  explicit BoundAlias(std::string alias, std::unique_ptr<BoundExpression> child)
+      : BoundExpression(ExpressionType::ALIAS), alias_(std::move(alias)), child_(std::move(child)) {}
+
+  auto ToString() const -> std::string override { return fmt::format("({} as {})", child_, alias_); }
+
+  /** Alias name. */
+  std::string alias_;
+
+  /** The actual expression */
+  std::unique_ptr<BoundExpression> child_;
+};
+}  // namespace bustub

--- a/src/planner/plan_expression.cpp
+++ b/src/planner/plan_expression.cpp
@@ -2,6 +2,7 @@
 #include "binder/bound_expression.h"
 #include "binder/bound_statement.h"
 #include "binder/expressions/bound_agg_call.h"
+#include "binder/expressions/bound_alias.h"
 #include "binder/expressions/bound_binary_op.h"
 #include "binder/expressions/bound_column_ref.h"
 #include "binder/expressions/bound_constant.h"
@@ -133,6 +134,11 @@ auto Planner::PlanExpression(const BoundExpression &expr, const std::vector<cons
     case ExpressionType::CONSTANT: {
       const auto &constant_expr = dynamic_cast<const BoundConstant &>(expr);
       return std::make_tuple(unnamed_column, PlanConstant(constant_expr, children));
+    }
+    case ExpressionType::ALIAS: {
+      const auto &alias_expr = dynamic_cast<const BoundAlias &>(expr);
+      auto [_1, expr] = PlanExpression(*alias_expr.child_, children);
+      return std::make_tuple(alias_expr.alias_, std::move(expr));
     }
     default:
       break;


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

```
SELECT colA as a from __mock_table_1
```

now can be correctly planned. The output column will also have `a` name.

The issue is, we cannot do planning like:

```
SELECT colA as a from __mock_table_1 where a > 10
```

That's because `where` planning is using the scope of `from` clause (__mock_table_1), which absolutely doesn't have the a column. We should make `SELECT colA as a from __mock_table_1` a kind of table function when binding and planning.

If we make `select` a table function, we can also easily do uncorrelated subquery. I'm thinking whether we can do this in fall 2022.