### PR TITLE
feat(optimizer): merge projections

### DIFF
--- a/src/execution/plan_node.cpp
+++ b/src/execution/plan_node.cpp
@@ -18,7 +18,7 @@ auto SeqScanPlanNode::InferScanSchema(const TableInfo &table_info) -> Schema {
     auto col_name = fmt::format("{}.{}", table_info.name_, column.GetName());
     schema.emplace_back(Column(col_name, column));
   }
-  return Schema(schema);
+  return Schema(std::move(schema));
 }
 
 auto NestedLoopJoinPlanNode::InferJoinSchema(const AbstractPlanNode &left, const AbstractPlanNode &right) -> Schema {
@@ -29,7 +29,7 @@ auto NestedLoopJoinPlanNode::InferJoinSchema(const AbstractPlanNode &left, const
   for (const auto &column : right.OutputSchema().GetColumns()) {
     schema.emplace_back(column);
   }
-  return Schema(schema);
+  return Schema(std::move(schema));
 }
 
 auto ProjectionPlanNode::InferProjectionSchema(const std::vector<AbstractExpressionRef> &expressions) -> Schema {
@@ -43,7 +43,7 @@ auto ProjectionPlanNode::InferProjectionSchema(const std::vector<AbstractExpress
       schema.emplace_back("<unnamed>", type_id, VARCHAR_DEFAULT_LENGTH);
     }
   }
-  return Schema(schema);
+  return Schema(std::move(schema));
 }
 
 auto ProjectionPlanNode::RenameSchema(const Schema &schema, const std::vector<std::string> &col_names) -> Schema {
@@ -55,7 +55,7 @@ auto ProjectionPlanNode::RenameSchema(const Schema &schema, const std::vector<st
   for (const auto &column : schema.GetColumns()) {
     output.emplace_back(Column(col_names[idx++], column));
   }
-  return Schema(output);
+  return Schema(std::move(output));
 }
 
 auto AggregationPlanNode::InferAggSchema(const std::vector<AbstractExpressionRef> &group_bys,
@@ -70,7 +70,7 @@ auto AggregationPlanNode::InferAggSchema(const std::vector<AbstractExpressionRef
     // TODO(chi): correctly infer agg call return type
     output.emplace_back(Column("<unnamed>", TypeId::INTEGER));
   }
-  return Schema(output);
+  return Schema(std::move(output));
 }
 
 }  // namespace bustub

--- a/src/execution/plan_node.cpp
+++ b/src/execution/plan_node.cpp
@@ -18,7 +18,7 @@ auto SeqScanPlanNode::InferScanSchema(const TableInfo &table_info) -> Schema {
     auto col_name = fmt::format("{}.{}", table_info.name_, column.GetName());
     schema.emplace_back(Column(col_name, column));
   }
-  return Schema(std::move(schema));
+  return Schema(schema);
 }
 
 auto NestedLoopJoinPlanNode::InferJoinSchema(const AbstractPlanNode &left, const AbstractPlanNode &right) -> Schema {
@@ -29,7 +29,7 @@ auto NestedLoopJoinPlanNode::InferJoinSchema(const AbstractPlanNode &left, const
   for (const auto &column : right.OutputSchema().GetColumns()) {
     schema.emplace_back(column);
   }
-  return Schema(std::move(schema));
+  return Schema(schema);
 }
 
 auto ProjectionPlanNode::InferProjectionSchema(const std::vector<AbstractExpressionRef> &expressions) -> Schema {
@@ -43,7 +43,7 @@ auto ProjectionPlanNode::InferProjectionSchema(const std::vector<AbstractExpress
       schema.emplace_back("<unnamed>", type_id, VARCHAR_DEFAULT_LENGTH);
     }
   }
-  return Schema(std::move(schema));
+  return Schema(schema);
 }
 
 auto ProjectionPlanNode::RenameSchema(const Schema &schema, const std::vector<std::string> &col_names) -> Schema {
@@ -55,7 +55,7 @@ auto ProjectionPlanNode::RenameSchema(const Schema &schema, const std::vector<st
   for (const auto &column : schema.GetColumns()) {
     output.emplace_back(Column(col_names[idx++], column));
   }
-  return Schema(std::move(output));
+  return Schema(output);
 }
 
 auto AggregationPlanNode::InferAggSchema(const std::vector<AbstractExpressionRef> &group_bys,
@@ -70,7 +70,7 @@ auto AggregationPlanNode::InferAggSchema(const std::vector<AbstractExpressionRef
     // TODO(chi): correctly infer agg call return type
     output.emplace_back(Column("<unnamed>", TypeId::INTEGER));
   }
-  return Schema(std::move(output));
+  return Schema(output);
 }
 
 }  // namespace bustub

