### PR TITLE
feat(binder): bind insert and values

### DIFF
--- a/src/binder/CMakeLists.txt
+++ b/src/binder/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   OBJECT
   binder.cpp
   bind_create.cpp
+  bind_insert.cpp
   bind_select.cpp
   bound_statement.cpp
   fmt_impl.cpp

--- a/src/binder/bind_insert.cpp
+++ b/src/binder/bind_insert.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+// Copyright 2018-2022 Stichting DuckDB Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice (including the next paragraph)
+// shall be included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//===----------------------------------------------------------------------===//
+
+#include <iterator>
+#include <memory>
+#include <string>
+
+#include "binder/binder.h"
+#include "binder/statement/insert_statement.h"
+#include "common/exception.h"
+#include "common/util/string_util.h"
+#include "nodes/parsenodes.hpp"
+
+namespace bustub {
+
+auto Binder::BindInsert(duckdb_libpgquery::PGInsertStmt *pg_stmt) -> std::unique_ptr<InsertStatement> {
+  if (pg_stmt->cols != nullptr) {
+    throw NotImplementedException("insert only supports all columns, don't specify columns");
+  }
+
+  auto table_name = std::string(pg_stmt->relation->relname);
+
+  auto table_info = catalog_.GetTable(table_name);
+  if (table_info == nullptr || StringUtil::StartsWith(table_name, "__")) {
+    throw bustub::Exception(fmt::format("invalid table for insert: {}", table_name));
+  }
+
+  auto select_statement = BindSelect(reinterpret_cast<duckdb_libpgquery::PGSelectStmt *>(pg_stmt->selectStmt));
+
+  return std::make_unique<InsertStatement>(table_name, std::move(select_statement));
+}
+
+}  // namespace bustub

--- a/src/binder/bind_insert.cpp
+++ b/src/binder/bind_insert.cpp
@@ -25,7 +25,10 @@
 #include <string>
 
 #include "binder/binder.h"
+#include "binder/bound_expression.h"
+#include "binder/bound_table_ref.h"
 #include "binder/statement/insert_statement.h"
+#include "binder/statement/select_statement.h"
 #include "common/exception.h"
 #include "common/util/string_util.h"
 #include "nodes/parsenodes.hpp"

--- a/src/binder/fmt_impl.cpp
+++ b/src/binder/fmt_impl.cpp
@@ -1,6 +1,14 @@
 #include "binder/expressions/bound_agg_call.h"
+#include "binder/table_ref/bound_expression_list_ref.h"
 #include "fmt/format.h"
+#include "fmt/ranges.h"
 
 namespace bustub {
-auto BoundAggCall::ToString() const -> std::string { return fmt::format("{}({})", func_name_, fmt::join(args_, ", ")); }
+
+auto BoundAggCall::ToString() const -> std::string { return fmt::format("{}({})", func_name_, args_); }
+
+auto BoundExpressionListRef::ToString() const -> std::string {
+  return fmt::format("BoundExpressionListRef {{ values={} }}", values_);
+}
+
 }  // namespace bustub

--- a/src/binder/statement/insert_statement.cpp
+++ b/src/binder/statement/insert_statement.cpp
@@ -1,10 +1,29 @@
+#include "fmt/ranges.h"
+
+#include "binder/bound_expression.h"
+#include "binder/bound_table_ref.h"
 #include "binder/statement/insert_statement.h"
+#include "binder/statement/select_statement.h"
+#include "common/util/string_util.h"
 
 namespace bustub {
 
-InsertStatement::InsertStatement(duckdb_libpgquery::PGInsertStmt *pg_stmt)
-    : BoundStatement(StatementType::INSERT_STATEMENT) {}
+auto IndentAllLines(const std::string &lines, size_t num_indent) -> std::string {
+  std::vector<std::string> lines_str;
+  auto lines_split = StringUtil::Split(lines, '\n');
+  lines_str.reserve(lines_split.size());
+  auto indent_str = StringUtil::Indent(num_indent);
+  for (auto &line : lines_split) {
+    lines_str.push_back(fmt::format("{}{}", indent_str, line));
+  }
+  return fmt::format("\n{}", fmt::join(lines_str, "\n"));
+}
 
-auto InsertStatement::ToString() const -> std::string { return {}; }
+InsertStatement::InsertStatement(std::string table, std::unique_ptr<SelectStatement> select)
+    : BoundStatement(StatementType::INSERT_STATEMENT), table_(std::move(table)), select_(std::move(select)) {}
+
+auto InsertStatement::ToString() const -> std::string {
+  return fmt::format("BoundInsert {{\n  table={},\n  select={}\n}}", table_, IndentAllLines(select_->ToString(), 2));
+}
 
 }  // namespace bustub

