### PR TITLE
feat(planner): support plan order by, limit, and explain

### DIFF
--- a/src/binder/bind_insert.cpp
+++ b/src/binder/bind_insert.cpp
@@ -26,6 +26,7 @@
 
 #include "binder/binder.h"
 #include "binder/bound_expression.h"
+#include "binder/bound_order_by.h"
 #include "binder/bound_table_ref.h"
 #include "binder/statement/insert_statement.h"
 #include "binder/statement/select_statement.h"

--- a/src/binder/statement/CMakeLists.txt
+++ b/src/binder/statement/CMakeLists.txt
@@ -3,8 +3,9 @@ add_library(
   OBJECT
   create_statement.cpp
   delete_statement.cpp
+  explain_statement.cpp
   insert_statement.cpp
   select_statement.cpp)
 set(ALL_OBJECT_FILES
-    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_statement>
-    PARENT_SCOPE)
+  ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_statement>
+  PARENT_SCOPE)

--- a/src/binder/statement/explain_statement.cpp
+++ b/src/binder/statement/explain_statement.cpp
@@ -15,7 +15,7 @@ ExplainStatement::ExplainStatement(std::unique_ptr<BoundStatement> statement)
     : BoundStatement(StatementType::EXPLAIN_STATEMENT), statement_(std::move(statement)) {}
 
 auto ExplainStatement::ToString() const -> std::string {
-  return fmt::format("BoundExplain {{\n  statement={},\n}}", IndentAllLines(statement_->ToString(), 2));
+  return fmt::format("BoundExplain {{\n  statement={},\n}}", StringUtil::IndentAllLines(statement_->ToString(), 2));
 }
 
 }  // namespace bustub

--- a/src/binder/statement/explain_statement.cpp
+++ b/src/binder/statement/explain_statement.cpp
@@ -1,0 +1,21 @@
+#include "binder/statement/explain_statement.h"
+#include "fmt/ranges.h"
+
+#include "binder/binder.h"
+#include "binder/bound_expression.h"
+#include "binder/bound_order_by.h"
+#include "binder/bound_table_ref.h"
+#include "binder/statement/insert_statement.h"
+#include "binder/statement/select_statement.h"
+#include "common/util/string_util.h"
+
+namespace bustub {
+
+ExplainStatement::ExplainStatement(std::unique_ptr<BoundStatement> statement)
+    : BoundStatement(StatementType::EXPLAIN_STATEMENT), statement_(std::move(statement)) {}
+
+auto ExplainStatement::ToString() const -> std::string {
+  return fmt::format("BoundExplain {{\n  statement={},\n}}", IndentAllLines(statement_->ToString(), 2));
+}
+
+}  // namespace bustub

--- a/src/binder/statement/insert_statement.cpp
+++ b/src/binder/statement/insert_statement.cpp
@@ -1,6 +1,7 @@
 #include "fmt/ranges.h"
 
 #include "binder/bound_expression.h"
+#include "binder/bound_order_by.h"
 #include "binder/bound_table_ref.h"
 #include "binder/statement/insert_statement.h"
 #include "binder/statement/select_statement.h"

--- a/src/binder/statement/select_statement.cpp
+++ b/src/binder/statement/select_statement.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include "binder/bound_order_by.h"
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
@@ -14,16 +15,23 @@ SelectStatement::SelectStatement(std::unique_ptr<BoundTableRef> table,
                                  std::vector<std::unique_ptr<BoundExpression>> select_list,
                                  std::unique_ptr<BoundExpression> where,
                                  std::vector<std::unique_ptr<BoundExpression>> group_by,
-                                 std::unique_ptr<BoundExpression> having)
+                                 std::unique_ptr<BoundExpression> having, std::unique_ptr<BoundExpression> limit_count,
+                                 std::unique_ptr<BoundExpression> limit_offset,
+                                 std::vector<std::unique_ptr<BoundOrderBy>> sort)
     : BoundStatement(StatementType::SELECT_STATEMENT),
       table_(std::move(table)),
       select_list_(std::move(select_list)),
       where_(std::move(where)),
       group_by_(std::move(group_by)),
