### PR TITLE
feat(binder): bind index and delete

### DIFF
--- a/src/binder/bind_insert.cpp
+++ b/src/binder/bind_insert.cpp
@@ -1,25 +1,3 @@
-//===----------------------------------------------------------------------===//
-// Copyright 2018-2022 Stichting DuckDB Foundation
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice (including the next paragraph)
-// shall be included in all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//===----------------------------------------------------------------------===//
-
 #include <iterator>
 #include <memory>
 #include <string>
@@ -28,11 +6,14 @@
 #include "binder/bound_expression.h"
 #include "binder/bound_order_by.h"
 #include "binder/bound_table_ref.h"
+#include "binder/expressions/bound_constant.h"
+#include "binder/statement/delete_statement.h"
 #include "binder/statement/insert_statement.h"
 #include "binder/statement/select_statement.h"
 #include "common/exception.h"
 #include "common/util/string_util.h"
 #include "nodes/parsenodes.hpp"
+#include "type/value_factory.h"
 
 namespace bustub {
 
@@ -51,6 +32,20 @@ auto Binder::BindInsert(duckdb_libpgquery::PGInsertStmt *pg_stmt) -> std::unique
   auto select_statement = BindSelect(reinterpret_cast<duckdb_libpgquery::PGSelectStmt *>(pg_stmt->selectStmt));
 
   return std::make_unique<InsertStatement>(table_name, std::move(select_statement));
+}
+
+auto Binder::BindDelete(duckdb_libpgquery::PGDeleteStmt *stmt) -> std::unique_ptr<DeleteStatement> {
+  auto table = BindRangeVar(stmt->relation);
+  auto ctx_guard = NewContext();
+  scope_ = table.get();
+  std::unique_ptr<BoundExpression> expr = nullptr;
+  if (stmt->whereClause != nullptr) {
+    expr = BindExpression(stmt->whereClause);
+  } else {
+    expr = std::make_unique<BoundConstant>(ValueFactory::GetBooleanValue(true));
+  }
+
+  return std::make_unique<DeleteStatement>(std::move(table), std::move(expr));
 }
 
 }  // namespace bustub

--- a/src/binder/statement/CMakeLists.txt
+++ b/src/binder/statement/CMakeLists.txt
@@ -4,8 +4,10 @@ add_library(
   create_statement.cpp
   delete_statement.cpp
   explain_statement.cpp
+  index_statement.cpp
   insert_statement.cpp
   select_statement.cpp)
+
 set(ALL_OBJECT_FILES
   ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:bustub_statement>
   PARENT_SCOPE)

--- a/src/binder/statement/delete_statement.cpp
+++ b/src/binder/statement/delete_statement.cpp
@@ -1,10 +1,13 @@
 #include "binder/statement/delete_statement.h"
+#include "fmt/core.h"
 
 namespace bustub {
 
-DeleteStatement::DeleteStatement(duckdb_libpgquery::PGDeleteStmt *pg_stmt)
-    : BoundStatement(StatementType::DELETE_STATEMENT) {}
+DeleteStatement::DeleteStatement(std::unique_ptr<BoundBaseTableRef> table, std::unique_ptr<BoundExpression> expr)
+    : BoundStatement(StatementType::DELETE_STATEMENT), table_(std::move(table)), expr_(std::move(expr)) {}
 
-auto DeleteStatement::ToString() const -> std::string { return {}; }
+auto DeleteStatement::ToString() const -> std::string {
+  return fmt::format("Delete {{ table={}, expr={} }}", *table_, *expr_);
+}
 
 }  // namespace bustub

--- a/src/binder/statement/index_statement.cpp
+++ b/src/binder/statement/index_statement.cpp
@@ -1,0 +1,20 @@
+#include "binder/statement/index_statement.h"
+#include "binder/bound_expression.h"
+#include "binder/expressions/bound_column_ref.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+
+namespace bustub {
+
+IndexStatement::IndexStatement(std::string index_name, std::unique_ptr<BoundBaseTableRef> table,
+                               std::vector<std::unique_ptr<BoundColumnRef>> cols)
+    : BoundStatement(StatementType::INDEX_STATEMENT),
+      index_name_(std::move(index_name)),
+      table_(std::move(table)),
+      cols_(std::move(cols)) {}
+
+auto IndexStatement::ToString() const -> std::string {
+  return fmt::format("Index {{ index_name={}, table={}, cols={} }}", index_name_, *table_, cols_);
+}
+
+}  // namespace bustub