--- a/src/binder/statement/insert_statement.cpp
+++ b/src/binder/statement/insert_statement.cpp
@@ -8,22 +8,12 @@
 
 namespace bustub {
 
-auto IndentAllLines(const std::string &lines, size_t num_indent) -> std::string {
-  std::vector<std::string> lines_str;
-  auto lines_split = StringUtil::Split(lines, '\n');
-  lines_str.reserve(lines_split.size());
-  auto indent_str = StringUtil::Indent(num_indent);
-  for (auto &line : lines_split) {
-    lines_str.push_back(fmt::format("{}{}", indent_str, line));
-  }
-  return fmt::format("\n{}", fmt::join(lines_str, "\n"));
-}
-
 InsertStatement::InsertStatement(std::string table, std::unique_ptr<SelectStatement> select)
     : BoundStatement(StatementType::INSERT_STATEMENT), table_(std::move(table)), select_(std::move(select)) {}
 
 auto InsertStatement::ToString() const -> std::string {
-  return fmt::format("BoundInsert {{\n  table={},\n  select={}\n}}", table_, IndentAllLines(select_->ToString(), 2));
+  return fmt::format("BoundInsert {{\n  table={},\n  select={}\n}}", table_,
+                     StringUtil::IndentAllLines(select_->ToString(), 2));
 }
 
 }  // namespace bustub

--- a/src/binder/transformer.cpp
+++ b/src/binder/transformer.cpp
@@ -58,7 +58,7 @@ auto Binder::TransformStatement(duckdb_libpgquery::PGNode *stmt) -> std::unique_
     case duckdb_libpgquery::T_PGCreateStmt:
       return BindCreate(reinterpret_cast<duckdb_libpgquery::PGCreateStmt *>(stmt));
     case duckdb_libpgquery::T_PGInsertStmt:
-      return std::make_unique<InsertStatement>(reinterpret_cast<duckdb_libpgquery::PGInsertStmt *>(stmt));
+      return BindInsert(reinterpret_cast<duckdb_libpgquery::PGInsertStmt *>(stmt));
     case duckdb_libpgquery::T_PGSelectStmt:
       return BindSelect(reinterpret_cast<duckdb_libpgquery::PGSelectStmt *>(stmt));
     case duckdb_libpgquery::T_PGDeleteStmt:

--- a/src/common/util/string_util.cpp
+++ b/src/common/util/string_util.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "common/util/string_util.h"
+#include "fmt/format.h"
 
 namespace bustub {
 
@@ -205,6 +206,17 @@ auto StringUtil::Replace(std::string source, const std::string &from, const std:
                                // replacing 'x' with 'yx'
   }
   return source;
+}
+
+auto StringUtil::IndentAllLines(const std::string &lines, size_t num_indent) -> std::string {
+  std::vector<std::string> lines_str;
+  auto lines_split = StringUtil::Split(lines, '\n');
+  lines_str.reserve(lines_split.size());
+  auto indent_str = StringUtil::Indent(num_indent);
+  for (auto &line : lines_split) {
+    lines_str.push_back(fmt::format("{}{}", indent_str, line));
+  }
+  return fmt::format("\n{}", fmt::join(lines_str, "\n"));
 }
 
 }  // namespace bustub

--- a/src/execution/fmt_impl.cpp
+++ b/src/execution/fmt_impl.cpp
@@ -15,7 +15,7 @@ auto AbstractPlanNode::ChildrenToString(int indent) const -> std::string {
   }
   std::vector<std::string> children_str;
   children_str.reserve(children_.size());
