### PR TITLE
feat(planner): plan subquery and distinct

### DIFF
--- a/src/binder/fmt_impl.cpp
+++ b/src/binder/fmt_impl.cpp
@@ -1,14 +1,28 @@
+#include "binder/bound_order_by.h"
 #include "binder/expressions/bound_agg_call.h"
+#include "binder/statement/select_statement.h"
 #include "binder/table_ref/bound_expression_list_ref.h"
+#include "binder/table_ref/bound_subquery_ref.h"
+#include "common/util/string_util.h"
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
 namespace bustub {
 
-auto BoundAggCall::ToString() const -> std::string { return fmt::format("{}({})", func_name_, args_); }
+auto BoundAggCall::ToString() const -> std::string {
+  if (is_distinct_) {
+    return fmt::format("{}_distinct({})", func_name_, args_);
+  }
+  return fmt::format("{}({})", func_name_, args_);
+}
 
 auto BoundExpressionListRef::ToString() const -> std::string {
-  return fmt::format("BoundExpressionListRef {{ values={} }}", values_);
+  return fmt::format("BoundExpressionListRef {{ identifier={}, values={} }}", identifier_, values_);
+}
+
+auto BoundSubqueryRef::ToString() const -> std::string {
+  return fmt::format("BoundSubqueryRef {{\n  alias={},\n  subquery={},\n}}", alias_,
+                     StringUtil::IndentAllLines(subquery_->ToString(), 2, true));
 }
 
 }  // namespace bustub

--- a/src/binder/statement/explain_statement.cpp
+++ b/src/binder/statement/explain_statement.cpp
@@ -15,7 +15,8 @@ ExplainStatement::ExplainStatement(std::unique_ptr<BoundStatement> statement)
     : BoundStatement(StatementType::EXPLAIN_STATEMENT), statement_(std::move(statement)) {}
 
 auto ExplainStatement::ToString() const -> std::string {
-  return fmt::format("BoundExplain {{\n  statement={},\n}}", StringUtil::IndentAllLines(statement_->ToString(), 2));
+  return fmt::format("BoundExplain {{\n  statement={},\n}}",
+                     StringUtil::IndentAllLines(statement_->ToString(), 2, true));
 }
 
 }  // namespace bustub

--- a/src/binder/statement/select_statement.cpp
+++ b/src/binder/statement/select_statement.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "binder/bound_order_by.h"
+#include "common/util/string_util.h"
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
@@ -17,7 +18,7 @@ SelectStatement::SelectStatement(std::unique_ptr<BoundTableRef> table,
                                  std::vector<std::unique_ptr<BoundExpression>> group_by,
                                  std::unique_ptr<BoundExpression> having, std::unique_ptr<BoundExpression> limit_count,
                                  std::unique_ptr<BoundExpression> limit_offset,
-                                 std::vector<std::unique_ptr<BoundOrderBy>> sort)
+                                 std::vector<std::unique_ptr<BoundOrderBy>> sort, bool is_distinct)
     : BoundStatement(StatementType::SELECT_STATEMENT),
       table_(std::move(table)),
       select_list_(std::move(select_list)),
@@ -26,12 +27,15 @@ SelectStatement::SelectStatement(std::unique_ptr<BoundTableRef> table,
       having_(std::move(having)),
       limit_count_(std::move(limit_count)),
       limit_offset_(std::move(limit_offset)),
-      sort_(std::move(sort)) {}
+      sort_(std::move(sort)),
+      is_distinct_(is_distinct) {}
 
 auto SelectStatement::ToString() const -> std::string {
   return fmt::format(
       "BoundSelect {{\n  table={},\n  columns={},\n  groupBy={},\n  having={},\n  where={},\n  limit={},\n  "
-      "offset={},\n  order_by={}}}",
-      table_, select_list_, group_by_, having_, where_, limit_count_, limit_offset_, sort_);
+      "offset={},\n  order_by={},\n  is_distinct={},\n}}",
+      StringUtil::IndentAllLines(table_->ToString(), 2, true), select_list_, group_by_, having_, where_, limit_count_,
+      limit_offset_, sort_, is_distinct_);
 }
+
 }  // namespace bustub

--- a/src/common/bustub_instance.cpp
+++ b/src/common/bustub_instance.cpp
@@ -9,6 +9,7 @@
 #include "catalog/schema.h"
 #include "catalog/table_generator.h"
 #include "common/enums/statement_type.h"
+#include "common/exception.h"
 #include "concurrency/lock_manager.h"
 #include "execution/execution_engine.h"
 #include "execution/executor_context.h"
