### PR TITLE
fix(build): compile to wasm

### DIFF
--- a/src/binder/bind_select.cpp
+++ b/src/binder/bind_select.cpp
@@ -452,7 +452,7 @@ auto Binder::BindFuncCall(duckdb_libpgquery::PGFuncCall *root) -> std::unique_pt
     }
 
     // Bind function as agg call.
-    return std::make_unique<BoundAggCall>(function_name, root->agg_distinct, move(children));
+    return std::make_unique<BoundAggCall>(function_name, root->agg_distinct, std::move(children));
   }
   throw bustub::Exception(fmt::format("unsupported func call {}", function_name));
 }

--- a/src/binder/transformer.cpp
+++ b/src/binder/transformer.cpp
@@ -43,7 +43,7 @@ auto Binder::TransformParseTree(duckdb_libpgquery::PGList *tree) -> std::vector<
   std::vector<std::unique_ptr<BoundStatement>> statements;
   for (auto entry = tree->head; entry != nullptr; entry = entry->next) {
     auto stmt = TransformStatement(static_cast<duckdb_libpgquery::PGNode *>(entry->data.ptr_value));
-    statements.push_back(move(stmt));
+    statements.push_back(std::move(stmt));
   }
   return statements;
 }

--- a/src/include/binder/expressions/bound_agg_call.h
+++ b/src/include/binder/expressions/bound_agg_call.h
@@ -18,7 +18,7 @@ class BoundAggCall : public BoundExpression {
       : BoundExpression(ExpressionType::AGG_CALL),
         func_name_(std::move(func_name)),
         is_distinct_(is_distinct),
-        args_(move(args)) {}
+        args_(std::move(args)) {}
 
   auto ToString() const -> std::string override;
 

--- a/src/include/common/config.h
+++ b/src/include/common/config.h
@@ -27,15 +27,15 @@ extern std::atomic<bool> enable_logging;
 /** If ENABLE_LOGGING is true, the log should be flushed to disk every LOG_TIMEOUT. */
 extern std::chrono::duration<int64_t> log_timeout;
 
-static constexpr int INVALID_PAGE_ID = -1;                                    // invalid page id
-static constexpr int INVALID_TXN_ID = -1;                                     // invalid transaction id
-static constexpr int INVALID_LSN = -1;                                        // invalid log sequence number
-static constexpr int HEADER_PAGE_ID = 0;                                      // the header page id
-static constexpr int PAGE_SIZE = 4096;                                        // size of a data page in byte
-static constexpr int BUFFER_POOL_SIZE = 10;                                   // size of buffer pool
-static constexpr int LOG_BUFFER_SIZE = ((BUFFER_POOL_SIZE + 1) * PAGE_SIZE);  // size of a log buffer in byte
-static constexpr int BUCKET_SIZE = 50;                                        // size of extendible hash bucket
-static constexpr int LRUK_REPLACER_K = 10;                                    // lookback window for lru-k replacer
+static constexpr int INVALID_PAGE_ID = -1;                                           // invalid page id
+static constexpr int INVALID_TXN_ID = -1;                                            // invalid transaction id
+static constexpr int INVALID_LSN = -1;                                               // invalid log sequence number
+static constexpr int HEADER_PAGE_ID = 0;                                             // the header page id
+static constexpr int BUSTUB_PAGE_SIZE = 4096;                                        // size of a data page in byte
+static constexpr int BUFFER_POOL_SIZE = 10;                                          // size of buffer pool
+static constexpr int LOG_BUFFER_SIZE = ((BUFFER_POOL_SIZE + 1) * BUSTUB_PAGE_SIZE);  // size of a log buffer in byte
+static constexpr int BUCKET_SIZE = 50;                                               // size of extendible hash bucket
+static constexpr int LRUK_REPLACER_K = 10;  // lookback window for lru-k replacer
 
 using frame_id_t = int32_t;    // frame id type
 using page_id_t = int32_t;     // page id type

--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -18,7 +18,7 @@ namespace bustub {
 
 #define B_PLUS_TREE_INTERNAL_PAGE_TYPE BPlusTreeInternalPage<KeyType, ValueType, KeyComparator>
 #define INTERNAL_PAGE_HEADER_SIZE 24
-#define INTERNAL_PAGE_SIZE ((PAGE_SIZE - INTERNAL_PAGE_HEADER_SIZE) / (sizeof(MappingType)))
+#define INTERNAL_PAGE_SIZE ((BUSTUB_PAGE_SIZE - INTERNAL_PAGE_HEADER_SIZE) / (sizeof(MappingType)))
 /**
  * Store n indexed keys and n+1 child pointers (page_id) within internal page.
  * Pointer PAGE_ID(i) points to a subtree in which all keys K satisfy:

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -19,7 +19,7 @@ namespace bustub {
 
 #define B_PLUS_TREE_LEAF_PAGE_TYPE BPlusTreeLeafPage<KeyType, ValueType, KeyComparator>
 #define LEAF_PAGE_HEADER_SIZE 28
-#define LEAF_PAGE_SIZE ((PAGE_SIZE - LEAF_PAGE_HEADER_SIZE) / sizeof(MappingType))
+#define LEAF_PAGE_SIZE ((BUSTUB_PAGE_SIZE - LEAF_PAGE_HEADER_SIZE) / sizeof(MappingType))
 
 /**
  * Store indexed key and record id(record id = page id combined with slot id,

--- a/src/include/storage/page/hash_table_page_defs.h
+++ b/src/include/storage/page/hash_table_page_defs.h
@@ -22,11 +22,11 @@
 /**
  * BLOCK_ARRAY_SIZE is the number of (key, value) pairs that can be stored in a linear probe hash block page. It is an
  * approximate calculation based on the size of MappingType (which is a std::pair of KeyType and ValueType). For each
- * key/value pair, we need two additional bits for occupied_ and readable_. 4 * PAGE_SIZE / (4 * sizeof (MappingType) +
- * 1) = PAGE_SIZE/(sizeof (MappingType) + 0.25) because 0.25 bytes = 2 bits is the space required to maintain the
- * occupied and readable flags for a key value pair.
+ * key/value pair, we need two additional bits for occupied_ and readable_. 4 * BUSTUB_PAGE_SIZE / (4 * sizeof
+ * (MappingType) + 1) = BUSTUB_PAGE_SIZE/(sizeof (MappingType) + 0.25) because 0.25 bytes = 2 bits is the space required
+ * to maintain the occupied and readable flags for a key value pair.
  */
-#define BLOCK_ARRAY_SIZE (4 * PAGE_SIZE / (4 * sizeof(MappingType) + 1))
+#define BLOCK_ARRAY_SIZE (4 * BUSTUB_PAGE_SIZE / (4 * sizeof(MappingType) + 1))
 
 /**
  * Extendible Hashing Definitions
@@ -38,7 +38,7 @@
  * The computation is the same as the above BLOCK_ARRAY_SIZE, but blocks and buckets have different implementations
  * of search, insertion, removal, and helper methods.
  */
-#define BUCKET_ARRAY_SIZE (4 * PAGE_SIZE / (4 * sizeof(MappingType) + 1))
+#define BUCKET_ARRAY_SIZE (4 * BUSTUB_PAGE_SIZE / (4 * sizeof(MappingType) + 1))
 
 /**
  * DIRECTORY_ARRAY_SIZE is the number of page_ids that can fit in the directory page of an extendible hash index.

--- a/src/include/storage/page/page.h
+++ b/src/include/storage/page/page.h
@@ -76,10 +76,10 @@ class Page {
 
  private:
   /** Zeroes out the data that is held within the page. */
-  inline void ResetMemory() { memset(data_, OFFSET_PAGE_START, PAGE_SIZE); }
+  inline void ResetMemory() { memset(data_, OFFSET_PAGE_START, BUSTUB_PAGE_SIZE); }
 
   /** The actual data that is stored within a page. */
-  char data_[PAGE_SIZE]{};
+  char data_[BUSTUB_PAGE_SIZE]{};
   /** The ID of this page. */
   page_id_t page_id_ = INVALID_PAGE_ID;
   /** The pin count of this page. */

--- a/src/storage/disk/disk_manager.cpp
+++ b/src/storage/disk/disk_manager.cpp
@@ -79,11 +79,11 @@ void DiskManager::ShutDown() {
  */
 void DiskManager::WritePage(page_id_t page_id, const char *page_data) {
   std::scoped_lock scoped_db_io_latch(db_io_latch_);
-  size_t offset = static_cast<size_t>(page_id) * PAGE_SIZE;
+  size_t offset = static_cast<size_t>(page_id) * BUSTUB_PAGE_SIZE;
   // set write cursor to offset
   num_writes_ += 1;
   db_io_.seekp(offset);
-  db_io_.write(page_data, PAGE_SIZE);
+  db_io_.write(page_data, BUSTUB_PAGE_SIZE);
   // check for I/O error
   if (db_io_.bad()) {
     LOG_DEBUG("I/O error while writing");
@@ -98,7 +98,7 @@ void DiskManager::WritePage(page_id_t page_id, const char *page_data) {
  */
 void DiskManager::ReadPage(page_id_t page_id, char *page_data) {
   std::scoped_lock scoped_db_io_latch(db_io_latch_);
-  int offset = page_id * PAGE_SIZE;
+  int offset = page_id * BUSTUB_PAGE_SIZE;
   // check if read beyond file length
   if (offset > GetFileSize(file_name_)) {
     LOG_DEBUG("I/O error reading past end of file");
@@ -106,18 +106,18 @@ void DiskManager::ReadPage(page_id_t page_id, char *page_data) {
   } else {
     // set read cursor to offset
     db_io_.seekp(offset);
-    db_io_.read(page_data, PAGE_SIZE);
+    db_io_.read(page_data, BUSTUB_PAGE_SIZE);
     if (db_io_.bad()) {
       LOG_DEBUG("I/O error while reading");
       return;
     }
-    // if file ends before reading PAGE_SIZE
+    // if file ends before reading BUSTUB_PAGE_SIZE
     int read_count = db_io_.gcount();
-    if (read_count < PAGE_SIZE) {
+    if (read_count < BUSTUB_PAGE_SIZE) {
       LOG_DEBUG("Read less than a page");
       db_io_.clear();
       // std::cerr << "Read less than a page" << std::endl;
-      memset(page_data + read_count, 0, PAGE_SIZE - read_count);
+      memset(page_data + read_count, 0, BUSTUB_PAGE_SIZE - read_count);
     }
   }
 }

--- a/src/storage/disk/disk_manager_memory.cpp
+++ b/src/storage/disk/disk_manager_memory.cpp
@@ -27,24 +27,24 @@ namespace bustub {
 /**
  * Constructor: used for memory based manager
  */
-DiskManagerMemory::DiskManagerMemory(size_t pages) { memory_ = new char[pages * PAGE_SIZE]; }
+DiskManagerMemory::DiskManagerMemory(size_t pages) { memory_ = new char[pages * BUSTUB_PAGE_SIZE]; }
 
 /**
  * Write the contents of the specified page into disk file
  */
 void DiskManagerMemory::WritePage(page_id_t page_id, const char *page_data) {
-  size_t offset = static_cast<size_t>(page_id) * PAGE_SIZE;
+  size_t offset = static_cast<size_t>(page_id) * BUSTUB_PAGE_SIZE;
   // set write cursor to offset
   num_writes_ += 1;
-  memcpy(memory_ + offset, page_data, PAGE_SIZE);
+  memcpy(memory_ + offset, page_data, BUSTUB_PAGE_SIZE);
 }
 
 /**
  * Read the contents of the specified page into the given memory area
  */
 void DiskManagerMemory::ReadPage(page_id_t page_id, char *page_data) {
-  int64_t offset = static_cast<int64_t>(page_id) * PAGE_SIZE;
-  memcpy(page_data, memory_ + offset, PAGE_SIZE);
+  int64_t offset = static_cast<int64_t>(page_id) * BUSTUB_PAGE_SIZE;
+  memcpy(page_data, memory_ + offset, BUSTUB_PAGE_SIZE);
 }
 
 }  // namespace bustub

--- a/src/storage/table/table_heap.cpp
+++ b/src/storage/table/table_heap.cpp
@@ -32,13 +32,13 @@ TableHeap::TableHeap(BufferPoolManager *buffer_pool_manager, LockManager *lock_m
   BUSTUB_ASSERT(first_page != nullptr,
                 "Couldn't create a page for the table heap. Have you completed the buffer pool manager project?");
   first_page->WLatch();
-  first_page->Init(first_page_id_, PAGE_SIZE, INVALID_LSN, log_manager_, txn);
+  first_page->Init(first_page_id_, BUSTUB_PAGE_SIZE, INVALID_LSN, log_manager_, txn);
   first_page->WUnlatch();
   buffer_pool_manager_->UnpinPage(first_page_id_, true);
 }
 
 auto TableHeap::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) -> bool {
-  if (tuple.size_ + 32 > PAGE_SIZE) {  // larger than one page size
+  if (tuple.size_ + 32 > BUSTUB_PAGE_SIZE) {  // larger than one page size
     txn->SetState(TransactionState::ABORTED);
     return false;
   }
@@ -76,7 +76,7 @@ auto TableHeap::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn) -> b
       // Otherwise we were able to create a new page. We initialize it now.
       new_page->WLatch();
       cur_page->SetNextPageId(next_page_id);
-      new_page->Init(next_page_id, PAGE_SIZE, cur_page->GetTablePageId(), log_manager_, txn);
+      new_page->Init(next_page_id, BUSTUB_PAGE_SIZE, cur_page->GetTablePageId(), log_manager_, txn);
       cur_page->WUnlatch();
       buffer_pool_manager_->UnpinPage(cur_page->GetTablePageId(), true);
       cur_page = new_page;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,20 +4,19 @@ include(GoogleTest)
 
 file(GLOB_RECURSE BUSTUB_TEST_SOURCES "${PROJECT_SOURCE_DIR}/test/*/*test.cpp")
 
-######################################################################################################################
+# #####################################################################################################################
 # MAKE TARGETS
-######################################################################################################################
+# #####################################################################################################################
 
-##########################################
+# #########################################
 # "make check-tests"
-##########################################
+# #########################################
 add_custom_target(build-tests COMMAND ${CMAKE_CTEST_COMMAND} --show-only)
 add_custom_target(check-tests COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
 
-##########################################
+# #########################################
 # "make XYZ_test"
-##########################################
-
+# #########################################
 foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
     # Create a human readable name.
     get_filename_component(bustub_test_filename ${bustub_test_source} NAME)
@@ -33,10 +32,11 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
             --gtest_color=auto
             --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${bustub_test_name}.xml
             --gtest_catch_exceptions=0
+            DISCOVERY_TIMEOUT 120
             PROPERTIES
             TIMEOUT 30
             )
-    
+
     target_link_libraries(${bustub_test_name} bustub gtest gmock_main)
 
     # Set test target properties and dependencies.

--- a/test/buffer/buffer_pool_manager_instance_test.cpp
+++ b/test/buffer/buffer_pool_manager_instance_test.cpp
@@ -42,19 +42,19 @@ TEST(BufferPoolManagerInstanceTest, DISABLED_BinaryDataTest) {
   ASSERT_NE(nullptr, page0);
   EXPECT_EQ(0, page_id_temp);
 
-  char random_binary_data[PAGE_SIZE];
+  char random_binary_data[BUSTUB_PAGE_SIZE];
   // Generate random binary data
   for (char &i : random_binary_data) {
     i = uniform_dist(rng);
   }
 
   // Insert terminal characters both in the middle and at end
-  random_binary_data[PAGE_SIZE / 2] = '\0';
-  random_binary_data[PAGE_SIZE - 1] = '\0';
+  random_binary_data[BUSTUB_PAGE_SIZE / 2] = '\0';
+  random_binary_data[BUSTUB_PAGE_SIZE - 1] = '\0';
 
   // Scenario: Once we have a page, we should be able to read and write content.
-  std::memcpy(page0->GetData(), random_binary_data, PAGE_SIZE);
-  EXPECT_EQ(0, std::memcmp(page0->GetData(), random_binary_data, PAGE_SIZE));
+  std::memcpy(page0->GetData(), random_binary_data, BUSTUB_PAGE_SIZE);
+  EXPECT_EQ(0, std::memcmp(page0->GetData(), random_binary_data, BUSTUB_PAGE_SIZE));
 
   // Scenario: We should be able to create new pages until we fill up the buffer pool.
   for (size_t i = 1; i < buffer_pool_size; ++i) {
@@ -77,7 +77,7 @@ TEST(BufferPoolManagerInstanceTest, DISABLED_BinaryDataTest) {
   }
   // Scenario: We should be able to fetch the data we wrote a while ago.
   page0 = bpm->FetchPage(0);
-  EXPECT_EQ(0, memcmp(page0->GetData(), random_binary_data, PAGE_SIZE));
+  EXPECT_EQ(0, memcmp(page0->GetData(), random_binary_data, BUSTUB_PAGE_SIZE));
   EXPECT_EQ(true, bpm->UnpinPage(0, true));
 
   // Shutdown the disk manager and remove the temporary file we created.
@@ -105,7 +105,7 @@ TEST(BufferPoolManagerInstanceTest, DISABLED_SampleTest) {
   EXPECT_EQ(0, page_id_temp);
 
   // Scenario: Once we have a page, we should be able to read and write content.
-  snprintf(page0->GetData(), PAGE_SIZE, "Hello");
+  snprintf(page0->GetData(), BUSTUB_PAGE_SIZE, "Hello");
   EXPECT_EQ(0, strcmp(page0->GetData(), "Hello"));
 
   // Scenario: We should be able to create new pages until we fill up the buffer pool.

--- a/test/recovery/recovery_test.cpp
+++ b/test/recovery/recovery_test.cpp
@@ -277,14 +277,14 @@ TEST_F(RecoveryTest, DISABLED_CheckpointTest) {
   // compare each page in the buffer pool to that page's
   // data on disk. ensure they match after the checkpoint
   bool all_pages_match = true;
-  auto *disk_data = new char[PAGE_SIZE];
+  auto *disk_data = new char[BUSTUB_PAGE_SIZE];
   for (size_t i = 0; i < pool_size; i++) {
     Page *page = &pages[i];
     page_id_t page_id = page->GetPageId();
 
     if (page_id != INVALID_PAGE_ID) {
       bustub_instance->disk_manager_->ReadPage(page_id, disk_data);
-      if (std::memcmp(disk_data, page->GetData(), PAGE_SIZE) != 0) {
+      if (std::memcmp(disk_data, page->GetData(), BUSTUB_PAGE_SIZE) != 0) {
         all_pages_match = false;
         break;
       }

--- a/test/storage/disk_manager_test.cpp
+++ b/test/storage/disk_manager_test.cpp
@@ -35,8 +35,8 @@ class DiskManagerTest : public ::testing::Test {
 
 // NOLINTNEXTLINE
 TEST_F(DiskManagerTest, ReadWritePageTest) {
-  char buf[PAGE_SIZE] = {0};
-  char data[PAGE_SIZE] = {0};
+  char buf[BUSTUB_PAGE_SIZE] = {0};
+  char data[BUSTUB_PAGE_SIZE] = {0};
   std::string db_file("test.db");
   auto dm = DiskManager(db_file);
   std::strncpy(data, "A test string.", sizeof(data));

--- a/test/storage/tmp_tuple_page_test.cpp
+++ b/test/storage/tmp_tuple_page_test.cpp
@@ -26,11 +26,11 @@ TEST(TmpTuplePageTest, DISABLED_BasicTest) {
 
   TmpTuplePage page{};
   page_id_t page_id = 15445;
-  page.Init(page_id, PAGE_SIZE);
+  page.Init(page_id, BUSTUB_PAGE_SIZE);
 
   char *data = page.GetData();
   ASSERT_EQ(*reinterpret_cast<page_id_t *>(data), page_id);
-  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + sizeof(page_id_t) + sizeof(lsn_t)), PAGE_SIZE);
+  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + sizeof(page_id_t) + sizeof(lsn_t)), BUSTUB_PAGE_SIZE);
 
   std::vector<Column> columns;
   columns.emplace_back("A", TypeId::INTEGER);
@@ -43,9 +43,9 @@ TEST(TmpTuplePageTest, DISABLED_BasicTest) {
   TmpTuple tmp_tuple(INVALID_PAGE_ID, 0);
   page.Insert(tuple, &tmp_tuple);
 
-  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + sizeof(page_id_t) + sizeof(lsn_t)), PAGE_SIZE - 8);
-  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + PAGE_SIZE - 8), 4);
-  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + PAGE_SIZE - 4), 123);
+  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + sizeof(page_id_t) + sizeof(lsn_t)), BUSTUB_PAGE_SIZE - 8);
+  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + BUSTUB_PAGE_SIZE - 8), 4);
+  ASSERT_EQ(*reinterpret_cast<uint32_t *>(data + BUSTUB_PAGE_SIZE - 4), 123);
 }
 
 }  // namespace bustub


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This PR includes changes on some headers. `PAGE_SIZE` is defined in Emscripten, so we rename it to `BUSTUB_PAGE_SIZE`. Also clang-16 detects some issues with missing `std::` before move.