-  std::string indent_str(indent, ' ');
+  auto indent_str = StringUtil::Indent(indent);
   for (const auto &child : children_) {
     auto child_str = child->ToString();
     auto lines = StringUtil::Split(child_str, '\n');

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -46,10 +46,15 @@
 
 #include "binder/tokens.h"
 #include "catalog/catalog.h"
+#include "catalog/column.h"
+#include "common/macros.h"
 #include "common/util/string_util.h"
 #include "fmt/format.h"
+#include "nodes/parsenodes.hpp"
 #include "pg_definitions.hpp"
 #include "postgres_parser.hpp"
+#include "type/type_id.h"
+#include "type/value.h"
 
 namespace duckdb_libpgquery {
 struct PGList;
@@ -151,6 +156,10 @@ class Binder {
 
   auto ResolveColumn(const BoundTableRef &scope, const std::vector<std::string> &col_name)
       -> std::unique_ptr<BoundExpression>;
+
+  auto BindInsert(duckdb_libpgquery::PGInsertStmt *pg_stmt) -> std::unique_ptr<InsertStatement>;
+
+  auto BindValuesList(duckdb_libpgquery::PGList *list) -> std::unique_ptr<BoundExpressionListRef>;
 
   class ContextGuard {
    public:

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -37,13 +37,6 @@
 #include <string>
 
 #include "binder/simplified_token.h"
-#include "binder/statement/create_statement.h"
-#include "catalog/column.h"
-#include "common/macros.h"
-#include "nodes/parsenodes.hpp"
-#include "type/type_id.h"
-#include "type/value.h"
-
 #include "binder/tokens.h"
 #include "catalog/catalog.h"
 #include "catalog/column.h"
@@ -72,10 +65,12 @@ struct PGJoinExpr;
 namespace bustub {
 
 class Catalog;
-
 class BoundExpression;
 class BoundTableRef;
 class BoundExpression;
+class BoundExpressionListRef;
+class SelectStatement;
+class CreateStatement;
 
 /**
  * The binder is responsible for transforming the Postgres parse tree to a binder tree

--- a/src/include/binder/bound_expression.h
+++ b/src/include/binder/bound_expression.h
@@ -31,7 +31,7 @@ class BoundExpression {
   BoundExpression() = default;
   virtual ~BoundExpression() = default;
 
-  virtual auto ToString() const -> std::string { return "<invalid>"; };
+  virtual auto ToString() const -> std::string { return ""; };
 
   auto IsInvalid() const -> bool { return type_ == ExpressionType::INVALID; }
 

--- a/src/include/binder/bound_table_ref.h
+++ b/src/include/binder/bound_table_ref.h
@@ -13,11 +13,12 @@ namespace bustub {
  * Table reference types.
  */
 enum class TableReferenceType : uint8_t {
-  INVALID = 0,       /**< Invalid table reference type. */
-  BASE_TABLE = 1,    /**< Base table reference. */
-  JOIN = 3,          /**< Output of join. */
-  CROSS_PRODUCT = 4, /**< Output of cartesian product. */
-  EMPTY = 8          /**< Placeholder for empty FROM. */
+  INVALID = 0,         /**< Invalid table reference type. */
+  BASE_TABLE = 1,      /**< Base table reference. */
+  JOIN = 3,            /**< Output of join. */
+  CROSS_PRODUCT = 4,   /**< Output of cartesian product. */
+  EXPRESSION_LIST = 5, /**< Values clause. */
+  EMPTY = 8            /**< Placeholder for empty FROM. */
 };
 
 /**
@@ -32,7 +33,7 @@ class BoundTableRef {
   virtual auto ToString() const -> std::string {
     switch (type_) {
       case TableReferenceType::INVALID:
-        return "<invalid>";
+        return "";
       case TableReferenceType::EMPTY:
         return "<empty>";
       default:
@@ -87,6 +88,9 @@ struct fmt::formatter<bustub::TableReferenceType> : formatter<string_view> {
         break;
       case bustub::TableReferenceType::EMPTY:
         name = "Empty";
+        break;
+      case bustub::TableReferenceType::EXPRESSION_LIST:
+        name = "ExpressionList";
         break;
       default:
         name = "Unknown";

--- a/src/include/binder/statement/insert_statement.h
+++ b/src/include/binder/statement/insert_statement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -20,13 +21,14 @@ struct PGInsertStmt;
 
 namespace bustub {
 
+class SelectStatement;
+
 class InsertStatement : public BoundStatement {
  public:
-  explicit InsertStatement(duckdb_libpgquery::PGInsertStmt *pg_stmt);
+  explicit InsertStatement(std::string table, std::unique_ptr<SelectStatement> select);
 
   std::string table_;
-  std::vector<Column> columns_;
-  std::vector<std::vector<Value>> values_;
+  std::unique_ptr<SelectStatement> select_;
 
   auto ToString() const -> std::string override;
 };

--- a/src/include/binder/table_ref/bound_expression_list_ref.h
+++ b/src/include/binder/table_ref/bound_expression_list_ref.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include "binder/bound_table_ref.h"
+#include "catalog/schema.h"
+#include "fmt/core.h"
+#include "type/type.h"
+
+namespace bustub {
+
+class BoundExpression;
+
+/**
+ * A bound table ref type for `values` clause.
+ */
+class BoundExpressionListRef : public BoundTableRef {
+ public:
+  explicit BoundExpressionListRef(std::vector<std::vector<std::unique_ptr<BoundExpression>>> values)
+      : BoundTableRef(TableReferenceType::EXPRESSION_LIST), values_(std::move(values)) {}
+
+  auto ToString() const -> std::string override;
+
+  /** The value list */
+  std::vector<std::vector<std::unique_ptr<BoundExpression>>> values_;
+};
+}  // namespace bustub

--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -111,6 +111,15 @@ class StringUtil {
    * @return a new string with all occurrences of `from` replaced with `to`.
    */
   static auto Replace(std::string source, const std::string &from, const std::string &to) -> std::string;
+
+  /**
+   * Add indention to all lines of the `lines` variable.
+   *
+   * @param lines input string
+   * @param num_indent number of spaces prepended to each line
+   * @return a new string with spaces added to each line
+   */
+  static auto IndentAllLines(const std::string &lines, size_t num_indent) -> std::string;
 };
 
 }  // namespace bustub

--- a/src/include/execution/plans/values_plan.h
+++ b/src/include/execution/plans/values_plan.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "catalog/catalog.h"
 #include "execution/expressions/abstract_expression.h"
@@ -33,15 +34,17 @@ class ValuesPlanNode : public AbstractPlanNode {
    * @param output The output schema of this values plan node
    * @param child The child plan node
    */
-  ValuesPlanNode(const Schema *output, const AbstractPlanNode *child) : AbstractPlanNode(output, {child}) {}
+  explicit ValuesPlanNode(const Schema *output, std::vector<std::vector<const AbstractExpression *>> values)
+      : AbstractPlanNode(output, {}), values_(std::move(values)) {}
 
   /** @return The type of the plan node */
   auto GetType() const -> PlanType override { return PlanType::Values; }
 
  protected:
-  auto PlanNodeToString() const -> std::string override { return fmt::format("Values {{ }}"); }
+  auto PlanNodeToString() const -> std::string override { return fmt::format("Values {{ rows={} }}", values_.size()); }
 
  private:
+  std::vector<std::vector<const AbstractExpression *>> values_;
 };
 
 }  // namespace bustub

--- a/src/include/execution/plans/values_plan.h
+++ b/src/include/execution/plans/values_plan.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "catalog/catalog.h"

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -22,6 +22,10 @@ class BoundBinaryOp;
 class BoundConstant;
 class BoundColumnRef;
 class BoundUnaryOp;
+class BoundBaseTableRef;
+class BoundCrossProductRef;
+class BoundJoinRef;
+class BoundExpressionListRef;
 
 /**
  * The planner takes a bound statement, and transforms it into the BusTub plan tree.
@@ -48,6 +52,14 @@ class Planner {
    * @return the plan node of this bound table ref.
    */
   auto PlanTableRef(const BoundTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
+
+  auto PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
+
+  auto PlanCrossProductRef(const BoundCrossProductRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
+
+  auto PlanJoinRef(const BoundJoinRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
+
+  auto PlanExpressionListRef(const BoundExpressionListRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
 
   auto PlanExpression(const BoundExpression &expr, const std::vector<const AbstractPlanNode *> &children)
       -> std::tuple<std::string, std::unique_ptr<AbstractExpression>>;
@@ -82,6 +94,9 @@ class Planner {
     allocated_expressions_.emplace_back(std::move(expression));
     return allocated_expressions_.back().get();
   }
+
+  auto MakeOutputSchema(const std::vector<std::pair<std::string, const AbstractExpression *>> &exprs)
+      -> std::unique_ptr<Schema>;
 
   std::vector<std::unique_ptr<Schema>> allocated_output_schemas_;
 

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <utility>
 
+#include "fmt/format.h"
+
 #include "type/limits.h"
 #include "type/type.h"
 
@@ -165,3 +167,21 @@ class Value {
   TypeId type_id_;
 };
 }  // namespace bustub
+
+template <typename T>
+struct fmt::formatter<T, std::enable_if_t<std::is_base_of<bustub::Value, T>::value, char>>
+    : fmt::formatter<std::string> {
+  template <typename FormatCtx>
+  auto format(const bustub::Value &x, FormatCtx &ctx) const {
+    return fmt::formatter<std::string>::format(x.ToString(), ctx);
+  }
+};
+
+template <typename T>
+struct fmt::formatter<std::unique_ptr<T>, std::enable_if_t<std::is_base_of<bustub::Value, T>::value, char>>
+    : fmt::formatter<std::string> {
+  template <typename FormatCtx>
+  auto format(const std::unique_ptr<bustub::Value> &x, FormatCtx &ctx) const {
+    return fmt::formatter<std::string>::format(x->ToString(), ctx);
+  }
+};

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cstring>
+#include <memory>
 #include <string>
 #include <utility>
 

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   bustub_planner
   OBJECT
   plan_expression.cpp
+  plan_table_ref.cpp
   planner.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/planner/plan_table_ref.cpp
+++ b/src/planner/plan_table_ref.cpp
@@ -1,0 +1,159 @@
+#include <memory>
+#include <utility>
+
+#include "binder/bound_statement.h"
+#include "binder/bound_table_ref.h"
+#include "binder/table_ref/bound_base_table_ref.h"
+#include "binder/table_ref/bound_cross_product_ref.h"
+#include "binder/table_ref/bound_expression_list_ref.h"
+#include "binder/table_ref/bound_join_ref.h"
+#include "catalog/column.h"
+#include "common/exception.h"
+#include "common/macros.h"
+#include "common/util/string_util.h"
+#include "execution/expressions/column_value_expression.h"
+#include "execution/expressions/constant_value_expression.h"
+#include "execution/plans/mock_scan_plan.h"
+#include "execution/plans/nested_loop_join_plan.h"
+#include "execution/plans/seq_scan_plan.h"
+#include "execution/plans/values_plan.h"
+#include "fmt/core.h"
+#include "fmt/format.h"
+#include "planner/planner.h"
+#include "type/value_factory.h"
+
+namespace bustub {
+
+auto Planner::PlanTableRef(const BoundTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode> {
+  switch (table_ref.type_) {
+    case TableReferenceType::BASE_TABLE: {
+      const auto &base_table_ref = dynamic_cast<const BoundBaseTableRef &>(table_ref);
+      return PlanBaseTableRef(base_table_ref);
+    }
+    case TableReferenceType::CROSS_PRODUCT: {
+      const auto &cross_product = dynamic_cast<const BoundCrossProductRef &>(table_ref);
+      return PlanCrossProductRef(cross_product);
+    }
+    case TableReferenceType::JOIN: {
+      const auto &join = dynamic_cast<const BoundJoinRef &>(table_ref);
+      return PlanJoinRef(join);
+    }
+    case TableReferenceType::EXPRESSION_LIST: {
+      const auto &expression_list = dynamic_cast<const BoundExpressionListRef &>(table_ref);
+      return PlanExpressionListRef(expression_list);
+    }
+    default:
+      break;
+  }
+  throw Exception(fmt::format("the table ref type {} is not supported in planner yet", table_ref.type_));
+}
+
+auto Planner::PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode> {
+  // We always scan ALL columns of the table, and use projection executor to
+  // remove some of them, therefore simplifying the planning process.
+
+  // It is also possible to have a "virtual" logical projection node, and
+  // we can merge it with table scan when optimizing. But for now, having
+  // an optimizer or not remains undecided. So I'd prefer going with a new
+  // ProjectionExecutor.
+
+  auto table = catalog_.GetTable(table_ref.table_);
+  BUSTUB_ASSERT(table, "table not found");
+  const auto &schema = table->schema_;
+  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+
+  size_t idx = 0;
+  for (const auto &column : schema.GetColumns()) {
+    output_schema.emplace_back(fmt::format("{}.{}", table_ref.table_, column.GetName()),
+                               SaveExpression(std::make_unique<ColumnValueExpression>(0, idx, column.GetType())));
+    idx += 1;
+  }
+
+  if (StringUtil::StartsWith(table->name_, "__")) {
+    // Plan as MockScanExecutor if it is a mock table.
+    if (StringUtil::StartsWith(table->name_, "__mock")) {
+      return std::make_unique<MockScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), 100);
+    }
+  } else {
+    throw bustub::Exception(fmt::format("unsupported internal table: {}", table->name_));
+  }
+  // Otherwise, plan as normal SeqScan.
+  return std::make_unique<SeqScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), nullptr, table->oid_);
+}
+
+auto Planner::PlanCrossProductRef(const BoundCrossProductRef &table_ref) -> std::unique_ptr<AbstractPlanNode> {
+  auto left = PlanTableRef(*table_ref.left_);
+  auto right = PlanTableRef(*table_ref.right_);
+  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+  size_t idx = 0;
+  for (const auto &column : left->OutputSchema()->GetColumns()) {
+    output_schema.emplace_back(column.GetName(),
+                               SaveExpression(std::make_unique<ColumnValueExpression>(0, idx, column.GetType())));
+    idx += 1;
+  }
+  idx = 0;
+  for (const auto &column : right->OutputSchema()->GetColumns()) {
+    output_schema.emplace_back(column.GetName(),
+                               SaveExpression(std::make_unique<ColumnValueExpression>(1, idx, column.GetType())));
+    idx += 1;
+  }
+  return std::make_unique<NestedLoopJoinPlanNode>(
+      SaveSchema(MakeOutputSchema(output_schema)),
+      std::vector{SavePlanNode(std::move(left)), SavePlanNode(std::move(right))},
+      SaveExpression(std::make_unique<ConstantValueExpression>(ValueFactory::GetBooleanValue(true))));
+}
+
+auto Planner::PlanJoinRef(const BoundJoinRef &table_ref) -> std::unique_ptr<AbstractPlanNode> {
+  auto left = PlanTableRef(*table_ref.left_);
+  auto right = PlanTableRef(*table_ref.right_);
+  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+  size_t idx = 0;
+  for (const auto &column : left->OutputSchema()->GetColumns()) {
+    output_schema.emplace_back(column.GetName(),
+                               SaveExpression(std::make_unique<ColumnValueExpression>(0, idx, column.GetType())));
+    idx += 1;
+  }
+  idx = 0;
+  for (const auto &column : right->OutputSchema()->GetColumns()) {
+    output_schema.emplace_back(column.GetName(),
+                               SaveExpression(std::make_unique<ColumnValueExpression>(1, idx, column.GetType())));
+    idx += 1;
+  }
+  auto nlj_output_schema = SaveSchema(MakeOutputSchema(output_schema));
+  auto [_, join_condition] = PlanExpression(*table_ref.condition_, {&*left, &*right});
+  auto nlj_node = std::make_unique<NestedLoopJoinPlanNode>(
+      nlj_output_schema, std::vector{SavePlanNode(std::move(left)), SavePlanNode(std::move(right))},
+      SaveExpression(std::move(join_condition)));
+  return nlj_node;
+}
+
+auto Planner::PlanExpressionListRef(const BoundExpressionListRef &table_ref) -> std::unique_ptr<AbstractPlanNode> {
+  std::vector<std::vector<const AbstractExpression *>> all_exprs;
+  for (const auto &row : table_ref.values_) {
+    std::vector<const AbstractExpression *> row_exprs;
+    for (const auto &col : row) {
+      auto [_, expr] = PlanExpression(*col, {});
+      row_exprs.push_back(SaveExpression(std::move(expr)));
+    }
+    all_exprs.emplace_back(std::move(row_exprs));
+  }
+
+  const auto &first_row = all_exprs[0];
+  std::vector<Column> cols;
+  cols.reserve(first_row.size());
+  size_t idx = 0;
+  for (const auto &col : first_row) {
+    auto col_name = fmt::format("__values.{}", idx);
+    if (col->GetReturnType() != TypeId::VARCHAR) {
+      cols.emplace_back(std::move(col_name), col->GetReturnType(), nullptr);
+    } else {
+      cols.emplace_back(std::move(col_name), col->GetReturnType(), VARCHAR_DEFAULT_LENGTH, nullptr);
+    }
+    idx += 1;
+  }
+  auto schema = std::make_unique<Schema>(cols);
+
+  return std::make_unique<ValuesPlanNode>(SaveSchema(std::move(schema)), std::move(all_exprs));
+}
+
+}  // namespace bustub

--- a/src/planner/plan_table_ref.cpp
+++ b/src/planner/plan_table_ref.cpp
@@ -74,7 +74,6 @@ auto Planner::PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> std::uniqu
     if (StringUtil::StartsWith(table->name_, "__mock")) {
       return std::make_unique<MockScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), 100);
     }