--- a/src/include/execution/plans/abstract_plan.h
+++ b/src/include/execution/plans/abstract_plan.h
@@ -22,6 +22,14 @@
 
 namespace bustub {
 
+#define CLONE_WITH_CHILDREN(cname)                                                                           \
+  auto CloneWithChildren(std::vector<AbstractPlanNodeRef> children) const->std::unique_ptr<AbstractPlanNode> \
+      override {                                                                                             \
+    auto plan_node = cname(*this);                                                                           \
+    plan_node.children_ = children;                                                                          \
+    return std::make_unique<cname>(std::move(plan_node));                                                    \
+  }
+
 /** PlanType represents the types of plans that we have in our system. */
 enum class PlanType {
   SeqScan,
@@ -80,6 +88,10 @@ class AbstractPlanNode {
   auto ToString() const -> std::string {
     return fmt::format("{} | {}{}", PlanNodeToString(), output_schema_, ChildrenToString(2));
   }
+
+  /** @return the cloned plan node with new children */
+  virtual auto CloneWithChildren(std::vector<AbstractPlanNodeRef> children) const
+      -> std::unique_ptr<AbstractPlanNode> = 0;
 
   /**
    * The schema for the output of this plan node. In the volcano model, every plan node will spit out tuples,

--- a/src/include/execution/plans/aggregation_plan.h
+++ b/src/include/execution/plans/aggregation_plan.h
@@ -85,6 +85,8 @@ class AggregationPlanNode : public AbstractPlanNode {
                              const std::vector<AbstractExpressionRef> &aggregates,
                              const std::vector<AggregationType> &agg_types) -> Schema;
 
+  CLONE_WITH_CHILDREN(AggregationPlanNode);
+
  private:
   /** A HAVING clause expression (may be `nullptr`) */
   AbstractExpressionRef having_;

--- a/src/include/execution/plans/delete_plan.h
+++ b/src/include/execution/plans/delete_plan.h
@@ -48,6 +48,8 @@ class DeletePlanNode : public AbstractPlanNode {
     return GetChildAt(0);
   }
 
+  CLONE_WITH_CHILDREN(DeletePlanNode);
+
  private:
   /** The identifier of the table from which tuples are deleted */
   table_oid_t table_oid_;

--- a/src/include/execution/plans/filter_plan.h
+++ b/src/include/execution/plans/filter_plan.h
@@ -49,6 +49,8 @@ class FilterPlanNode : public AbstractPlanNode {
     return GetChildAt(0);
   }
 
+  CLONE_WITH_CHILDREN(FilterPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override {
     return fmt::format("Filter {{ predicate={} }}", *predicate_);

--- a/src/include/execution/plans/hash_join_plan.h
+++ b/src/include/execution/plans/hash_join_plan.h
@@ -59,6 +59,8 @@ class HashJoinPlanNode : public AbstractPlanNode {
     return GetChildAt(1);
   }
 
+  CLONE_WITH_CHILDREN(HashJoinPlanNode);
+
  private:
   /** The expression to compute the left JOIN key */
   AbstractExpressionRef left_key_expression_;

--- a/src/include/execution/plans/index_scan_plan.h
+++ b/src/include/execution/plans/index_scan_plan.h
@@ -42,6 +42,8 @@ class IndexScanPlanNode : public AbstractPlanNode {
   /** @return the identifier of the table that should be scanned */
   auto GetIndexOid() const -> index_oid_t { return index_oid_; }
 
+  CLONE_WITH_CHILDREN(IndexScanPlanNode);
+
  private:
   /** The predicate that all returned tuples must satisfy. */
   AbstractExpressionRef predicate_;

--- a/src/include/execution/plans/insert_plan.h
+++ b/src/include/execution/plans/insert_plan.h
@@ -77,6 +77,8 @@ class InsertPlanNode : public AbstractPlanNode {
     return GetChildAt(0);
   }
 
+  CLONE_WITH_CHILDREN(InsertPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override { return fmt::format("Insert {{ table_oid={} }}", table_oid_); }
 

--- a/src/include/execution/plans/limit_plan.h
+++ b/src/include/execution/plans/limit_plan.h
@@ -45,6 +45,8 @@ class LimitPlanNode : public AbstractPlanNode {
     return GetChildAt(0);
   }
 
+  CLONE_WITH_CHILDREN(LimitPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override { return fmt::format("Limit {{ limit={} }}", limit_); }
 

--- a/src/include/execution/plans/mock_scan_plan.h
+++ b/src/include/execution/plans/mock_scan_plan.h
@@ -59,6 +59,8 @@ class MockScanPlanNode : public AbstractPlanNode {
   /** @return The table name of this mock scan node, used to determine the generated content. */
   auto GetTable() const -> const std::string & { return table_; }
 
+  CLONE_WITH_CHILDREN(MockScanPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override { return fmt::format("MockScan {{ size={} }}", size_); }
 

--- a/src/include/execution/plans/nested_index_join_plan.h
+++ b/src/include/execution/plans/nested_index_join_plan.h
@@ -61,6 +61,8 @@ class NestedIndexJoinPlanNode : public AbstractPlanNode {
   /** @return Schema with needed columns in from the inner table */
   auto InnerTableSchema() const -> const Schema & { return *inner_table_schema_; }
 
+  CLONE_WITH_CHILDREN(NestedIndexJoinPlanNode);
+
  private:
   /** The nested index join predicate. */
   AbstractExpressionRef predicate_;

--- a/src/include/execution/plans/nested_loop_join_plan.h
+++ b/src/include/execution/plans/nested_loop_join_plan.h
@@ -54,6 +54,8 @@ class NestedLoopJoinPlanNode : public AbstractPlanNode {
 
   static auto InferJoinSchema(const AbstractPlanNode &left, const AbstractPlanNode &right) -> Schema;
 
+  CLONE_WITH_CHILDREN(NestedLoopJoinPlanNode);
+
  private:
   /** The join predicate */
   AbstractExpressionRef predicate_;

--- a/src/include/execution/plans/projection_plan.h
+++ b/src/include/execution/plans/projection_plan.h
@@ -55,6 +55,8 @@ class ProjectionPlanNode : public AbstractPlanNode {
 
   static auto RenameSchema(const Schema &schema, const std::vector<std::string> &col_names) -> Schema;
 
+  CLONE_WITH_CHILDREN(ProjectionPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override;
 

--- a/src/include/execution/plans/seq_scan_plan.h
+++ b/src/include/execution/plans/seq_scan_plan.h
@@ -49,6 +49,8 @@ class SeqScanPlanNode : public AbstractPlanNode {
 
   static auto InferScanSchema(const TableInfo &table_info) -> Schema;
 
+  CLONE_WITH_CHILDREN(SeqScanPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override {
     return fmt::format("SeqScan {{ table_oid={} }}", table_oid_);

--- a/src/include/execution/plans/sort_plan.h
+++ b/src/include/execution/plans/sort_plan.h
@@ -52,6 +52,8 @@ class SortPlanNode : public AbstractPlanNode {
   /** @return Get sort by expressions */
   auto GetOrderBy() -> const std::vector<std::pair<OrderByType, AbstractExpressionRef>> & { return order_bys_; }
 
+  CLONE_WITH_CHILDREN(SortPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override;
 

--- a/src/include/execution/plans/topn_plan.h
+++ b/src/include/execution/plans/topn_plan.h
@@ -44,6 +44,8 @@ class TopNPlanNode : public AbstractPlanNode {
     return GetChildAt(0);
   }
 
+  CLONE_WITH_CHILDREN(TopNPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override { return fmt::format("TopN {{ }}"); }
 

--- a/src/include/execution/plans/update_plan.h
+++ b/src/include/execution/plans/update_plan.h
@@ -62,6 +62,8 @@ class UpdatePlanNode : public AbstractPlanNode {
   /** @return The update attributes */
   auto GetUpdateAttr() const -> const std::unordered_map<uint32_t, UpdateInfo> & { return update_attrs_; }
 
+  CLONE_WITH_CHILDREN(UpdatePlanNode);
+
  private:
   /** The table to be updated. */
   table_oid_t table_oid_;

--- a/src/include/execution/plans/values_plan.h
+++ b/src/include/execution/plans/values_plan.h
@@ -43,6 +43,8 @@ class ValuesPlanNode : public AbstractPlanNode {
 
   auto GetValues() const -> const std::vector<std::vector<AbstractExpressionRef>> & { return values_; }
 
+  CLONE_WITH_CHILDREN(ValuesPlanNode);
+
  protected:
   auto PlanNodeToString() const -> std::string override { return fmt::format("Values {{ rows={} }}", values_.size()); }
 

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -18,7 +18,7 @@ class Optimizer {
  public:
   explicit Optimizer(const Catalog &catalog) : catalog_(catalog) {}
 
-  auto Optimize(AbstractPlanNodeRef plan) -> AbstractPlanNodeRef;
+  auto Optimize(const AbstractPlanNodeRef &plan) -> AbstractPlanNodeRef;
 
  private:
   /**

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -21,6 +21,13 @@ class Optimizer {
   auto Optimize(AbstractPlanNodeRef plan) -> AbstractPlanNodeRef;
 
  private:
+  /**
+   * @brief merge projections that do identical project.
+   * Identical projection might be produced when there's `SELECT *`, aggregation, or when we need to rename the columns
+   * in the planner. We merge these projections so as to make execution faster.
+   */
+  auto OptimizeMergeProjection(const AbstractPlanNodeRef &plan) -> AbstractPlanNodeRef;
+
   /** Catalog will be used during the planning process. USERS SHOULD ENSURE IT OUTLIVES
    * OPTIMIZER, otherwise it's a dangling reference.
    */

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     bustub_optimizer
     OBJECT
+    merge_projection.cpp
     optimizer.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/optimizer/merge_projection.cpp
+++ b/src/optimizer/merge_projection.cpp
@@ -1,0 +1,56 @@
+#include <algorithm>
+#include <memory>
+#include "catalog/column.h"
+#include "catalog/schema.h"
+#include "execution/expressions/column_value_expression.h"
+#include "execution/plans/abstract_plan.h"
+#include "execution/plans/projection_plan.h"
+#include "optimizer/optimizer.h"
+
+namespace bustub {
+
+auto Optimizer::OptimizeMergeProjection(const AbstractPlanNodeRef &plan) -> AbstractPlanNodeRef {
+  std::vector<AbstractPlanNodeRef> children;
+  for (const auto &child : plan->GetChildren()) {
+    children.emplace_back(OptimizeMergeProjection(child));
+  }
+  if (plan->GetType() == PlanType::Projection) {
+    const auto &projection_plan = dynamic_cast<const ProjectionPlanNode &>(*plan);
+    // Has exactly one child
+    if (children.size() == 1) {
+      // If the schema is the same (except column name)
+      const auto &child_plan = children[0];
+      const auto &child_schema = child_plan->OutputSchema();
+      const auto &projection_schema = projection_plan.OutputSchema();
+      const auto &child_columns = child_schema.GetColumns();
+      const auto &projection_columns = projection_schema.GetColumns();
+      if (std::equal(child_columns.begin(), child_columns.end(), projection_columns.begin(), projection_columns.end(),
+                     [](auto &&child_col, auto &&proj_col) {
+                       // TODO(chi): consider VARCHAR length
+                       return child_col.GetType() == proj_col.GetType();
+                     })) {
+        const auto &exprs = projection_plan.GetExpressions();
+        // If all items are column value expressions
+        bool is_identical = true;
+        for (size_t idx = 0; idx < exprs.size(); idx++) {
+          auto column_value_expr = dynamic_cast<const ColumnValueExpression *>(exprs[idx].get());
+          if (column_value_expr != nullptr) {
+            if (column_value_expr->GetTupleIdx() == 0 && column_value_expr->GetColIdx() == idx) {
+              continue;
+            }
+          }
+          is_identical = false;
+          break;
+        }
+        if (is_identical) {
+          auto plan = child_plan->CloneWithChildren(child_plan->GetChildren());
+          plan->output_schema_ = std::make_shared<Schema>(projection_schema);
+          return std::move(plan);
+        }
+      }
+    }
+  }
+  return plan->CloneWithChildren(std::move(children));
+}
+
+}  // namespace bustub

--- a/src/optimizer/merge_projection.cpp
+++ b/src/optimizer/merge_projection.cpp
@@ -45,7 +45,7 @@ auto Optimizer::OptimizeMergeProjection(const AbstractPlanNodeRef &plan) -> Abst
         if (is_identical) {
           auto plan = child_plan->CloneWithChildren(child_plan->GetChildren());
           plan->output_schema_ = std::make_shared<Schema>(projection_schema);
-          return std::move(plan);
+          return plan;
         }
       }
     }

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -2,5 +2,9 @@
 #include "execution/plans/abstract_plan.h"
 
 namespace bustub {
-auto Optimizer::Optimize(AbstractPlanNodeRef plan) -> AbstractPlanNodeRef { return plan; }
+
+auto Optimizer::Optimize(AbstractPlanNodeRef plan) -> AbstractPlanNodeRef {
+  return OptimizeMergeProjection(std::move(plan));
+}
+
 }  // namespace bustub

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -3,8 +3,8 @@
 
 namespace bustub {
 
-auto Optimizer::Optimize(AbstractPlanNodeRef plan) -> AbstractPlanNodeRef {
-  return OptimizeMergeProjection(std::move(plan));
+auto Optimizer::Optimize(const AbstractPlanNodeRef &plan) -> AbstractPlanNodeRef {
+  return OptimizeMergeProjection(plan);
 }
 
 }  // namespace bustub


### PR DESCRIPTION
The smart ptr refactor makes optimizer rules easier to implement. The ProjectionMerge optimizer rule will eliminate unnecessary projections.

```
=== PLANNER ===
Agg { types=[], aggregates=[[]], having=, group_by=[[#0.0, #0.1]] } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
  Projection { exprs=[#0.0, #0.1] } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
    Projection { exprs=[#0.0, #0.1] } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
      Projection { exprs=[#0.0, #0.1] } | (__subquery#0.__mock_table_1.colA:INTEGER, maxcolc:INTEGER)
        Agg { types=[max], aggregates=[[#0.1]], having=, group_by=[[#0.0]] } | (__subquery#0.__mock_table_1.colA:INTEGER, agg#0:INTEGER)
          Projection { exprs=[#0.0, #0.1] } | (__subquery#0.__mock_table_1.colA:INTEGER, __subquery#0.__mock_table_2.colC:VARCHAR)
            Projection { exprs=[#0.0, #0.2] } | (__mock_table_1.colA:INTEGER, __mock_table_2.colC:VARCHAR)
              NestedLoopJoin { predicate=#0.0=#1.0 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER, __mock_table_2.colC:VARCHAR, __mock_table_2.colD:VARCHAR)
                MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
                MockScan { size=100 } | (__mock_table_2.colC:VARCHAR, __mock_table_2.colD:VARCHAR)
=== OPTIMIZER ===
Agg { types=[], aggregates=[[]], having=, group_by=[[#0.0, #0.1]] } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
  Agg { types=[max], aggregates=[[#0.1]], having=, group_by=[[#0.0]] } | (__subquery#1.__subquery#0.__mock_table_1.colA:INTEGER, __subquery#1.maxcolc:INTEGER)
    Projection { exprs=[#0.0, #0.2] } | (__subquery#0.__mock_table_1.colA:INTEGER, __subquery#0.__mock_table_2.colC:VARCHAR)
      NestedLoopJoin { predicate=#0.0=#1.0 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER, __mock_table_2.colC:VARCHAR, __mock_table_2.colD:VARCHAR)
        MockScan { size=100 } | (__mock_table_1.colA:INTEGER, __mock_table_1.colB:INTEGER)
        MockScan { size=100 } | (__mock_table_2.colC:VARCHAR, __mock_table_2.colD:VARCHAR)
```