--- a/src/binder/transformer.cpp
+++ b/src/binder/transformer.cpp
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 //===----------------------------------------------------------------------===//
 
+#include <memory>
 #include "binder/binder.h"
 #include "binder/bound_expression.h"
 #include "binder/bound_order_by.h"
@@ -27,6 +28,7 @@
 #include "binder/statement/create_statement.h"
 #include "binder/statement/delete_statement.h"
 #include "binder/statement/explain_statement.h"
+#include "binder/statement/index_statement.h"
 #include "binder/statement/insert_statement.h"
 #include "binder/statement/select_statement.h"
 #include "binder/table_ref/bound_base_table_ref.h"
@@ -68,8 +70,9 @@ auto Binder::TransformStatement(duckdb_libpgquery::PGNode *stmt) -> std::unique_
     case duckdb_libpgquery::T_PGExplainStmt:
       return BindExplain(reinterpret_cast<duckdb_libpgquery::PGExplainStmt *>(stmt));
     case duckdb_libpgquery::T_PGDeleteStmt:
-      return std::make_unique<DeleteStatement>(reinterpret_cast<duckdb_libpgquery::PGDeleteStmt *>(stmt));
+      return BindDelete(reinterpret_cast<duckdb_libpgquery::PGDeleteStmt *>(stmt));
     case duckdb_libpgquery::T_PGIndexStmt:
+      return BindIndex(reinterpret_cast<duckdb_libpgquery::PGIndexStmt *>(stmt));
     case duckdb_libpgquery::T_PGUpdateStmt:
     default:
       throw NotImplementedException(NodeTagToString(stmt->type));

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -68,12 +68,15 @@ namespace bustub {
 class Catalog;
 class BoundExpression;
 class BoundTableRef;
+class BoundBaseTableRef;
 class BoundExpression;
 class BoundExpressionListRef;
 class BoundOrderBy;
 class SelectStatement;
 class CreateStatement;
 class ExplainStatement;
+class IndexStatement;
+class DeleteStatement;
 
 /**
  * The binder is responsible for transforming the Postgres parse tree to a binder tree
@@ -150,6 +153,10 @@ class Binder {
 
   auto BindFrom(duckdb_libpgquery::PGList *list) -> std::unique_ptr<BoundTableRef>;
 
+  auto BindBaseTableRef(std::string table_name, std::optional<std::string> alias) -> std::unique_ptr<BoundBaseTableRef>;
+
+  auto BindRangeVar(duckdb_libpgquery::PGRangeVar *table_ref) -> std::unique_ptr<BoundBaseTableRef>;
+
   auto BindTableRef(duckdb_libpgquery::PGNode *node) -> std::unique_ptr<BoundTableRef>;
 
   auto BindJoin(duckdb_libpgquery::PGJoinExpr *root) -> std::unique_ptr<BoundTableRef>;
@@ -168,6 +175,10 @@ class Binder {
   auto BindLimitOffset(duckdb_libpgquery::PGNode *root) -> std::unique_ptr<BoundExpression>;
 
   auto BindSort(duckdb_libpgquery::PGList *list) -> std::vector<std::unique_ptr<BoundOrderBy>>;
+
+  auto BindIndex(duckdb_libpgquery::PGIndexStmt *stmt) -> std::unique_ptr<IndexStatement>;
+
+  auto BindDelete(duckdb_libpgquery::PGDeleteStmt *stmt) -> std::unique_ptr<DeleteStatement>;
 
   class ContextGuard {
    public:

--- a/src/include/binder/bound_expression.h
+++ b/src/include/binder/bound_expression.h
@@ -48,7 +48,7 @@ template <typename T>
 struct fmt::formatter<T, std::enable_if_t<std::is_base_of<bustub::BoundExpression, T>::value, char>>
     : fmt::formatter<std::string> {
   template <typename FormatCtx>
-  auto format(const bustub::BoundExpression &x, FormatCtx &ctx) const {
+  auto format(const T &x, FormatCtx &ctx) const {
     return fmt::formatter<std::string>::format(x.ToString(), ctx);
   }
 };
@@ -57,7 +57,7 @@ template <typename T>
 struct fmt::formatter<std::unique_ptr<T>, std::enable_if_t<std::is_base_of<bustub::BoundExpression, T>::value, char>>
     : fmt::formatter<std::string> {
   template <typename FormatCtx>
-  auto format(const std::unique_ptr<bustub::BoundExpression> &x, FormatCtx &ctx) const {
+  auto format(const std::unique_ptr<T> &x, FormatCtx &ctx) const {
     return fmt::formatter<std::string>::format(x->ToString(), ctx);
   }
 };

--- a/src/include/binder/statement/index_statement.h
+++ b/src/include/binder/statement/index_statement.h
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         BusTub
 //
-// binder/delete_statement.h
+// binder/index_statement.h
 //
 //===----------------------------------------------------------------------===//
 
@@ -9,25 +9,32 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
-#include "binder/bound_expression.h"
 #include "binder/bound_statement.h"
+#include "binder/expressions/bound_column_ref.h"
 #include "binder/table_ref/bound_base_table_ref.h"
 #include "catalog/column.h"
 
 namespace duckdb_libpgquery {
-struct PGDeleteStmt;
+struct PGIndexStmt;
 }  // namespace duckdb_libpgquery
 
 namespace bustub {
 
-class DeleteStatement : public BoundStatement {
+class IndexStatement : public BoundStatement {
  public:
-  explicit DeleteStatement(std::unique_ptr<BoundBaseTableRef> table, std::unique_ptr<BoundExpression> expr);
+  explicit IndexStatement(std::string index_name, std::unique_ptr<BoundBaseTableRef> table,
+                          std::vector<std::unique_ptr<BoundColumnRef>> cols);
 
+  /** Name of the index */
+  std::string index_name_;
+
+  /** Create on which table */
   std::unique_ptr<BoundBaseTableRef> table_;
 
-  std::unique_ptr<BoundExpression> expr_;
+  /** Name of the columns */
+  std::vector<std::unique_ptr<BoundColumnRef>> cols_;
 
   auto ToString() const -> std::string override;
 };