-  } else {
     throw bustub::Exception(fmt::format("unsupported internal table: {}", table->name_));
   }
   // Otherwise, plan as normal SeqScan.
@@ -120,7 +119,7 @@ auto Planner::PlanJoinRef(const BoundJoinRef &table_ref) -> std::unique_ptr<Abst
     idx += 1;
   }
   auto nlj_output_schema = SaveSchema(MakeOutputSchema(output_schema));
-  auto [_, join_condition] = PlanExpression(*table_ref.condition_, {&*left, &*right});
+  auto [_, join_condition] = PlanExpression(*table_ref.condition_, {left.get(), right.get()});
   auto nlj_node = std::make_unique<NestedLoopJoinPlanNode>(
       nlj_output_schema, std::vector{SavePlanNode(std::move(left)), SavePlanNode(std::move(right))},
       SaveExpression(std::move(join_condition)));

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -1,30 +1,21 @@
-#include "planner/planner.h"
 #include <memory>
 #include <utility>
+
 #include "binder/bound_expression.h"
 #include "binder/bound_statement.h"
+#include "binder/bound_table_ref.h"
 #include "binder/expressions/bound_agg_call.h"
-#include "binder/expressions/bound_binary_op.h"
 #include "binder/statement/select_statement.h"
-#include "binder/table_ref/bound_base_table_ref.h"
-#include "binder/table_ref/bound_cross_product_ref.h"
-#include "binder/table_ref/bound_join_ref.h"
 #include "common/exception.h"
 #include "common/macros.h"
 #include "common/util/string_util.h"