-      having_(std::move(having)) {}
+      having_(std::move(having)),
+      limit_count_(std::move(limit_count)),
+      limit_offset_(std::move(limit_offset)),
+      sort_(std::move(sort)) {}
 
 auto SelectStatement::ToString() const -> std::string {
-  return fmt::format("BoundSelect {{\n  table={},\n  columns={},\n  groupBy={},\n  having={},\n  where={}\n}}", table_,
-                     select_list_, group_by_, having_, where_);
+  return fmt::format(
+      "BoundSelect {{\n  table={},\n  columns={},\n  groupBy={},\n  having={},\n  where={},\n  limit={},\n  "
+      "offset={},\n  order_by={}}}",
+      table_, select_list_, group_by_, having_, where_, limit_count_, limit_offset_, sort_);
 }
 }  // namespace bustub

--- a/src/binder/transformer.cpp
+++ b/src/binder/transformer.cpp
@@ -22,15 +22,19 @@
 
 #include "binder/binder.h"
 #include "binder/bound_expression.h"
+#include "binder/bound_order_by.h"
 #include "binder/bound_statement.h"
 #include "binder/statement/create_statement.h"
 #include "binder/statement/delete_statement.h"
+#include "binder/statement/explain_statement.h"
 #include "binder/statement/insert_statement.h"
 #include "binder/statement/select_statement.h"
 #include "binder/table_ref/bound_base_table_ref.h"
 #include "common/exception.h"
 #include "common/logger.h"
 #include "common/util/string_util.h"