--- a/src/include/common/enums/statement_type.h
+++ b/src/include/common/enums/statement_type.h
@@ -29,6 +29,7 @@ enum class StatementType : uint8_t {
   DELETE_STATEMENT,   // delete statement type
   EXPLAIN_STATEMENT,  // explain statement type
   DROP_STATEMENT,     // drop statement type
+  INDEX_STATEMENT,    // index statement type
 };
 
 }  // namespace bustub
@@ -62,6 +63,9 @@ struct fmt::formatter<bustub::StatementType> : formatter<string_view> {
         break;
       case bustub::StatementType::DROP_STATEMENT:
         name = "Drop";
+        break;
+      case bustub::StatementType::INDEX_STATEMENT:
+        name = "Index";
         break;
     }
     return formatter<string_view>::format(name, ctx);

--- a/src/include/execution/expressions/abstract_expression.h
+++ b/src/include/execution/expressions/abstract_expression.h
@@ -95,7 +95,7 @@ template <typename T>
 struct fmt::formatter<T, std::enable_if_t<std::is_base_of<bustub::AbstractExpression, T>::value, char>>
     : fmt::formatter<std::string> {
   template <typename FormatCtx>
-  auto format(const bustub::AbstractExpression &x, FormatCtx &ctx) const {
+  auto format(const T &x, FormatCtx &ctx) const {
     return fmt::formatter<std::string>::format(x.ToString(), ctx);
   }
 };

--- a/src/include/execution/plans/abstract_plan.h
+++ b/src/include/execution/plans/abstract_plan.h
@@ -118,7 +118,7 @@ template <typename T>
 struct fmt::formatter<T, std::enable_if_t<std::is_base_of<bustub::AbstractPlanNode, T>::value, char>>
     : fmt::formatter<std::string> {
   template <typename FormatCtx>
-  auto format(const bustub::AbstractPlanNode &x, FormatCtx &ctx) const {
+  auto format(const T &x, FormatCtx &ctx) const {
     return fmt::formatter<std::string>::format(x.ToString(), ctx);
   }
 };
@@ -127,7 +127,7 @@ template <typename T>
 struct fmt::formatter<std::unique_ptr<T>, std::enable_if_t<std::is_base_of<bustub::AbstractPlanNode, T>::value, char>>
     : fmt::formatter<std::string> {
   template <typename FormatCtx>
-  auto format(const std::unique_ptr<bustub::AbstractPlanNode> &x, FormatCtx &ctx) const {
+  auto format(const std::unique_ptr<T> &x, FormatCtx &ctx) const {
     return fmt::formatter<std::string>::format(x->ToString(), ctx);
   }
 };


### PR DESCRIPTION
This PR adds support for binding `create index` and `delete from table <where x>`.

close https://github.com/cmu-db/bustub/issues/359
close https://github.com/cmu-db/bustub/issues/362