-#include "execution/expressions/abstract_expression.h"
 #include "execution/expressions/aggregate_value_expression.h"
-#include "execution/expressions/column_value_expression.h"
-#include "execution/expressions/constant_value_expression.h"
 #include "execution/plans/abstract_plan.h"
 #include "execution/plans/aggregation_plan.h"
 #include "execution/plans/filter_plan.h"
-#include "execution/plans/mock_scan_plan.h"
-#include "execution/plans/nested_loop_join_plan.h"
 #include "execution/plans/projection_plan.h"
-#include "execution/plans/seq_scan_plan.h"
 #include "fmt/format.h"
-#include "type/value_factory.h"
+#include "planner/planner.h"
 
 namespace bustub {
 
@@ -39,7 +30,7 @@ void Planner::PlanQuery(const BoundStatement &statement) {
   }
 }
 
-auto MakeOutputSchema(const std::vector<std::pair<std::string, const AbstractExpression *>> &exprs)
+auto Planner::MakeOutputSchema(const std::vector<std::pair<std::string, const AbstractExpression *>> &exprs)
     -> std::unique_ptr<Schema> {
   std::vector<Column> cols;
   cols.reserve(exprs.size());
@@ -131,93 +122,6 @@ auto Planner::PlanSelect(const SelectStatement &statement) -> std::unique_ptr<Ab
   }
 
   throw Exception("invalid select list: agg calls appear with other columns");