+#include "nodes/nodes.hpp"
+#include "nodes/parsenodes.hpp"
 #include "type/decimal_type.h"
 
 namespace bustub {
@@ -61,6 +65,8 @@ auto Binder::TransformStatement(duckdb_libpgquery::PGNode *stmt) -> std::unique_
       return BindInsert(reinterpret_cast<duckdb_libpgquery::PGInsertStmt *>(stmt));
     case duckdb_libpgquery::T_PGSelectStmt:
       return BindSelect(reinterpret_cast<duckdb_libpgquery::PGSelectStmt *>(stmt));
+    case duckdb_libpgquery::T_PGExplainStmt:
+      return BindExplain(reinterpret_cast<duckdb_libpgquery::PGExplainStmt *>(stmt));
     case duckdb_libpgquery::T_PGDeleteStmt:
       return std::make_unique<DeleteStatement>(reinterpret_cast<duckdb_libpgquery::PGDeleteStmt *>(stmt));
     case duckdb_libpgquery::T_PGIndexStmt:

--- a/src/execution/filter_executor.cpp
+++ b/src/execution/filter_executor.cpp
@@ -1,14 +1,35 @@
 #include "execution/executors/filter_executor.h"
 #include "common/exception.h"
+#include "type/value_factory.h"
 
 namespace bustub {
 
 FilterExecutor::FilterExecutor(ExecutorContext *exec_ctx, const FilterPlanNode *plan,
                                std::unique_ptr<AbstractExecutor> &&child_executor)
-    : AbstractExecutor(exec_ctx) {}
+    : AbstractExecutor(exec_ctx), plan_(plan), child_executor_(std::move(child_executor)) {}
 
-void FilterExecutor::Init() { throw NotImplementedException("FilterExecutor is not implemented"); }
+void FilterExecutor::Init() {
+  // Initialize the child executor
+  child_executor_->Init();
+}
 
-auto FilterExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
+auto FilterExecutor::Next(Tuple *tuple, RID *rid) -> bool {
+  auto filter_expr = plan_->GetPredicate();
+  auto true_value = ValueFactory::GetBooleanValue(true);
+
+  while (true) {
+    // Get the next tuple
+    const auto status = child_executor_->Next(tuple, rid);
+
+    if (!status) {
+      return false;
+    }
+
+    auto value = filter_expr->Evaluate(tuple, child_executor_->GetOutputSchema());
+    if (value.CompareEquals(true_value) == CmpBool::CmpTrue) {
+      return true;
+    }
+  }
+}
 
 }  // namespace bustub

--- a/src/execution/fmt_impl.cpp
+++ b/src/execution/fmt_impl.cpp
@@ -1,3 +1,5 @@
+#include <type_traits>
+#include "execution/plans/sort_plan.h"
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
@@ -26,11 +28,23 @@ auto AbstractPlanNode::ChildrenToString(int indent) const -> std::string {
   return fmt::format("\n{}", fmt::join(children_str, "\n"));
 }
 
+// TODO(chi): ALL BELOW HELPERS ARE NO LONGER NEED IF WE SWITCH TO std::unique_ptr INSTEAD OF RAW POINTERS!!!
+
 static auto HelperVecExprFmt(const std::vector<const AbstractExpression *> &exprs) -> std::string {
   std::vector<std::string> joins;
   joins.reserve(exprs.size());
   for (const auto &expr : exprs) {
     joins.push_back(fmt::format("{}", *expr));
+  }
+  return fmt::format("{}", fmt::join(joins, ", "));
+}
+
+template <typename T>
+static auto HelperVecPairExprFmt(const std::vector<std::pair<T, const AbstractExpression *>> &exprs) -> std::string {
+  std::vector<std::string> joins;
+  joins.reserve(exprs.size());
+  for (const auto &[ty, expr] : exprs) {
+    joins.push_back(fmt::format("({}, {})", ty, *expr));
   }
   return fmt::format("{}", fmt::join(joins, ", "));
 }
@@ -42,8 +56,11 @@ auto AggregationPlanNode::PlanNodeToString() const -> std::string {
 }
 
 auto ProjectionPlanNode::PlanNodeToString() const -> std::string {
-  auto exprs = HelperVecExprFmt(expressions_);
-  return fmt::format("Projection {{ exprs=[{}] }}", exprs);
+  return fmt::format("Projection {{ exprs={} }}", HelperVecExprFmt(expressions_));
+}
+
+auto SortPlanNode::PlanNodeToString() const -> std::string {
+  return fmt::format("Sort {{ order_bys={} }}", HelperVecPairExprFmt(order_bys_));
 }
 
 }  // namespace bustub

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -75,8 +75,6 @@ class SelectStatement;
 class CreateStatement;
 class ExplainStatement;
 
