### PR TITLE
feat(binder): support select star from subquery

### DIFF
--- a/src/binder/bind_select.cpp
+++ b/src/binder/bind_select.cpp
@@ -402,15 +402,7 @@ auto Binder::BindColumnRef(duckdb_libpgquery::PGColumnRef *node) -> std::unique_
       for (auto node = fields->head; node != nullptr; node = node->next) {
         column_names.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(node->data.ptr_value)->val.str);
       }
-      if (column_names.size() == 1) {
-        // Bind `SELECT col`.
-        return ResolveColumn(*scope_, column_names);
-      }
-      if (column_names.size() == 2) {
-        // Bind `SELECT table.col`.
-        return ResolveColumn(*scope_, column_names);
-      }
-      throw bustub::Exception(fmt::format("unsupported ColumnRef: zero or multiple elements found"));
+      return ResolveColumn(*scope_, column_names);
     }
     case duckdb_libpgquery::T_PGAStar: {
       return BindStar(reinterpret_cast<duckdb_libpgquery::PGAStar *>(head_node));
@@ -533,9 +525,6 @@ static auto MatchSuffix(const std::vector<std::string> &suffix, const std::vecto
 static auto ResolveColumnRefFromSelectList(const std::vector<std::vector<std::string>> &subquery_select_list,
                                            const std::vector<std::string> &col_name)
     -> std::unique_ptr<BoundColumnRef> {
-  if (col_name.size() != 1) {
-    return nullptr;
-  }
   std::unique_ptr<BoundColumnRef> column_ref = nullptr;
   for (const auto &column : subquery_select_list) {
     if (MatchSuffix(col_name, column)) {

--- a/src/binder/bind_select.cpp
+++ b/src/binder/bind_select.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <vector>
 #include "binder/binder.h"
 #include "binder/bound_expression.h"
@@ -65,9 +66,33 @@ auto Binder::BindRangeSubselect(duckdb_libpgquery::PGRangeSubselect *root) -> st
   if (root->lateral) {
     throw NotImplementedException("LATERAL in subquery is not supported");
   }
-  auto table_ref =
-      std::make_unique<BoundSubqueryRef>(std::move(subquery), fmt::format("__subquery#{}", universal_id_++));
-  return table_ref;
+
+  std::vector<std::vector<std::string>> select_list_name;
+
+  for (const auto &col : subquery->select_list_) {
+    switch (col->type_) {
+      case ExpressionType::COLUMN_REF: {
+        const auto &column_ref_expr = dynamic_cast<const BoundColumnRef &>(*col);
+        select_list_name.push_back(column_ref_expr.col_name_);
+        continue;
+      }
+      case ExpressionType::ALIAS: {
+        const auto &alias_expr = dynamic_cast<const BoundAlias &>(*col);
+        select_list_name.push_back(std::vector{alias_expr.alias_});
+        continue;
+      }
+      default:
+        select_list_name.push_back(std::vector{fmt::format("__item#{}", universal_id_++)});
+        continue;
+    }
+  }
+
+  if (root->alias != nullptr) {
+    return std::make_unique<BoundSubqueryRef>(std::move(subquery), std::move(select_list_name),
+                                              std::string(root->alias->aliasname));
+  }
+  return std::make_unique<BoundSubqueryRef>(std::move(subquery), std::move(select_list_name),
+                                            fmt::format("__subquery#{}", universal_id_++));
 }
 
 auto Binder::BindSelect(duckdb_libpgquery::PGSelectStmt *pg_stmt) -> std::unique_ptr<SelectStatement> {
@@ -242,7 +267,11 @@ auto Binder::BindTableRef(duckdb_libpgquery::PGNode *node) -> std::unique_ptr<Bo
       if (table_info == nullptr) {
         throw bustub::Exception(fmt::format("invalid table {}", table_ref->relname));
       }
-      return std::make_unique<BoundBaseTableRef>(table_ref->relname, table_info->schema_);
+      if (table_ref->alias != nullptr) {
+        return std::make_unique<BoundBaseTableRef>(table_ref->relname, std::make_optional(table_ref->alias->aliasname),
+                                                   table_info->schema_);
+      }
+      return std::make_unique<BoundBaseTableRef>(table_ref->relname, std::nullopt, table_info->schema_);
     }
     case duckdb_libpgquery::T_PGJoinExpr: {
       return BindJoin(reinterpret_cast<duckdb_libpgquery::PGJoinExpr *>(node));
@@ -259,11 +288,11 @@ auto Binder::GetAllColumns(const BoundTableRef &scope) -> std::vector<std::uniqu
   switch (scope.type_) {
     case TableReferenceType::BASE_TABLE: {
       const auto &base_table_ref = dynamic_cast<const BoundBaseTableRef &>(scope);
-      const auto &table_name = base_table_ref.table_;
+      auto bound_table_name = base_table_ref.GetBoundTableName();
       const auto &schema = base_table_ref.schema_;
       auto columns = std::vector<std::unique_ptr<BoundExpression>>{};
       for (const auto &column : schema.GetColumns()) {
-        columns.push_back(std::make_unique<BoundColumnRef>(std::vector{table_name, column.GetName()}));
+        columns.push_back(std::make_unique<BoundColumnRef>(std::vector{bound_table_name, column.GetName()}));
       }
       return columns;
     }
@@ -286,24 +315,8 @@ auto Binder::GetAllColumns(const BoundTableRef &scope) -> std::vector<std::uniqu
     case TableReferenceType::SUBQUERY: {
       const auto &subquery_ref = dynamic_cast<const BoundSubqueryRef &>(scope);
       auto columns = std::vector<std::unique_ptr<BoundExpression>>{};
-      for (const auto &col : subquery_ref.subquery_->select_list_) {
-        switch (col->type_) {
-          case ExpressionType::COLUMN_REF: {
-            const auto &column_ref_expr = dynamic_cast<const BoundColumnRef &>(*col);
-            std::vector<std::string> full_column_name = {subquery_ref.alias_};
-            std::copy(column_ref_expr.col_name_.cbegin(), column_ref_expr.col_name_.cend(),
-                      std::back_inserter(full_column_name));
-            columns.push_back(std::make_unique<BoundColumnRef>(std::move(full_column_name)));
-            continue;
-          }
-          case ExpressionType::ALIAS: {
-            const auto &alias_expr = dynamic_cast<const BoundAlias &>(*col);
-            columns.push_back(std::make_unique<BoundColumnRef>(std::vector{subquery_ref.alias_, alias_expr.alias_}));
-            continue;
-          }
-          default:
-            throw NotImplementedException("must alias each column when select * from subquery");
-        }
+      for (const auto &col_name : subquery_ref.select_list_name_) {
+        columns.emplace_back(BoundColumnRef::Prepend(std::make_unique<BoundColumnRef>(col_name), subquery_ref.alias_));
       }
       return columns;
     }
@@ -452,19 +465,57 @@ auto Binder::BindFuncCall(duckdb_libpgquery::PGFuncCall *root) -> std::unique_pt
   throw bustub::Exception(fmt::format("unsupported func call {}", function_name));
 }
 
-static auto MatchTableColumn(const std::vector<std::string> &col_name, const std::string &table_name,
-                             const Column &column) -> std::unique_ptr<BoundColumnRef> {
-  auto table_col_name = column.GetName();
-  if (col_name.size() == 1) {
-    if (StringUtil::Lower(table_col_name) == col_name[0]) {
-      return std::make_unique<BoundColumnRef>(std::vector<std::string>{table_name, table_col_name});
-    }
-  } else if (col_name.size() == 2) {
-    if (StringUtil::Lower(table_name) == col_name[0] && StringUtil::Lower(table_col_name) == col_name[1]) {
-      return std::make_unique<BoundColumnRef>(std::vector<std::string>{table_name, table_col_name});
+/**
+ * @brief Get `BoundColumnRef` from the schema.
+ */
+static auto ResolveColumnRefFromSchema(const Schema &schema, const std::vector<std::string> &col_name)
+    -> std::unique_ptr<BoundColumnRef> {
+  if (col_name.size() != 1) {
+    return nullptr;
+  }
+  std::unique_ptr<BoundColumnRef> column_ref = nullptr;
+  for (const auto &column : schema.GetColumns()) {
+    if (StringUtil::Lower(column.GetName()) == col_name[0]) {
+      if (column_ref != nullptr) {
+        throw Exception(fmt::format("{} is ambiguous in schema", fmt::join(col_name, ".")));
+      }
+      column_ref = std::make_unique<BoundColumnRef>(std::vector{column.GetName()});
     }
   }
-  return nullptr;
+  return column_ref;
+}
+
+/**
+ * @brief Get `BoundColumnRef` from the table. Returns something like `alias.column` or `table_name.column`.
+ */
+static auto ResolveColumnRefFromBaseTableRef(const BoundBaseTableRef &table_ref,
+                                             const std::vector<std::string> &col_name)
+    -> std::unique_ptr<BoundColumnRef> {
+  auto bound_table_name = table_ref.GetBoundTableName();
+  // Firstly, try directly resolve the column name through schema
+  std::unique_ptr<BoundColumnRef> direct_resolved_expr =
+      BoundColumnRef::Prepend(ResolveColumnRefFromSchema(table_ref.schema_, col_name), bound_table_name);
+
+  std::unique_ptr<BoundColumnRef> strip_resolved_expr = nullptr;
+
+  // Then, try strip the prefix and match again
+  if (col_name.size() > 1) {
+    // Strip alias and resolve again
+    if (col_name[0] == bound_table_name) {
+      auto strip_column_name = col_name;
+      strip_column_name.erase(strip_column_name.begin());
+      strip_resolved_expr =
+          BoundColumnRef::Prepend(ResolveColumnRefFromSchema(table_ref.schema_, strip_column_name), *table_ref.alias_);
+    }
+  }
+
+  if (strip_resolved_expr != nullptr && direct_resolved_expr != nullptr) {
+    throw bustub::Exception(fmt::format("{} is ambiguous in table {}", fmt::join(col_name, "."), table_ref.table_));
+  }
+  if (strip_resolved_expr != nullptr) {
+    return strip_resolved_expr;
+  }
+  return direct_resolved_expr;
 }
 
 static auto MatchSuffix(const std::vector<std::string> &suffix, const std::vector<std::string> &full_name) -> bool {
@@ -479,21 +530,58 @@ static auto MatchSuffix(const std::vector<std::string> &suffix, const std::vecto
   return std::equal(suffix.rbegin(), suffix.rend(), lowercase_full_name.rbegin());
 }
 
+static auto ResolveColumnRefFromSelectList(const std::vector<std::vector<std::string>> &subquery_select_list,
+                                           const std::vector<std::string> &col_name)
+    -> std::unique_ptr<BoundColumnRef> {
+  if (col_name.size() != 1) {
+    return nullptr;
+  }
+  std::unique_ptr<BoundColumnRef> column_ref = nullptr;
+  for (const auto &column : subquery_select_list) {
+    if (MatchSuffix(col_name, column)) {
+      if (column_ref != nullptr) {
+        throw Exception(fmt::format("{} is ambiguous in subquery select list", fmt::join(col_name, ".")));
+      }
+      column_ref = std::make_unique<BoundColumnRef>(column);
+    }
+  }
+  return column_ref;
+}
+
+static auto ResolveColumnRefFromSubqueryRef(const BoundSubqueryRef &subquery_ref,
+                                            const std::vector<std::string> &col_name) {
+  // Firstly, try directly resolve the column name through schema
+  std::unique_ptr<BoundColumnRef> direct_resolved_expr = BoundColumnRef::Prepend(
+      ResolveColumnRefFromSelectList(subquery_ref.select_list_name_, col_name), subquery_ref.alias_);
+
+  std::unique_ptr<BoundColumnRef> strip_resolved_expr = nullptr;
+
+  // Then, try strip the prefix and match again
+  if (col_name.size() > 1) {
+    if (col_name[0] == subquery_ref.alias_) {
+      auto strip_column_name = col_name;
+      strip_column_name.erase(strip_column_name.begin());
+      strip_resolved_expr = BoundColumnRef::Prepend(
+          ResolveColumnRefFromSelectList(subquery_ref.select_list_name_, strip_column_name), subquery_ref.alias_);
+    }
+  }
+
+  if (strip_resolved_expr != nullptr && direct_resolved_expr != nullptr) {
+    throw bustub::Exception(
+        fmt::format("{} is ambiguous in subquery {}", fmt::join(col_name, "."), subquery_ref.alias_));
+  }
+  if (strip_resolved_expr != nullptr) {
+    return strip_resolved_expr;
+  }
+  return direct_resolved_expr;
+}
+
 static auto ResolveColumnInternal(const BoundTableRef &table_ref, const std::vector<std::string> &col_name)
     -> std::unique_ptr<BoundExpression> {
   switch (table_ref.type_) {
     case TableReferenceType::BASE_TABLE: {
       const auto &base_table_ref = dynamic_cast<const BoundBaseTableRef &>(table_ref);
-      // TODO(chi): handle case-insensitive table / column names
-      const auto &table_name = base_table_ref.table_;
-      auto expr = std::make_unique<BoundExpression>();
-      for (const auto &column : base_table_ref.schema_.GetColumns()) {
-        auto expr = MatchTableColumn(col_name, table_name, column);
-        if (expr != nullptr) {
-          return expr;
-        }
-      }
-      return nullptr;
+      return ResolveColumnRefFromBaseTableRef(base_table_ref, col_name);
     }
     case TableReferenceType::CROSS_PRODUCT: {
       const auto &cross_product_ref = dynamic_cast<const BoundCrossProductRef &>(table_ref);
@@ -521,37 +609,7 @@ static auto ResolveColumnInternal(const BoundTableRef &table_ref, const std::vec
     }
     case TableReferenceType::SUBQUERY: {
       const auto &subquery_ref = dynamic_cast<const BoundSubqueryRef &>(table_ref);
-
-      // Match column name with a column within subquery.
-      // TODO(chi): throw a warning when ambiguous.
-      for (const auto &col : subquery_ref.subquery_->select_list_) {
-        switch (col->type_) {
-          case ExpressionType::COLUMN_REF: {
-            const auto &column_ref_expr = dynamic_cast<const BoundColumnRef &>(*col);
-
-            // `full_col_name` will be `subquery.x.y.z`.
-            auto full_col_name = std::vector(column_ref_expr.col_name_);
-            full_col_name.insert(full_col_name.begin(), subquery_ref.alias_);
-
-            if (MatchSuffix(col_name, full_col_name)) {
-              return std::make_unique<BoundColumnRef>(std::move(full_col_name));
-            }
-            continue;
-          }
-          case ExpressionType::ALIAS: {
-            const auto &alias_expr = dynamic_cast<const BoundAlias &>(*col);
-            if (MatchSuffix(col_name, {subquery_ref.alias_, alias_expr.alias_})) {
-              // Return BoundColumnRef as `<subquery_alias>.<expr_alias>`.
-              return std::make_unique<BoundColumnRef>(std::vector<std::string>{subquery_ref.alias_, alias_expr.alias_});
-            }
-            continue;
-          }
-          default:
-            // Do not match unnamed columns
-            continue;
-        }
-      }
-      return nullptr;
+      return ResolveColumnRefFromSubqueryRef(subquery_ref, col_name);
     }
     default:
       throw bustub::Exception("unsupported TableReferenceType");

--- a/src/binder/fmt_impl.cpp
+++ b/src/binder/fmt_impl.cpp
@@ -21,8 +21,12 @@ auto BoundExpressionListRef::ToString() const -> std::string {
 }
 
 auto BoundSubqueryRef::ToString() const -> std::string {
-  return fmt::format("BoundSubqueryRef {{\n  alias={},\n  subquery={},\n}}", alias_,
-                     StringUtil::IndentAllLines(subquery_->ToString(), 2, true));
+  std::vector<std::string> columns;
+  for (const auto &name : select_list_name_) {
+    columns.push_back(fmt::format("{}", fmt::join(name, ".")));
+  }
+  return fmt::format("BoundSubqueryRef {{\n  alias={},\n  subquery={},\n  columns={},\n}}", alias_,
+                     StringUtil::IndentAllLines(subquery_->ToString(), 2, true), columns);
 }
 
 }  // namespace bustub

--- a/src/execution/plan_node.cpp
+++ b/src/execution/plan_node.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include "binder/table_ref/bound_base_table_ref.h"
 #include "catalog/catalog.h"
 #include "catalog/column.h"
 #include "catalog/schema.h"
@@ -12,10 +13,10 @@
 
 namespace bustub {
 
-auto SeqScanPlanNode::InferScanSchema(const TableInfo &table_info) -> Schema {
+auto SeqScanPlanNode::InferScanSchema(const BoundBaseTableRef &table) -> Schema {
   std::vector<Column> schema;
-  for (const auto &column : table_info.schema_.GetColumns()) {
-    auto col_name = fmt::format("{}.{}", table_info.name_, column.GetName());
+  for (const auto &column : table.schema_.GetColumns()) {
+    auto col_name = fmt::format("{}.{}", table.GetBoundTableName(), column.GetName());
     schema.emplace_back(Column(col_name, column));
   }
   return Schema(schema);

--- a/src/include/binder/expressions/bound_column_ref.h
+++ b/src/include/binder/expressions/bound_column_ref.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <algorithm>
+#include <iterator>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "binder/bound_expression.h"
 
 namespace bustub {
@@ -14,6 +18,15 @@ class BoundColumnRef : public BoundExpression {
  public:
   explicit BoundColumnRef(std::vector<std::string> col_name)
       : BoundExpression(ExpressionType::COLUMN_REF), col_name_(std::move(col_name)) {}
+
+  static auto Prepend(std::unique_ptr<BoundColumnRef> self, std::string prefix) -> std::unique_ptr<BoundColumnRef> {
+    if (self == nullptr) {
+      return nullptr;
+    }
+    std::vector<std::string> col_name{std::move(prefix)};
+    std::copy(self->col_name_.cbegin(), self->col_name_.cend(), std::back_inserter(col_name));
+    return std::make_unique<BoundColumnRef>(std::move(col_name));
+  }
 
   auto ToString() const -> std::string override { return fmt::format("{}", fmt::join(col_name_, ".")); }
 

--- a/src/include/binder/table_ref/bound_base_table_ref.h
+++ b/src/include/binder/table_ref/bound_base_table_ref.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 #include "binder/bound_table_ref.h"
@@ -13,13 +14,31 @@ namespace bustub {
  */
 class BoundBaseTableRef : public BoundTableRef {
  public:
-  explicit BoundBaseTableRef(std::string table, Schema schema)
-      : BoundTableRef(TableReferenceType::BASE_TABLE), table_(std::move(table)), schema_(std::move(schema)) {}
+  explicit BoundBaseTableRef(std::string table, std::optional<std::string> alias, Schema schema)
+      : BoundTableRef(TableReferenceType::BASE_TABLE),
+        table_(std::move(table)),
+        alias_(std::move(alias)),
+        schema_(std::move(schema)) {}
 
-  auto ToString() const -> std::string override { return fmt::format("BoundBaseTableRef {{ table={} }}", table_); }
+  auto ToString() const -> std::string override {
+    if (alias_ == std::nullopt) {
+      return fmt::format("BoundBaseTableRef {{ table={} }}", table_);
+    }
+    return fmt::format("BoundBaseTableRef {{ table={}, alias={} }}", table_, *alias_);
+  }
+
+  auto GetBoundTableName() const -> std::string {
+    if (alias_ != std::nullopt) {
+      return *alias_;
+    }
+    return table_;
+  }
 
   /** The name of the table. */
   std::string table_;
+
+  /** The alias of the table */
+  std::optional<std::string> alias_;
 
   /** The schema of the table. */
   Schema schema_;

--- a/src/include/binder/table_ref/bound_subquery_ref.h
+++ b/src/include/binder/table_ref/bound_subquery_ref.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "binder/bound_expression.h"
 #include "binder/bound_table_ref.h"
@@ -17,13 +18,20 @@ class SelectStatement;
  */
 class BoundSubqueryRef : public BoundTableRef {
  public:
-  explicit BoundSubqueryRef(std::unique_ptr<SelectStatement> subquery, std::string alias)
-      : BoundTableRef(TableReferenceType::SUBQUERY), subquery_(std::move(subquery)), alias_(std::move(alias)) {}
+  explicit BoundSubqueryRef(std::unique_ptr<SelectStatement> subquery,
+                            std::vector<std::vector<std::string>> select_list_name, std::string alias)
+      : BoundTableRef(TableReferenceType::SUBQUERY),
+        subquery_(std::move(subquery)),
+        select_list_name_(std::move(select_list_name)),
+        alias_(std::move(alias)) {}
 
   auto ToString() const -> std::string override;
 
   /** Subquery. */
   std::unique_ptr<SelectStatement> subquery_;
+
+  /** Name of each item in the select list. */
+  std::vector<std::vector<std::string>> select_list_name_;
 
   /** Alias. */
   std::string alias_;

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "catalog/column.h"
+#include "common/exception.h"
 #include "type/type.h"
 
 namespace bustub {

--- a/src/include/execution/plans/seq_scan_plan.h
+++ b/src/include/execution/plans/seq_scan_plan.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <utility>
 
+#include "binder/table_ref/bound_base_table_ref.h"
 #include "catalog/catalog.h"
 #include "catalog/schema.h"
 #include "execution/expressions/abstract_expression.h"
@@ -47,7 +48,7 @@ class SeqScanPlanNode : public AbstractPlanNode {
   /** @return The identifier of the table that should be scanned */
   auto GetTableOid() const -> table_oid_t { return table_oid_; }
 
-  static auto InferScanSchema(const TableInfo &table_info) -> Schema;
+  static auto InferScanSchema(const BoundBaseTableRef &table_ref) -> Schema;
 
   BUSTUB_PLAN_NODE_CLONE_WITH_CHILDREN(SeqScanPlanNode);
 

--- a/src/planner/plan_expression.cpp
+++ b/src/planner/plan_expression.cpp
@@ -65,6 +65,16 @@ auto Planner::PlanColumnRef(const BoundColumnRef &expr, const std::vector<Abstra
     // use this branch.
     const auto &child = children[0];
     auto schema = child->OutputSchema();
+    // Before we can call `schema.GetColIdx`,  we need to ensure there's no duplicated column.
+    bool found = false;
+    for (const auto &col : schema.GetColumns()) {
+      if (col_name == col.GetName()) {
+        if (found) {
+          throw bustub::Exception("duplicated column found in schema");
+        }
+        found = true;
+      }
+    }
     uint32_t col_idx = schema.GetColIdx(col_name);
     auto col_type = schema.GetColumn(col_idx).GetType();
     return std::make_tuple(col_name, std::make_shared<ColumnValueExpression>(0, col_idx, col_type));

--- a/src/planner/plan_table_ref.cpp
+++ b/src/planner/plan_table_ref.cpp
@@ -93,14 +93,14 @@ auto Planner::PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> AbstractPl
   if (StringUtil::StartsWith(table->name_, "__")) {
     // Plan as MockScanExecutor if it is a mock table.
     if (StringUtil::StartsWith(table->name_, "__mock")) {
-      return std::make_shared<MockScanPlanNode>(std::make_shared<Schema>(SeqScanPlanNode::InferScanSchema(*table)), 100,
-                                                table->name_);
+      return std::make_shared<MockScanPlanNode>(std::make_shared<Schema>(SeqScanPlanNode::InferScanSchema(table_ref)),
+                                                100, table->name_);
     }
     throw bustub::Exception(fmt::format("unsupported internal table: {}", table->name_));
   }
   // Otherwise, plan as normal SeqScan.
-  return std::make_shared<SeqScanPlanNode>(std::make_shared<Schema>(SeqScanPlanNode::InferScanSchema(*table)), nullptr,
-                                           table->oid_);
+  return std::make_shared<SeqScanPlanNode>(std::make_shared<Schema>(SeqScanPlanNode::InferScanSchema(table_ref)),
+                                           nullptr, table->oid_);
 }
 
 auto Planner::PlanCrossProductRef(const BoundCrossProductRef &table_ref) -> AbstractPlanNodeRef {


### PR DESCRIPTION
Handling alias is somehow messy in the current implementation. Let's refactor it later.

For now we just use some hacks to support `select * from (select * from t1)`.

close https://github.com/cmu-db/bustub/issues/355