-}
-
-auto Planner::PlanTableRef(const BoundTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode> {
-  switch (table_ref.type_) {
-    case TableReferenceType::BASE_TABLE: {
-      // We always scan ALL columns of the table, and use projection executor to
-      // remove some of them, therefore simplifying the planning process.
-
-      // It is also possible to have a "virtual" logical projection node, and
-      // we can merge it with table scan when optimizing. But for now, having
-      // an optimizer or not remains undecided. So I'd prefer going with a new
-      // ProjectionExecutor.
-
-      const auto &base_table_ref = dynamic_cast<const BoundBaseTableRef &>(table_ref);
-      auto table = catalog_.GetTable(base_table_ref.table_);
-      BUSTUB_ASSERT(table, "table not found");
-      const auto &schema = table->schema_;
-      std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
-
-      size_t idx = 0;
-      for (const auto &column : schema.GetColumns()) {
-        output_schema.emplace_back(fmt::format("{}.{}", base_table_ref.table_, column.GetName()),
-                                   SaveExpression(std::make_unique<ColumnValueExpression>(0, idx, column.GetType())));
-        idx += 1;
-      }
-
-      if (StringUtil::StartsWith(table->name_, "__")) {
-        // Plan as MockScanExecutor if it is a mock table.
-        if (StringUtil::StartsWith(table->name_, "__mock")) {
-          return std::make_unique<MockScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), 100, table->name_);
-        }
-      } else {
-        throw bustub::Exception(fmt::format("unsupported internal table: {}", table->name_));
-      }
-      // Otherwise, plan as normal SeqScan.
-      return std::make_unique<SeqScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), nullptr, table->oid_);
-    }
-    case TableReferenceType::CROSS_PRODUCT: {
-      const auto &cross_product = dynamic_cast<const BoundCrossProductRef &>(table_ref);
-      auto left = PlanTableRef(*cross_product.left_);
-      auto right = PlanTableRef(*cross_product.right_);
-      std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
-      size_t idx = 0;
-      for (const auto &column : left->OutputSchema()->GetColumns()) {
-        output_schema.emplace_back(column.GetName(),
-                                   SaveExpression(std::make_unique<ColumnValueExpression>(0, idx, column.GetType())));
-        idx += 1;
-      }
-      idx = 0;
-      for (const auto &column : right->OutputSchema()->GetColumns()) {
-        output_schema.emplace_back(column.GetName(),
-                                   SaveExpression(std::make_unique<ColumnValueExpression>(1, idx, column.GetType())));
-        idx += 1;
-      }
-      return std::make_unique<NestedLoopJoinPlanNode>(
-          SaveSchema(MakeOutputSchema(output_schema)),
-          std::vector{SavePlanNode(std::move(left)), SavePlanNode(std::move(right))},
-          SaveExpression(std::make_unique<ConstantValueExpression>(ValueFactory::GetBooleanValue(true))));
-    }
-    case TableReferenceType::JOIN: {
-      const auto &join = dynamic_cast<const BoundJoinRef &>(table_ref);
-      auto left = PlanTableRef(*join.left_);
-      auto right = PlanTableRef(*join.right_);
-      std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
-      size_t idx = 0;
-      for (const auto &column : left->OutputSchema()->GetColumns()) {
-        output_schema.emplace_back(column.GetName(),
-                                   SaveExpression(std::make_unique<ColumnValueExpression>(0, idx, column.GetType())));
-        idx += 1;
-      }
-      idx = 0;
-      for (const auto &column : right->OutputSchema()->GetColumns()) {
-        output_schema.emplace_back(column.GetName(),
-                                   SaveExpression(std::make_unique<ColumnValueExpression>(1, idx, column.GetType())));
-        idx += 1;
-      }
-      auto nlj_output_schema = SaveSchema(MakeOutputSchema(output_schema));
-      auto [_, join_condition] = PlanExpression(*join.condition_, {left.get(), right.get()});
-      auto nlj_node = std::make_unique<NestedLoopJoinPlanNode>(
-          nlj_output_schema, std::vector{SavePlanNode(std::move(left)), SavePlanNode(std::move(right))},
-          SaveExpression(std::move(join_condition)));
-      return nlj_node;
-    }
-    default:
-      break;
-  }
-  throw Exception(fmt::format("the table ref type {} is not supported in planner yet", table_ref.type_));
 }
 
 }  // namespace bustub

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -135,17 +135,11 @@ TEST(BinderTest, FailBindUnknownColumn) {
   EXPECT_THROW(TryBind("select zzzz"), Exception);
 }
 
-// TODO(chi): create / drop table is not supported yet
-TEST(BinderTest, DISABLED_BindCreateDropTable) {
-  TryBind("CREATE TABLE tablex (v1 int)");
-  TryBind("DROP TABLE tablex");
-}
+TEST(BinderTest, BindCreateTable) { TryBind("CREATE TABLE tablex (v1 int)"); }
 
-// TODO(chi): insert is not supported yet
-TEST(BinderTest, DISABLED_BindInsert) {
-  TryBind("INSERT INTO y VALUES (1,2,3,4,5), (6,7,8,9,10)");
-  TryBind("INSERT INTO y SELECT * FROM y WHERE x < 500");
-}
+TEST(BinderTest, BindInsert) { TryBind("INSERT INTO y VALUES (1,2,3,4,5), (6,7,8,9,10)"); }
+
+TEST(BinderTest, BindInsertSelect) { TryBind("INSERT INTO y SELECT * FROM y WHERE x < 500"); }
 
 TEST(BinderTest, BindVarchar) {
   TryBind(R"(INSERT INTO c VALUES ('1', '2'))");


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

* Refactor planner and split `plan_table_ref.cpp` out.
* Plan `values` as `ExpressListTableRef`
* Bind insert.