### PR TITLE
chore(test): set gtest_color=auto

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
 
     gtest_discover_tests(${bustub_test_name}
             EXTRA_ARGS
-            --gtest_color=yes
+            --gtest_color=auto
             --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${bustub_test_name}.xml
             --gtest_catch_exceptions=0
             PROPERTIES


### PR DESCRIPTION
So that autograder won't have color, but students' console will.