### PR TITLE
refactor: sync from private repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,28 +41,6 @@ autoconf/aclocal.m4
 autoconf/autom4te.cache
 /compile_commands.json
 
-
-#==============================================================================#
-# Autotools artifacts
-#==============================================================================#
-config/
-configure
-config-h.in
-autom4te.cache
-*Makefile.in
-*Makefile
-libtool
-aclocal.m4
-config.log
-config.status
-stamp-h1
-config.h
-m4/libtool.m4
-m4/ltoptions.m4
-m4/ltsugar.m4
-m4/ltversion.m4
-m4/lt~obsolete.m4
-
 #==============================================================================#
 # Build artifacts
 #==============================================================================#

--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -79,15 +79,9 @@ class TableWriteRecord {
  */
 class IndexWriteRecord {
  public:
-  IndexWriteRecord(RID rid, table_oid_t table_oid, WType wtype, const Tuple &tuple, const Tuple &old_tuple,
-                   index_oid_t index_oid, Catalog *catalog)
-      : rid_(rid),
-        table_oid_(table_oid),
-        wtype_(wtype),
-        tuple_(tuple),
-        old_tuple_(old_tuple),
-        index_oid_(index_oid),
-        catalog_(catalog) {}
+  IndexWriteRecord(RID rid, table_oid_t table_oid, WType wtype, const Tuple &tuple, index_oid_t index_oid,
+                   Catalog *catalog)
+      : rid_(rid), table_oid_(table_oid), wtype_(wtype), tuple_(tuple), index_oid_(index_oid), catalog_(catalog) {}
 
   /** The rid is the value stored in the index. */
   RID rid_;

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -172,6 +172,12 @@ class ExtendibleHashTable : public HashTable<K, V> {
   mutable std::mutex latch_;
   std::vector<std::shared_ptr<Bucket>> dir_;  // The directory of the hash table
 
+  /**
+   * @brief Redistribute the kv pairs in a full bucket.
+   * @param bucket The bucket to be redistributed.
+   */
+  auto RedistributeBucket(std::shared_ptr<Bucket> bucket) -> void;
+
   /*****************************************************************
    * Must acquire latch_ first before calling the below functions. *
    *****************************************************************/

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -165,12 +165,16 @@ class ExtendibleHashTable : public HashTable<K, V> {
   };
 
  private:
-  // TODO(student): You may add additional private members and helper functions
+  // TODO(student): You may add additional private members and helper functions and remove the ones
+  // you don't need.
+
   int global_depth_;    // The global depth of the directory
   size_t bucket_size_;  // The size of a bucket
   int num_buckets_;     // The number of buckets in the hash table
   mutable std::mutex latch_;
   std::vector<std::shared_ptr<Bucket>> dir_;  // The directory of the hash table
+
+  // The following functions are completely optional, you can delete them if you have your own ideas.
 
   /**
    * @brief Redistribute the kv pairs in a full bucket.
@@ -188,6 +192,7 @@ class ExtendibleHashTable : public HashTable<K, V> {
    * @return The entry index in the directory.
    */
   auto IndexOf(const K &key) -> size_t;
+
   auto GetGlobalDepthInternal() const -> int;
   auto GetLocalDepthInternal(int dir_index) const -> int;
   auto GetNumBucketsInternal() const -> int;

--- a/src/include/storage/page/hash_table_page_defs.h
+++ b/src/include/storage/page/hash_table_page_defs.h
@@ -32,13 +32,19 @@
  * Extendible Hashing Definitions
  */
 #define HASH_TABLE_BUCKET_TYPE HashTableBucketPage<KeyType, ValueType, KeyComparator>
-#define DIRECTORY_ARRAY_SIZE 512
 
 /**
- * BUCKET_ARRAY_SIZE is the number of (key, value) pairs that can be stored in an extendible hashing bucket page.
- * It is an approximate calculation based on the size of MappingType (which is a std::pair of KeyType and ValueType).
- * For each key/value pair, we need two additional bits for occupied_ and readable_. 4 * (PAGE_SIZE - 4) / (4 * sizeof
- * (MappingType) + 1) = (PAGE_SIZE - 4)/(sizeof (MappingType) + 0.25) because 0.25 bytes = 2 bits is the space required
- * to maintain the occupied and readable flags for a key value pair.
+ * BUCKET_ARRAY_SIZE is the number of (key, value) pairs that can be stored in an extendible hash index bucket page.
+ * The computation is the same as the above BLOCK_ARRAY_SIZE, but blocks and buckets have difference implementations
+ * of search, insertion, removal, and helper methods.
  */
 #define BUCKET_ARRAY_SIZE (4 * PAGE_SIZE / (4 * sizeof(MappingType) + 1))
+
+/**
+ * DIRECTORY_ARRAY_SIZE is the number of page_ids that can fit in the directory page of an extendible hash index.
+ * This is 512 because the directory array must grow in powers of 2, and 1024 page_ids leaves zero room for
+ * storage of the other member variables: page_id_, lsn_, global_depth_, and the array local_depths_.
+ * Extending the directory implementation to span multiple pages would be a meaningful improvement to the
+ * implementation.
+ */
+#define DIRECTORY_ARRAY_SIZE 512

--- a/src/include/storage/page/hash_table_page_defs.h
+++ b/src/include/storage/page/hash_table_page_defs.h
@@ -35,7 +35,7 @@
 
 /**
  * BUCKET_ARRAY_SIZE is the number of (key, value) pairs that can be stored in an extendible hash index bucket page.
- * The computation is the same as the above BLOCK_ARRAY_SIZE, but blocks and buckets have difference implementations
+ * The computation is the same as the above BLOCK_ARRAY_SIZE, but blocks and buckets have different implementations
  * of search, insertion, removal, and helper methods.
  */
 #define BUCKET_ARRAY_SIZE (4 * PAGE_SIZE / (4 * sizeof(MappingType) + 1))

--- a/src/storage/index/b_plus_tree.cpp
+++ b/src/storage/index/b_plus_tree.cpp
@@ -1,14 +1,3 @@
-//===----------------------------------------------------------------------===//
-//
-//                         CMU-DB Project (15-445/645)
-//                         ***DO NO SHARE PUBLICLY***
-//
-// Identification: src/index/b_plus_tree.cpp
-//
-// Copyright (c) 2018, Carnegie Mellon University Database Group
-//
-//===----------------------------------------------------------------------===//
-
 #include <string>
 
 #include "common/exception.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,8 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
             --gtest_color=yes
             --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${bustub_test_name}.xml
             --gtest_catch_exceptions=0
+            PROPERTIES
+            TIMEOUT 30
             )
     
     target_link_libraries(${bustub_test_name} bustub gtest gmock_main)

--- a/test/buffer/counter.h
+++ b/test/buffer/counter.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <atomic>
+
 #include "gtest/gtest.h"
 
 namespace bustub {


### PR DESCRIPTION
cc @timlee0119 we missed one function from the private repo. Shall we add it to the public header? (They can remove it at any time).

I was scared when I see the header of `src/storage/index/b_plus_tree.cpp`, but it turned out it isn't a private one. So I removed the header.