@@ -40,7 +41,12 @@ BustubInstance::BustubInstance(const std::string &db_file_name) {
 
   // We need more frames for GenerateTestTable to work. Therefore, we use 128 instead of the default
   // buffer pool size specified in `config.h`.
-  buffer_pool_manager_ = new BufferPoolManagerInstance(128, disk_manager_, LRUK_REPLACER_K, log_manager_);
+  try {
+    buffer_pool_manager_ = new BufferPoolManagerInstance(128, disk_manager_, LRUK_REPLACER_K, log_manager_);
+  } catch (NotImplementedException &e) {
+    std::cerr << "BufferPoolManager is not implemented, only mock tables are supported." << std::endl;
+    buffer_pool_manager_ = nullptr;
+  }
 
   // Transaction (txn) related.
   lock_manager_ = new LockManager();

--- a/src/common/util/string_util.cpp
+++ b/src/common/util/string_util.cpp
@@ -208,15 +208,23 @@ auto StringUtil::Replace(std::string source, const std::string &from, const std:
   return source;
 }
 
-auto StringUtil::IndentAllLines(const std::string &lines, size_t num_indent) -> std::string {
+auto StringUtil::IndentAllLines(const std::string &lines, size_t num_indent, bool except_first_line) -> std::string {
   std::vector<std::string> lines_str;
   auto lines_split = StringUtil::Split(lines, '\n');
   lines_str.reserve(lines_split.size());
   auto indent_str = StringUtil::Indent(num_indent);
+  bool is_first_line = true;
   for (auto &line : lines_split) {
+    if (is_first_line) {
+      is_first_line = false;
+      if (except_first_line) {
+        lines_str.push_back(line);
+        continue;
+      }
+    }
     lines_str.push_back(fmt::format("{}{}", indent_str, line));
   }
-  return fmt::format("\n{}", fmt::join(lines_str, "\n"));
+  return fmt::format("{}", fmt::join(lines_str, "\n"));
 }
 
 }  // namespace bustub

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -120,6 +120,8 @@ class Binder {
 
   auto BindSelect(duckdb_libpgquery::PGSelectStmt *pg_stmt) -> std::unique_ptr<SelectStatement>;
 
+  auto BindRangeSubselect(duckdb_libpgquery::PGRangeSubselect *root) -> std::unique_ptr<BoundTableRef>;
+
   auto BindSelectList(duckdb_libpgquery::PGList *list) -> std::vector<std::unique_ptr<BoundExpression>>;
 
   auto BindWhere(duckdb_libpgquery::PGNode *root) -> std::unique_ptr<BoundExpression>;
@@ -196,6 +198,9 @@ class Binder {
 
   /** The current scope for resolving column ref, used in binding expressions */
   const BoundTableRef *scope_;
+
+  /** Sometimes we will need to assign a name to some unnamed items. This variable gives them a universal ID. */
+  size_t universal_id_{0};
 };
 
 }  // namespace bustub

--- a/src/include/binder/bound_table_ref.h
+++ b/src/include/binder/bound_table_ref.h
@@ -18,6 +18,7 @@ enum class TableReferenceType : uint8_t {
   JOIN = 3,            /**< Output of join. */
   CROSS_PRODUCT = 4,   /**< Output of cartesian product. */
   EXPRESSION_LIST = 5, /**< Values clause. */
+  SUBQUERY = 6,        /**< Subquery. */
   EMPTY = 8            /**< Placeholder for empty FROM. */
 };
 
@@ -91,6 +92,9 @@ struct fmt::formatter<bustub::TableReferenceType> : formatter<string_view> {
         break;
       case bustub::TableReferenceType::EXPRESSION_LIST:
         name = "ExpressionList";
+        break;
+      case bustub::TableReferenceType::SUBQUERY:
+        name = "Subquery";
         break;
       default:
         name = "Unknown";

--- a/src/include/binder/expressions/bound_agg_call.h
+++ b/src/include/binder/expressions/bound_agg_call.h
@@ -14,8 +14,11 @@ namespace bustub {
  */
 class BoundAggCall : public BoundExpression {
  public:
-  explicit BoundAggCall(std::string func_name, std::vector<std::unique_ptr<BoundExpression>> args)
-      : BoundExpression(ExpressionType::AGG_CALL), func_name_(std::move(func_name)), args_(move(args)) {}
+  explicit BoundAggCall(std::string func_name, bool is_distinct, std::vector<std::unique_ptr<BoundExpression>> args)
+      : BoundExpression(ExpressionType::AGG_CALL),
+        func_name_(std::move(func_name)),
+        is_distinct_(is_distinct),
+        args_(move(args)) {}
 
   auto ToString() const -> std::string override;
 
@@ -23,6 +26,9 @@ class BoundAggCall : public BoundExpression {
 
   /** Function name. */
   std::string func_name_;
+
+  /** Is distinct aggregation */
+  bool is_distinct_;
 
   /** Arguments of the agg call. */
   std::vector<std::unique_ptr<BoundExpression>> args_;

--- a/src/include/binder/expressions/bound_column_ref.h
+++ b/src/include/binder/expressions/bound_column_ref.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 #include "binder/bound_expression.h"
 
 namespace bustub {
@@ -11,17 +12,14 @@ namespace bustub {
  */
 class BoundColumnRef : public BoundExpression {
  public:
-  explicit BoundColumnRef(std::string table, std::string col)
-      : BoundExpression(ExpressionType::COLUMN_REF), table_(std::move(table)), col_(std::move(col)) {}
+  explicit BoundColumnRef(std::vector<std::string> col_name)
+      : BoundExpression(ExpressionType::COLUMN_REF), col_name_(std::move(col_name)) {}
 
-  auto ToString() const -> std::string override { return fmt::format("{}.{}", table_, col_); }
+  auto ToString() const -> std::string override { return fmt::format("{}", fmt::join(col_name_, ".")); }
 
   auto HasAggregation() const -> bool override { return false; }
 
-  /** Name of the table. */
-  std::string table_;
-
-  /** The name of the column in the schema. */
-  std::string col_;
+  /** The name of the column. */
+  std::vector<std::string> col_name_;
 };
 }  // namespace bustub

--- a/src/include/binder/statement/select_statement.h
+++ b/src/include/binder/statement/select_statement.h
@@ -27,7 +27,7 @@ class SelectStatement : public BoundStatement {
                            std::vector<std::unique_ptr<BoundExpression>> group_by,
                            std::unique_ptr<BoundExpression> having, std::unique_ptr<BoundExpression> limit_count,
                            std::unique_ptr<BoundExpression> limit_offset,
-                           std::vector<std::unique_ptr<BoundOrderBy>> sort);
+                           std::vector<std::unique_ptr<BoundOrderBy>> sort, bool is_distinct);
 
   /** Bound FROM clause. */
   std::unique_ptr<BoundTableRef> table_;
@@ -52,6 +52,9 @@ class SelectStatement : public BoundStatement {
 
   /** Bound ORDER BY clause. */
   std::vector<std::unique_ptr<BoundOrderBy>> sort_;
+
+  /** Is SELECT DISTINCT */
+  bool is_distinct_;
 
   auto ToString() const -> std::string override;
 };

--- a/src/include/binder/table_ref/bound_expression_list_ref.h
+++ b/src/include/binder/table_ref/bound_expression_list_ref.h
@@ -18,12 +18,18 @@ class BoundExpression;
  */
 class BoundExpressionListRef : public BoundTableRef {
  public:
-  explicit BoundExpressionListRef(std::vector<std::vector<std::unique_ptr<BoundExpression>>> values)
-      : BoundTableRef(TableReferenceType::EXPRESSION_LIST), values_(std::move(values)) {}
+  explicit BoundExpressionListRef(std::vector<std::vector<std::unique_ptr<BoundExpression>>> values,
+                                  std::string identifier)
+      : BoundTableRef(TableReferenceType::EXPRESSION_LIST),
+        values_(std::move(values)),
+        identifier_(std::move(identifier)) {}
 
   auto ToString() const -> std::string override;
 
   /** The value list */
   std::vector<std::vector<std::unique_ptr<BoundExpression>>> values_;
+
+  /** A unique identifier for this values list, so that planner / binder can work correctly. */
+  std::string identifier_;
 };
 }  // namespace bustub

--- a/src/include/binder/table_ref/bound_subquery_ref.h
+++ b/src/include/binder/table_ref/bound_subquery_ref.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "binder/bound_expression.h"
+#include "binder/bound_table_ref.h"
+#include "fmt/format.h"
+
+namespace bustub {
+
+class SelectStatement;
+
+/**
+ * A subquery. e.g., `SELECT * FROM (SELECT * FROM t1)`, where `(SELECT * FROM t1)` is `BoundSubqueryRef`.
+ */
+class BoundSubqueryRef : public BoundTableRef {
+ public:
+  explicit BoundSubqueryRef(std::unique_ptr<SelectStatement> subquery, std::string alias)
+      : BoundTableRef(TableReferenceType::SUBQUERY), subquery_(std::move(subquery)), alias_(std::move(alias)) {}
+
+  auto ToString() const -> std::string override;
+
+  /** Subquery. */
+  std::unique_ptr<SelectStatement> subquery_;
+
+  /** Alias. */
+  std::string alias_;
+};
+}  // namespace bustub

--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -117,9 +117,11 @@ class StringUtil {
    *
    * @param lines input string
    * @param num_indent number of spaces prepended to each line
+   * @param except_first_line if true, the first line is not indented
    * @return a new string with spaces added to each line
    */
-  static auto IndentAllLines(const std::string &lines, size_t num_indent) -> std::string;
+  static auto IndentAllLines(const std::string &lines, size_t num_indent, bool except_first_line = false)
+      -> std::string;
 };
 
 }  // namespace bustub

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -27,6 +27,7 @@ class BoundConstant;
 class BoundColumnRef;
 class BoundUnaryOp;
 class BoundBaseTableRef;
+class BoundSubqueryRef;
 class BoundCrossProductRef;
 class BoundJoinRef;
 class BoundExpressionListRef;
@@ -87,6 +88,8 @@ class Planner {
    * @return the plan node of this bound table ref.
    */
   auto PlanTableRef(const BoundTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
+
+  auto PlanSubquery(const BoundSubqueryRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
 
   auto PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> std::unique_ptr<AbstractPlanNode>;
 

--- a/src/planner/plan_aggregation.cpp
+++ b/src/planner/plan_aggregation.cpp
@@ -28,6 +28,10 @@ auto Planner::PlanAggCall(const BoundAggCall &agg_call, const std::vector<const 
   if (agg_call.args_.size() != 1) {
     throw NotImplementedException("only agg call of one arg is supported for now");
   }
+  if (agg_call.is_distinct_) {
+    throw NotImplementedException("distinct agg is not implemented yet");
+  }
+
   std::unique_ptr<AbstractExpression> expr = nullptr;
   {
     // Create a new context that doesn't allow aggregation calls.

--- a/src/planner/plan_expression.cpp
+++ b/src/planner/plan_expression.cpp
@@ -64,7 +64,7 @@ auto Planner::PlanColumnRef(const BoundColumnRef &expr, const std::vector<const 
     throw Exception("column ref should have at least one child");
   }
 
-  auto col_name = fmt::format("{}.{}", expr.table_, expr.col_);
+  auto col_name = expr.ToString();
 
   if (children.size() == 1) {
     // Projections, Filters, and other executors evaluating expressions with one single child will
@@ -124,7 +124,8 @@ void Planner::AddAggCallToContext(BoundExpression &expr) {
     case ExpressionType::AGG_CALL: {
       auto &agg_call_expr = dynamic_cast<BoundAggCall &>(expr);
       auto agg_name = fmt::format("__pseudo_agg#{}", ctx_.aggregations_.size());
-      auto agg_call = BoundAggCall(agg_name, std::vector<std::unique_ptr<BoundExpression>>{});
+      auto agg_call =
+          BoundAggCall(agg_name, agg_call_expr.is_distinct_, std::vector<std::unique_ptr<BoundExpression>>{});
       // Replace the agg call in the original bound expression with a pseudo one, add agg call to the context.
       ctx_.AddAggregation(std::make_unique<BoundAggCall>(std::exchange(agg_call_expr, std::move(agg_call))));
       return;


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

```
Agg { types=[], aggregates=[], having=, group_by=[#0.0, #0.1] } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
  Projection { exprs=#0.0, #0.1 } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
    Projection { exprs=#0.0, #0.1 } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
      Projection { exprs=#0.0, #0.1 } | (__subquery#0.__mock_table_1.colA:INTEGER, maxcolc:INTEGER)
        Agg { types=[max], aggregates=[#0.1], having=, group_by=[#0.0] } | (__subquery#0.__mock_table_1.colA:INTEGER, agg#0:VARCHAR)
          Projection { exprs=#0.0, #0.1 } | (__subquery#0.__mock_table_1.colA:INTEGER, __subquery#0.__mock_table_2.colC:VARCHAR)
            Projection { exprs=#0.0, #0.2 } | (__mock_table_1.colA:INTEGER, __mock_table_2.colC:VARCHAR)
              NestedLoopJoin { predicate=#0.0=#1.0 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER, __mock_table_2.colC:VARCHAR, __mock_table_2.colD:VARCHAR)
                MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
                MockScan { size=100 } | (__mock_table_2.colC:VARCHAR, __mock_table_2.colD:VARCHAR)
```

The most complex plan we've ever had 🥵

```
explain select distinct colA, maxcolC FROM (select colA, max(colC) as maxColC from (select colA, colC from __mock_table_1 inner join __mock_table_2 on colA = colC) group by colA);
```

close https://github.com/cmu-db/bustub/issues/354