-auto IndentAllLines(const std::string &lines, size_t num_indent) -> std::string;
-
 /**
  * The binder is responsible for transforming the Postgres parse tree to a binder tree
  * which can be recognized unambiguously by the BusTub planner.

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -44,6 +44,7 @@
 #include "common/util/string_util.h"
 #include "fmt/format.h"
 #include "nodes/parsenodes.hpp"
+#include "nodes/pg_list.hpp"
 #include "pg_definitions.hpp"
 #include "postgres_parser.hpp"
 #include "type/type_id.h"
@@ -69,8 +70,12 @@ class BoundExpression;
 class BoundTableRef;
 class BoundExpression;
 class BoundExpressionListRef;
+class BoundOrderBy;
 class SelectStatement;
 class CreateStatement;
+class ExplainStatement;
+
+auto IndentAllLines(const std::string &lines, size_t num_indent) -> std::string;
 
 /**
  * The binder is responsible for transforming the Postgres parse tree to a binder tree
@@ -108,6 +113,8 @@ class Binder {
 
   // The following parts are undocumented. One `BindXXX` functions simply corresponds to a
   // node type in the Postgres parse tree.
+
+  auto BindExplain(duckdb_libpgquery::PGExplainStmt *stmt) -> std::unique_ptr<ExplainStatement>;
 
   auto BindCreate(duckdb_libpgquery::PGCreateStmt *pg_stmt) -> std::unique_ptr<CreateStatement>;
 
@@ -155,6 +162,12 @@ class Binder {
   auto BindInsert(duckdb_libpgquery::PGInsertStmt *pg_stmt) -> std::unique_ptr<InsertStatement>;
 
   auto BindValuesList(duckdb_libpgquery::PGList *list) -> std::unique_ptr<BoundExpressionListRef>;
+
+  auto BindLimitCount(duckdb_libpgquery::PGNode *root) -> std::unique_ptr<BoundExpression>;
+
+  auto BindLimitOffset(duckdb_libpgquery::PGNode *root) -> std::unique_ptr<BoundExpression>;
+
+  auto BindSort(duckdb_libpgquery::PGList *list) -> std::vector<std::unique_ptr<BoundOrderBy>>;
 
   class ContextGuard {
    public:

--- a/src/include/binder/bound_order_by.h
+++ b/src/include/binder/bound_order_by.h
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//                         BusTub
+//
+// bustub/binder/bound_order_by.h
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "binder/bound_expression.h"
+#include "common/exception.h"
+#include "fmt/format.h"
+
+namespace bustub {
+
+/**
+ * All types of order-bys in binder.
+ */
+enum class OrderByType : uint8_t {
+  INVALID = 0, /**< Invalid order by type. */
+  DEFAULT = 1, /**< Default order by type. */
+  ASC = 2,     /**< Ascending order by type. */
+  DESC = 3,    /**< Descending order by type. */
+};
+
+/**
+ * BoundOrderBy is an item in the ORDER BY clause.
+ */
+class BoundOrderBy {
+ public:
+  explicit BoundOrderBy(OrderByType type, std::unique_ptr<BoundExpression> expr)
+      : type_(type), expr_(std::move(expr)) {}
+
+  /** The order by type. */
+  OrderByType type_;
+
+  /** The order by expression */
+  std::unique_ptr<BoundExpression> expr_;
+
+  /** Render this statement as a string. */
+  auto ToString() const -> std::string { return fmt::format("BoundOrderBy {{ type={}, expr={} }}", type_, expr_); }
+};
+
+}  // namespace bustub
+
+template <typename T>
+struct fmt::formatter<T, std::enable_if_t<std::is_base_of<bustub::BoundOrderBy, T>::value, char>>
+    : fmt::formatter<std::string> {
+  template <typename FormatCtx>
+  auto format(const bustub::BoundOrderBy &x, FormatCtx &ctx) const {
+    return fmt::formatter<std::string>::format(x.ToString(), ctx);
+  }
+};
+
+template <typename T>
+struct fmt::formatter<std::unique_ptr<T>, std::enable_if_t<std::is_base_of<bustub::BoundOrderBy, T>::value, char>>
+    : fmt::formatter<std::string> {
+  template <typename FormatCtx>
+  auto format(const std::unique_ptr<bustub::BoundOrderBy> &x, FormatCtx &ctx) const {
+    return fmt::formatter<std::string>::format(x->ToString(), ctx);
+  }
+};
+
+template <>
+struct fmt::formatter<bustub::OrderByType> : formatter<string_view> {
+  template <typename FormatContext>
+  auto format(bustub::OrderByType c, FormatContext &ctx) const {
+    string_view name;
+    switch (c) {
+      case bustub::OrderByType::INVALID:
+        name = "Invalid";
+        break;
+      case bustub::OrderByType::ASC:
+        name = "Ascending";
+        break;
+      case bustub::OrderByType::DESC:
+        name = "Descending";
+        break;
+      case bustub::OrderByType::DEFAULT:
+        name = "Default";
+        break;
+      default:
+        name = "Unknown";
+        break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};

--- a/src/include/binder/statement/explain_statement.h
+++ b/src/include/binder/statement/explain_statement.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         BusTub
+//
+// binder/select_statement.h
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include "binder/bound_statement.h"
+
+namespace bustub {
+
+class ExplainStatement : public BoundStatement {
+ public:
+  explicit ExplainStatement(std::unique_ptr<BoundStatement> statement);
+
+  std::unique_ptr<BoundStatement> statement_;
+
+  auto ToString() const -> std::string override;
+};
+
+}  // namespace bustub

--- a/src/include/binder/statement/select_statement.h
+++ b/src/include/binder/statement/select_statement.h
@@ -17,6 +17,7 @@ namespace bustub {
 class Catalog;
 class BoundTableRef;
 class BoundExpression;
+class BoundOrderBy;
 
 class SelectStatement : public BoundStatement {
  public:
@@ -24,7 +25,10 @@ class SelectStatement : public BoundStatement {
                            std::vector<std::unique_ptr<BoundExpression>> select_list,
                            std::unique_ptr<BoundExpression> where,
                            std::vector<std::unique_ptr<BoundExpression>> group_by,
-                           std::unique_ptr<BoundExpression> having);
+                           std::unique_ptr<BoundExpression> having, std::unique_ptr<BoundExpression> limit_count,
+                           std::unique_ptr<BoundExpression> limit_offset,
+                           std::vector<std::unique_ptr<BoundOrderBy>> sort);
+
   /** Bound FROM clause. */
   std::unique_ptr<BoundTableRef> table_;
 
@@ -39,6 +43,15 @@ class SelectStatement : public BoundStatement {
 
   /** Bound HAVING clause. */
   std::unique_ptr<BoundExpression> having_;
+
+  /** Bound LIMIT clause. */
+  std::unique_ptr<BoundExpression> limit_count_;
+
+  /** Bound OFFSET clause. */
+  std::unique_ptr<BoundExpression> limit_offset_;
+
+  /** Bound ORDER BY clause. */
+  std::vector<std::unique_ptr<BoundOrderBy>> sort_;
 
   auto ToString() const -> std::string override;
 };

--- a/src/include/execution/executors/filter_executor.h
+++ b/src/include/execution/executors/filter_executor.h
@@ -53,5 +53,8 @@ class FilterExecutor : public AbstractExecutor {
  private:
   /** The filter plan node to be executed */
   const FilterPlanNode *plan_;
+
+  /** The child executor from which tuples are obtained */
+  std::unique_ptr<AbstractExecutor> child_executor_;
 };
 }  // namespace bustub

--- a/src/include/execution/expressions/abstract_expression.h
+++ b/src/include/execution/expressions/abstract_expression.h
@@ -97,6 +97,9 @@ struct fmt::formatter<std::unique_ptr<T>, std::enable_if_t<std::is_base_of<bustu
     : fmt::formatter<std::string> {
   template <typename FormatCtx>
   auto format(const std::unique_ptr<bustub::AbstractExpression> &x, FormatCtx &ctx) const {
-    return fmt::formatter<std::string>::format(x->ToString(), ctx);
+    if (x != nullptr) {
+      return fmt::formatter<std::string>::format(x->ToString(), ctx);
+    }
+    return fmt::formatter<std::string>::format("", ctx);
   }
 };

--- a/src/include/execution/plans/limit_plan.h
+++ b/src/include/execution/plans/limit_plan.h
@@ -12,7 +12,10 @@
 
 #pragma once
 
+#include <string>
+
 #include "execution/plans/abstract_plan.h"
+#include "fmt/format.h"
 
 namespace bustub {
 
@@ -40,6 +43,9 @@ class LimitPlanNode : public AbstractPlanNode {
     BUSTUB_ASSERT(GetChildren().size() == 1, "Limit should have at most one child plan.");
     return GetChildAt(0);
   }
+
+ protected:
+  auto PlanNodeToString() const -> std::string override { return fmt::format("Limit {{ limit={} }}", limit_); }
 
  private:
   /** The limit */

--- a/src/include/execution/plans/sort_plan.h
+++ b/src/include/execution/plans/sort_plan.h
@@ -14,7 +14,10 @@
 
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "binder/bound_order_by.h"
 #include "catalog/catalog.h"
 #include "execution/expressions/abstract_expression.h"
 #include "execution/plans/abstract_plan.h"
@@ -31,8 +34,11 @@ class SortPlanNode : public AbstractPlanNode {
    * Construct a new SortPlanNode instance.
    * @param output The output schema of this sort plan node
    * @param child The child plan node
+   * @param order_by The sort expressions and their order by types.
    */
-  SortPlanNode(const Schema *output, const AbstractPlanNode *child) : AbstractPlanNode(output, {child}) {}
+  SortPlanNode(const Schema *output, const AbstractPlanNode *child,
+               std::vector<std::pair<OrderByType, const AbstractExpression *>> order_bys)
+      : AbstractPlanNode(output, {child}), order_bys_(std::move(order_bys)) {}
 
   /** @return The type of the plan node */
   auto GetType() const -> PlanType override { return PlanType::Sort; }
@@ -43,10 +49,14 @@ class SortPlanNode : public AbstractPlanNode {
     return GetChildAt(0);
   }
 
+  /** @return Get sort by expressions */
+  auto GetOrderBy() -> const std::vector<std::pair<OrderByType, const AbstractExpression *>> & { return order_bys_; }
+
  protected:
-  auto PlanNodeToString() const -> std::string override { return fmt::format("Sort {{ }}"); }
+  auto PlanNodeToString() const -> std::string override;
 
  private:
+  std::vector<std::pair<OrderByType, const AbstractExpression *>> order_bys_;
 };
 
 }  // namespace bustub

--- a/src/planner/plan_aggregation.cpp
+++ b/src/planner/plan_aggregation.cpp
@@ -89,11 +89,14 @@ auto Planner::PlanSelectAgg(const SelectStatement &statement, const AbstractPlan
 
   // Plan group by expressions
   std::vector<const AbstractExpression *> group_by_exprs;
+  size_t group_by_idx = 0;
   for (const auto &expr : statement.group_by_) {
     auto [col_name, abstract_expr] = PlanExpression(*expr, {child});
     auto abstract_expr_ptr = SaveExpression(std::move(abstract_expr));
     group_by_exprs.push_back(abstract_expr_ptr);
-    output_schema.emplace_back(std::make_pair(std::move(col_name), abstract_expr_ptr));
+    auto schema_expr = SaveExpression(
+        std::make_unique<AggregateValueExpression>(true, group_by_idx++, abstract_expr_ptr->GetReturnType()));
+    output_schema.emplace_back(std::make_pair(std::move(col_name), schema_expr));
   }
 
   // Rewrite all agg call inside having.
@@ -111,7 +114,7 @@ auto Planner::PlanSelectAgg(const SelectStatement &statement, const AbstractPlan
   std::vector<AggregationType> agg_types;
   auto agg_begin_idx = group_by_exprs.size();  // agg-calls will be after group-bys in the output of agg.
 
-  int term_idx = 0;
+  size_t term_idx = 0;
   for (const auto &item : ctx_.aggregations_) {
     if (item->type_ != ExpressionType::AGG_CALL) {
       throw NotImplementedException("alias for agg call is not supported for now");
@@ -121,7 +124,9 @@ auto Planner::PlanSelectAgg(const SelectStatement &statement, const AbstractPlan
     auto abstract_expr = SaveExpression(std::move(expr));
     input_exprs.push_back(abstract_expr);
     agg_types.push_back(agg_type);
-    output_schema.emplace_back(std::make_pair(fmt::format("agg#{}", term_idx), abstract_expr));
+    auto schema_expr =
+        SaveExpression(std::make_unique<AggregateValueExpression>(false, term_idx, abstract_expr->GetReturnType()));
+    output_schema.emplace_back(std::make_pair(fmt::format("agg#{}", term_idx), schema_expr));
     // TODO(chi): correctly infer the type of the agg output.
     ctx_.expr_in_agg_.emplace_back(
         std::make_unique<ColumnValueExpression>(0, agg_begin_idx + term_idx, TypeId::INTEGER));

--- a/src/planner/plan_aggregation.cpp
+++ b/src/planner/plan_aggregation.cpp
@@ -142,7 +142,7 @@ auto Planner::PlanSelectAgg(const SelectStatement &statement, const AbstractPlan
                                             SavePlanNode(std::move(plan)));
   }
 
-  // Plan normal select
+  // Plan normal select (within aggregation context)
   std::vector<const AbstractExpression *> exprs;
   output_schema.clear();
   std::vector<const AbstractPlanNode *> children = {plan.get()};

--- a/src/planner/plan_select.cpp
+++ b/src/planner/plan_select.cpp
@@ -1,9 +1,12 @@
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "binder/bound_expression.h"
+#include "binder/bound_order_by.h"
 #include "binder/bound_statement.h"
 #include "binder/bound_table_ref.h"
+#include "binder/expressions/bound_constant.h"
 #include "binder/statement/insert_statement.h"
 #include "binder/statement/select_statement.h"
 #include "binder/tokens.h"
@@ -15,9 +18,12 @@
 #include "execution/expressions/column_value_expression.h"
 #include "execution/plans/abstract_plan.h"
 #include "execution/plans/filter_plan.h"
+#include "execution/plans/limit_plan.h"
 #include "execution/plans/projection_plan.h"
+#include "execution/plans/sort_plan.h"
 #include "fmt/format.h"
 #include "planner/planner.h"
+#include "type/type_id.h"
 
 namespace bustub {
 
@@ -47,21 +53,75 @@ auto Planner::PlanSelect(const SelectStatement &statement) -> std::unique_ptr<Ab
   }
 
   if (!statement.having_->IsInvalid() || !statement.group_by_.empty() || has_agg) {
-    return PlanSelectAgg(statement, SavePlanNode(std::move(plan)));
+    // Plan aggregation
+    plan = PlanSelectAgg(statement, SavePlanNode(std::move(plan)));
+  } else {
+    // Plan normal select
+    std::vector<const AbstractExpression *> exprs;
+    std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
+    std::vector<const AbstractPlanNode *> children = {plan.get()};
+    for (const auto &item : statement.select_list_) {
+      auto [name, expr] = PlanExpression(*item, {plan.get()});
+      auto abstract_expr = SaveExpression(std::move(expr));
+      exprs.push_back(abstract_expr);
+      output_schema.emplace_back(std::make_pair(name, abstract_expr));
+    }
+    plan = std::make_unique<ProjectionPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), std::move(exprs),
+                                                SavePlanNode(std::move(plan)));
   }
 
-  // Plan normal select
-  std::vector<const AbstractExpression *> exprs;
-  std::vector<std::pair<std::string, const AbstractExpression *>> output_schema;
-  std::vector<const AbstractPlanNode *> children = {plan.get()};
-  for (const auto &item : statement.select_list_) {
-    auto [name, expr] = PlanExpression(*item, {plan.get()});
-    auto abstract_expr = SaveExpression(std::move(expr));
-    exprs.push_back(abstract_expr);
-    output_schema.emplace_back(std::make_pair(name, abstract_expr));
+  // Plan LIMIT
+  if (!statement.limit_count_->IsInvalid() || !statement.limit_offset_->IsInvalid()) {
+    std::optional<size_t> offset = std::nullopt;
+    std::optional<size_t> limit = std::nullopt;
+
+    if (!statement.limit_count_->IsInvalid()) {
+      if (statement.limit_count_->type_ == ExpressionType::CONSTANT) {
+        const auto constant_expr = dynamic_cast<BoundConstant &>(*statement.limit_count_);
+        const auto val = constant_expr.val_.CastAs(TypeId::INTEGER);
+        if (constant_expr.val_.GetTypeId() == TypeId::INTEGER) {
+          limit = std::make_optional(constant_expr.val_.GetAs<int32_t>());
+        } else {
+          throw NotImplementedException("LIMIT clause must be an integer constant.");
+        }
+      } else {
+        throw NotImplementedException("LIMIT clause must be an integer constant.");
+      }
+    }
+
+    if (!statement.limit_offset_->IsInvalid()) {
+      if (statement.limit_offset_->type_ == ExpressionType::CONSTANT) {
+        const auto constant_expr = dynamic_cast<BoundConstant &>(*statement.limit_offset_);
+        const auto val = constant_expr.val_.CastAs(TypeId::INTEGER);
+        if (constant_expr.val_.GetTypeId() == TypeId::INTEGER) {
+          offset = std::make_optional(constant_expr.val_.GetAs<int32_t>());
+        } else {
+          throw NotImplementedException("OFFSET clause must be an integer constant.");
+        }
+      } else {
+        throw NotImplementedException("OFFSET clause must be an integer constant.");
+      }
+    }
+
+    if (offset != std::nullopt) {
+      throw NotImplementedException("OFFSET clause is not supported yet.");
+    }
+
+    plan = std::make_unique<LimitPlanNode>(plan->OutputSchema(), SavePlanNode(std::move(plan)), *limit);
   }
-  return std::make_unique<ProjectionPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), std::move(exprs),
-                                              SavePlanNode(std::move(plan)));
+
+  // Plan ORDER BY
+  if (!statement.sort_.empty()) {
+    std::vector<std::pair<OrderByType, const AbstractExpression *>> order_bys;
+    for (const auto &order_by : statement.sort_) {
+      auto [_, expr] = PlanExpression(*order_by->expr_, {plan.get()});
+      auto abstract_expr = SaveExpression(std::move(expr));
+      order_bys.emplace_back(std::make_pair(order_by->type_, abstract_expr));
+    }
+    plan = std::make_unique<SortPlanNode>(plan->OutputSchema(), SavePlanNode(std::move(plan)), std::move(order_bys));
+  }
+
+  return plan;
 }
 
 }  // namespace bustub

--- a/src/planner/plan_table_ref.cpp
+++ b/src/planner/plan_table_ref.cpp
@@ -72,7 +72,7 @@ auto Planner::PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> std::uniqu
   if (StringUtil::StartsWith(table->name_, "__")) {
     // Plan as MockScanExecutor if it is a mock table.
     if (StringUtil::StartsWith(table->name_, "__mock")) {
-      return std::make_unique<MockScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), 100);
+      return std::make_unique<MockScanPlanNode>(SaveSchema(MakeOutputSchema(output_schema)), 100, table->name_);
     }
     throw bustub::Exception(fmt::format("unsupported internal table: {}", table->name_));
   }


### PR DESCRIPTION
As title.

```
bustub> explain select * from __mock_table_1 order by (colA > colB) desc limit 10;
=== BINDER ===
BoundExplain {
  statement=
  BoundSelect {
    table=BoundBaseTableRef { table=__mock_table_1 },
    columns=[__mock_table_1.colA, __mock_table_1.colB],
    groupBy=[],
    having=,
    where=,
    limit=10,
    offset=,
    order_by=[BoundOrderBy { type=Descending, expr=(__mock_table_1.colA>__mock_table_1.colB) }]},
}
=== PLANNER ===
Sort { order_bys=(Descending, #0.0>#0.1) } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
  Limit { limit=10 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
    Projection { exprs=#0.0, #0.1 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
      MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
=== OPTIMIZER ===
Sort { order_bys=(Descending, #0.0>#0.1) } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
  Limit { limit=10 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
    Projection { exprs=#0.0, #0.1 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
      MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
bustub> 
```