### PR TITLE
feat(planner): plan having and select group by column in hashagg

### DIFF
--- a/src/common/bustub_instance.cpp
+++ b/src/common/bustub_instance.cpp
@@ -1,5 +1,6 @@
 #include "common/bustub_instance.h"
 #include "binder/binder.h"
+#include "binder/bound_expression.h"
 #include "binder/bound_statement.h"
 #include "binder/statement/create_statement.h"
 #include "binder/statement/select_statement.h"

--- a/src/include/binder/bound_expression.h
+++ b/src/include/binder/bound_expression.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include "common/macros.h"
 #include "fmt/format.h"
 
 namespace bustub {
@@ -34,6 +35,8 @@ class BoundExpression {
   virtual auto ToString() const -> std::string { return ""; };
 
   auto IsInvalid() const -> bool { return type_ == ExpressionType::INVALID; }
+
+  virtual auto HasAggregation() const -> bool { UNREACHABLE("has aggregation should have been implemented!"); }
 
   /** The type of this expression. */
   ExpressionType type_{ExpressionType::INVALID};

--- a/src/include/binder/expressions/bound_agg_call.h
+++ b/src/include/binder/expressions/bound_agg_call.h
@@ -19,6 +19,8 @@ class BoundAggCall : public BoundExpression {
 
   auto ToString() const -> std::string override;
 
+  auto HasAggregation() const -> bool override { return true; }
+
   /** Function name. */
   std::string func_name_;
 

--- a/src/include/binder/expressions/bound_alias.h
+++ b/src/include/binder/expressions/bound_alias.h
@@ -17,6 +17,8 @@ class BoundAlias : public BoundExpression {
 
   auto ToString() const -> std::string override { return fmt::format("({} as {})", child_, alias_); }
 
+  auto HasAggregation() const -> bool override { return child_->HasAggregation(); }
+
   /** Alias name. */
   std::string alias_;
 

--- a/src/include/binder/expressions/bound_binary_op.h
+++ b/src/include/binder/expressions/bound_binary_op.h
@@ -23,6 +23,8 @@ class BoundBinaryOp : public BoundExpression {
 
   auto ToString() const -> std::string override { return fmt::format("({}{}{})", larg_, op_name_, rarg_); }
 
+  auto HasAggregation() const -> bool override { return larg_->HasAggregation() || rarg_->HasAggregation(); }
+
   /** Operator name. */
   std::string op_name_;
 

--- a/src/include/binder/expressions/bound_column_ref.h
+++ b/src/include/binder/expressions/bound_column_ref.h
@@ -16,6 +16,8 @@ class BoundColumnRef : public BoundExpression {
 
   auto ToString() const -> std::string override { return fmt::format("{}.{}", table_, col_); }
 
+  auto HasAggregation() const -> bool override { return false; }
+
   /** Name of the table. */
   std::string table_;
 

--- a/src/include/binder/expressions/bound_constant.h
+++ b/src/include/binder/expressions/bound_constant.h
@@ -19,6 +19,8 @@ class BoundConstant : public BoundExpression {
 
   auto ToString() const -> std::string override { return val_.ToString(); }
 
+  auto HasAggregation() const -> bool override { return false; }
+
   /** The constant being bound. */
   Value val_;
 };

--- a/src/include/binder/expressions/bound_star.h
+++ b/src/include/binder/expressions/bound_star.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include "binder/bound_expression.h"
+#include "common/exception.h"
 
 namespace bustub {
 
@@ -12,6 +13,10 @@ namespace bustub {
 class BoundStar : public BoundExpression {
  public:
   BoundStar() : BoundExpression(ExpressionType::STAR) {}
+
+  auto HasAggregation() const -> bool override {
+    throw bustub::Exception("`HasAggregation` should not have been called on `BoundStar`.");
+  }
 
   auto ToString() const -> std::string override { return "*"; }
 };

--- a/src/include/binder/expressions/bound_unary_op.h
+++ b/src/include/binder/expressions/bound_unary_op.h
@@ -18,6 +18,8 @@ class BoundUnaryOp : public BoundExpression {
 
   auto ToString() const -> std::string override { return fmt::format("({}{})", op_name_, arg_); }
 
+  auto HasAggregation() const -> bool override { return arg_->HasAggregation(); }
+
   /** Operator name. */
   std::string op_name_;
 

--- a/src/include/binder/tokens.h
+++ b/src/include/binder/tokens.h
@@ -32,7 +32,7 @@ class SelectNode;
 //===--------------------------------------------------------------------===//
 class AbstractExpression;
 
-class ColumnRefExpression;
+class ColumnValueExpression;
 class ComparisonExpression;
 class ConstantExpression;
 

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   plan_expression.cpp
   plan_insert.cpp
   plan_table_ref.cpp
+  plan_select.cpp
   planner.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/planner/plan_aggregation.cpp
+++ b/src/planner/plan_aggregation.cpp
@@ -6,17 +6,20 @@
 #include "binder/bound_table_ref.h"
 #include "binder/expressions/bound_agg_call.h"
 #include "binder/statement/select_statement.h"
+#include "binder/tokens.h"
 #include "common/exception.h"
 #include "common/macros.h"
 #include "common/util/string_util.h"
 #include "execution/expressions/abstract_expression.h"
 #include "execution/expressions/aggregate_value_expression.h"
+#include "execution/expressions/column_value_expression.h"
 #include "execution/plans/abstract_plan.h"
 #include "execution/plans/aggregation_plan.h"
 #include "execution/plans/filter_plan.h"
 #include "execution/plans/projection_plan.h"
 #include "fmt/format.h"
 #include "planner/planner.h"
+#include "type/type_id.h"
 
 namespace bustub {
 
@@ -25,7 +28,13 @@ auto Planner::PlanAggCall(const BoundAggCall &agg_call, const std::vector<const 
   if (agg_call.args_.size() != 1) {
     throw NotImplementedException("only agg call of one arg is supported for now");
   }
-  auto [_, expr] = PlanExpression(*agg_call.args_[0], children);
+  std::unique_ptr<AbstractExpression> expr = nullptr;
+  {
+    // Create a new context that doesn't allow aggregation calls.
+    auto guard = NewContext();
+    auto [_, ret] = PlanExpression(*agg_call.args_[0], children);
+    expr = std::move(ret);
+  }
   if (agg_call.func_name_ == "min") {
     return {AggregationType::MinAggregate, std::move(expr)};
   }
@@ -41,44 +50,111 @@ auto Planner::PlanAggCall(const BoundAggCall &agg_call, const std::vector<const 
   throw Exception(fmt::format("unsupported agg_call {}", agg_call.func_name_));
 }
 
-auto Planner::PlanAggregation(const SelectStatement &statement, const AbstractPlanNode *child)
+auto Planner::PlanSelectAgg(const SelectStatement &statement, const AbstractPlanNode *child)
     -> std::unique_ptr<AbstractPlanNode> {
+  /* Transforming hash agg is complex. Let's see a concrete example here.
+   *
+   * Now that we have,
+   * ```
+   * select v3, max(v1) + max(v2) from table where <cond> group by v3 having count(v4) > count(v5);
+   * ```
+   *
+   * Before this comment section, we have `from table where <cond>` planned as filter / table scan.
+   *
+   * Given this is a group-by query, we will have something like this in the final plan,
+   * ```
+   * <Parent Plan Nodes>
+   *   Projection v3, max(v1) + max(v2)
+   *     Filter count(v4) > count(v5)
+   *       Aggregation group_by=v3 agg_types=[max, max, count, count] agg_expr=[v1, v2, v4, v5]
+   *         <Filter / Table Scan> --- "table scan child"
+   * ```
+   *
+   * For every expression in select list and having clause, we will do a two-phase planning. Firstly,
+   * we plan all aggregation calls, and then we plan other expressions. Let's take `max(v1) + max(v2)` as
+   * an example.
+   *
+   * - We plan `max(v1)` and `max(v2)` in the select list and `count(v4)`, `count(v5)` using the
+   *   "table scan child". We get tuples of `[agg_type, abstract_expression]`.
+   * - Then we construct the aggregation plan node with all required aggregations plus group-by expressions.
+   * - After that we plan the filter `count(v4) > count(v5)` and the projection `v3`, `max(v1) + max(v2)`.
+   * - That's all!
+   */
+
+  // Create a new context which allows aggrecation call.
+  auto guard = NewContext();
+  ctx_.allow_aggregation_ = true;
+
+  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+
   // Plan group by expressions
   std::vector<const AbstractExpression *> group_by_exprs;
   for (const auto &expr : statement.group_by_) {
-    auto [_, abstract_expr] = PlanExpression(*expr, {child});
-    group_by_exprs.push_back(SaveExpression(std::move(abstract_expr)));
+    auto [col_name, abstract_expr] = PlanExpression(*expr, {child});
+    auto abstract_expr_ptr = SaveExpression(std::move(abstract_expr));
+    group_by_exprs.push_back(abstract_expr_ptr);
+    output_schema.emplace_back(std::make_pair(std::move(col_name), abstract_expr_ptr));
   }
 
-  // Plan having
-  std::unique_ptr<AbstractExpression> having_expr = nullptr;
+  // Rewrite all agg call inside having.
   if (!statement.having_->IsInvalid()) {
-    throw NotImplementedException("planning having is not supported for now");
+    AddAggCallToContext(*statement.having_);
   }
 
-  // Plan select list
+  // Rewrite all agg call inside expression to a pseudo one.
+  for (auto &item : statement.select_list_) {
+    AddAggCallToContext(*item);
+  }
+
+  // Phase-1: plan an aggregation plan node out of all of the information we have.
   std::vector<const AbstractExpression *> input_exprs;
   std::vector<AggregationType> agg_types;
-  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+  auto agg_begin_idx = group_by_exprs.size();  // agg-calls will be after group-bys in the output of agg.
 
   int term_idx = 0;
-  for (const auto &item : statement.select_list_) {
+  for (const auto &item : ctx_.aggregations_) {
     if (item->type_ != ExpressionType::AGG_CALL) {
-      // TODO(chi): support select item from group by clause
-      throw NotImplementedException("only agg call is supported in select list for now");
+      throw NotImplementedException("alias for agg call is not supported for now");
     }
     const auto &agg_call = dynamic_cast<const BoundAggCall &>(*item);
-    auto [agg_type, abstract_expression] = PlanAggCall(agg_call, {child});
+    auto [agg_type, expr] = PlanAggCall(agg_call, {child});
+    auto abstract_expr = SaveExpression(std::move(expr));
+    input_exprs.push_back(abstract_expr);
     agg_types.push_back(agg_type);
-    input_exprs.push_back(SaveExpression(std::move(abstract_expression)));
-    output_schema.emplace_back(
-        std::make_pair(fmt::format("agg#{}", term_idx),
-                       SaveExpression(std::make_unique<AggregateValueExpression>(false, term_idx, TypeId::INTEGER))));
+    output_schema.emplace_back(std::make_pair(fmt::format("agg#{}", term_idx), abstract_expr));
+    // TODO(chi): correctly infer the type of the agg output.
+    ctx_.expr_in_agg_.emplace_back(
+        std::make_unique<ColumnValueExpression>(0, agg_begin_idx + term_idx, TypeId::INTEGER));
     term_idx += 1;
   }
 
-  return std::make_unique<AggregationPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), child, nullptr,
-                                               std::move(group_by_exprs), move(input_exprs), move(agg_types));
+  auto agg_output_schema = SaveSchema(MakeOutputSchema(output_schema));
+  // Create the aggregation plan node for the first phase (finally!)
+  std::unique_ptr<AbstractPlanNode> plan = std::make_unique<AggregationPlanNode>(
+      agg_output_schema, child, nullptr, std::move(group_by_exprs), std::move(input_exprs), std::move(agg_types));
+
+  // Phase-2: plan filter / projection to match the original select list
+
+  // Create filter based on the having clause
+  if (!statement.having_->IsInvalid()) {
+    auto [_, expr] = PlanExpression(*statement.having_, {plan.get()});
+    plan = std::make_unique<FilterPlanNode>(agg_output_schema, SaveExpression(std::move(expr)),
+                                            SavePlanNode(std::move(plan)));
+  }
+
+  // Plan normal select
+  std::vector<const AbstractExpression *> exprs;
+  output_schema.clear();
+  std::vector<const AbstractPlanNode *> children = {plan.get()};
+  for (const auto &item : statement.select_list_) {
+    auto [name, expr] = PlanExpression(*item, {plan.get()});
+    auto abstract_expr = SaveExpression(std::move(expr));
+    exprs.push_back(abstract_expr);
+    output_schema.emplace_back(std::make_pair(name, abstract_expr));
+  }
+
+  return std::make_unique<ProjectionPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), std::move(exprs),
+                                              SavePlanNode(std::move(plan)));
 }
 
 }  // namespace bustub

--- a/src/planner/plan_insert.cpp
+++ b/src/planner/plan_insert.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include "binder/bound_expression.h"
 #include "binder/statement/insert_statement.h"
 #include "execution/expressions/column_value_expression.h"
 #include "execution/plans/insert_plan.h"

--- a/src/planner/plan_select.cpp
+++ b/src/planner/plan_select.cpp
@@ -1,0 +1,67 @@
+#include <memory>
+#include <utility>
+
+#include "binder/bound_expression.h"
+#include "binder/bound_statement.h"
+#include "binder/bound_table_ref.h"
+#include "binder/statement/insert_statement.h"
+#include "binder/statement/select_statement.h"
+#include "binder/tokens.h"
+#include "common/enums/statement_type.h"
+#include "common/exception.h"
+#include "common/macros.h"
+#include "common/util/string_util.h"
+#include "execution/expressions/abstract_expression.h"
+#include "execution/expressions/column_value_expression.h"
+#include "execution/plans/abstract_plan.h"
+#include "execution/plans/filter_plan.h"
+#include "execution/plans/projection_plan.h"
+#include "fmt/format.h"
+#include "planner/planner.h"
+
+namespace bustub {
+
+auto Planner::PlanSelect(const SelectStatement &statement) -> std::unique_ptr<AbstractPlanNode> {
+  std::unique_ptr<AbstractPlanNode> plan = nullptr;
+
+  switch (statement.table_->type_) {
+    case TableReferenceType::EMPTY:
+      throw Exception("select value is not supported in planner yet");
+    default:
+      plan = PlanTableRef(*statement.table_);
+      break;
+  }
+
+  if (!statement.where_->IsInvalid()) {
+    auto schema = plan->OutputSchema();
+    auto [_, expr] = PlanExpression(*statement.where_, {plan.get()});
+    plan = std::make_unique<FilterPlanNode>(schema, SaveExpression(std::move(expr)), SavePlanNode(std::move(plan)));
+  }
+
+  bool has_agg = false;
+  for (const auto &item : statement.select_list_) {
+    if (item->HasAggregation()) {
+      has_agg = true;
+      break;
+    }
+  }
+
+  if (!statement.having_->IsInvalid() || !statement.group_by_.empty() || has_agg) {
+    return PlanSelectAgg(statement, SavePlanNode(std::move(plan)));
+  }
+
+  // Plan normal select
+  std::vector<const AbstractExpression *> exprs;
+  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+  std::vector<const AbstractPlanNode *> children = {plan.get()};
+  for (const auto &item : statement.select_list_) {
+    auto [name, expr] = PlanExpression(*item, {plan.get()});
+    auto abstract_expr = SaveExpression(std::move(expr));
+    exprs.push_back(abstract_expr);
+    output_schema.emplace_back(std::make_pair(name, abstract_expr));
+  }
+  return std::make_unique<ProjectionPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), std::move(exprs),
+                                              SavePlanNode(std::move(plan)));
+}
+
+}  // namespace bustub

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 #include "binder/binder.h"
 #include "common/bustub_instance.h"
 #include "common/exception.h"
@@ -16,10 +17,15 @@ auto main(int argc, char **argv) -> int {
   auto default_prompt = "bustub> ";
   auto emoji_prompt = "\U0001f6c1> ";  // the bathtub emoji
   bool use_emoji_prompt = false;
+  bool disable_tty = false;
 
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "--emoji-prompt") == 0) {
       use_emoji_prompt = true;
+      break;
+    }
+    if (strcmp(argv[i], "--disable-tty") == 0) {
+      disable_tty = true;
       break;
     }
   }
@@ -32,18 +38,36 @@ auto main(int argc, char **argv) -> int {
 
   linenoiseHistorySetMaxLen(1024);
 
-  char *query_c_str;
-  while ((query_c_str = linenoise(use_emoji_prompt ? emoji_prompt : default_prompt)) != nullptr) {
-    std::string query(query_c_str);
-    linenoiseHistoryAdd(query_c_str);
-    linenoiseFree(query_c_str);
-    try {
-      auto result = bustub->ExecuteSql(query);
-      for (const auto &line : result) {
-        std::cout << line << std::endl;
+  if (disable_tty) {
+    std::string query;
+    while (true) {
+      std::getline(std::cin, query);
+      if (!std::cin) {
+        break;
       }
-    } catch (bustub::Exception &ex) {
-      std::cerr << ex.what() << std::endl;
+      try {
+        auto result = bustub->ExecuteSql(query);
+        for (const auto &line : result) {
+          std::cout << line << std::endl;
+        }
+      } catch (bustub::Exception &ex) {
+        std::cerr << ex.what() << std::endl;
+      }
+    }
+  } else {
+    char *query_c_str;
+    while ((query_c_str = linenoise(use_emoji_prompt ? emoji_prompt : default_prompt)) != nullptr) {
+      std::string query(query_c_str);
+      linenoiseHistoryAdd(query_c_str);
+      linenoiseFree(query_c_str);
+      try {
+        auto result = bustub->ExecuteSql(query);
+        for (const auto &line : result) {
+          std::cout << line << std::endl;
+        }
+      } catch (bustub::Exception &ex) {
+        std::cerr << ex.what() << std::endl;
+      }
     }
   }
 


### PR DESCRIPTION
Not tested with refsol yet, but the plan looks correct. See comments in `PlanSelectAgg` for more.

```
bustub> select colB, sum(colA) > max(colB) from __mock_table_1 group by colB having min(colA) == 3;
=== BINDER ===
BoundSelect {
  table=BoundBaseTableRef { table=__mock_table_1 },
  columns=[__mock_table_1.colB, (sum([__mock_table_1.colA])>max([__mock_table_1.colB]))],
  groupBy=[__mock_table_1.colB],
  having=(min([__mock_table_1.colA])==3),
  where=
}
=== PLANNER ===
Projection { exprs=[#0.0, #0.2>#0.3] } | (__mock_table_1.colB:INTEGER, <unnamed>:BOOLEAN)
  Filter { predicate=#0.1=3 } | (__mock_table_1.colB:INTEGER, agg#0:INTEGER, agg#1:INTEGER, agg#2:INTEGER)
    Agg { types=[min, sum, max], aggregates=[#0.0, #0.0, #0.1], having=, group_by=[#0.1] } | (__mock_table_1.colB:INTEGER, agg#0:INTEGER, agg#1:INTEGER, agg#2:INTEGER)
      MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
=== OPTIMIZER ===
Projection { exprs=[#0.0, #0.2>#0.3] } | (__mock_table_1.colB:INTEGER, <unnamed>:BOOLEAN)
  Filter { predicate=#0.1=3 } | (__mock_table_1.colB:INTEGER, agg#0:INTEGER, agg#1:INTEGER, agg#2:INTEGER)
    Agg { types=[min, sum, max], aggregates=[#0.0, #0.0, #0.1], having=, group_by=[#0.1] } | (__mock_table_1.colB:INTEGER, agg#0:INTEGER, agg#1:INTEGER, agg#2:INTEGER)
      MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
```