### PR TITLE
feat(optimizer): match index and plan nested index join

### DIFF
--- a/src/binder/bind_select.cpp
+++ b/src/binder/bind_select.cpp
@@ -35,6 +35,7 @@
 #include "nodes/primnodes.hpp"
 #include "pg_definitions.hpp"
 #include "postgres_parser.hpp"
+#include "type/type_id.h"
 #include "type/value_factory.h"
 
 namespace bustub {
@@ -391,6 +392,10 @@ auto Binder::BindConstant(duckdb_libpgquery::PGAConst *node) -> std::unique_ptr<
     }
     case duckdb_libpgquery::T_PGString: {
       return std::make_unique<BoundConstant>(ValueFactory::GetVarcharValue(val.val.str));
+    }
+    case duckdb_libpgquery::T_PGNull: {
+      // TODO(chi): cast integer null to other types
+      return std::make_unique<BoundConstant>(ValueFactory::GetNullValueByType(TypeId::INTEGER));
     }
     default:
       break;

--- a/src/common/bustub_instance.cpp
+++ b/src/common/bustub_instance.cpp
@@ -168,7 +168,7 @@ auto BustubInstance::ExecuteSql(const std::string &sql) -> std::vector<std::stri
 
         // Print binder result.
         std::cout << "=== BINDER ===" << std::endl;
-        std::cout << statement->ToString() << std::endl;
+        std::cout << explain_stmt.statement_->ToString() << std::endl;
 
         // Print planner result.
         bustub::Planner planner(*catalog_);

--- a/src/include/execution/plans/seq_scan_plan.h
+++ b/src/include/execution/plans/seq_scan_plan.h
@@ -36,14 +36,11 @@ class SeqScanPlanNode : public AbstractPlanNode {
    * @param predicate The predicate applied during the scan operation
    * @param table_oid The identifier of table to be scanned
    */
-  SeqScanPlanNode(SchemaRef output, AbstractExpressionRef predicate, table_oid_t table_oid)
-      : AbstractPlanNode(std::move(output), {}), predicate_(std::move(predicate)), table_oid_{table_oid} {}
+  SeqScanPlanNode(SchemaRef output, table_oid_t table_oid, std::string table_name)
+      : AbstractPlanNode(std::move(output), {}), table_oid_{table_oid}, table_name_(std::move(table_name)) {}
 
   /** @return The type of the plan node */
   auto GetType() const -> PlanType override { return PlanType::SeqScan; }
-
-  /** @return The predicate to test tuples against; tuples should only be returned if they evaluate to true */
-  auto GetPredicate() const -> AbstractExpressionRef { return predicate_; }
 
   /** @return The identifier of the table that should be scanned */
   auto GetTableOid() const -> table_oid_t { return table_oid_; }
@@ -52,16 +49,14 @@ class SeqScanPlanNode : public AbstractPlanNode {
 
   BUSTUB_PLAN_NODE_CLONE_WITH_CHILDREN(SeqScanPlanNode);
 
- protected:
-  auto PlanNodeToString() const -> std::string override {
-    return fmt::format("SeqScan {{ table_oid={} }}", table_oid_);
-  }
-
- private:
-  /** The predicate that all returned tuples must satisfy */
-  AbstractExpressionRef predicate_;
   /** The table whose tuples should be scanned */
   table_oid_t table_oid_;
+
+  /** The table name */
+  std::string table_name_;
+
+ protected:
+  auto PlanNodeToString() const -> std::string override { return fmt::format("SeqScan {{ table={} }}", table_name_); }
 };
 
 }  // namespace bustub

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
     merge_projection.cpp
     merge_filter_nlj.cpp
     nlj_as_hash_join.cpp
+    nlj_as_index_join.cpp
     optimizer.cpp
     order_by_index_scan.cpp)
 

--- a/src/optimizer/nlj_as_index_join.cpp
+++ b/src/optimizer/nlj_as_index_join.cpp
@@ -1,0 +1,93 @@
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include "catalog/column.h"
+#include "catalog/schema.h"
+#include "common/exception.h"
+#include "common/macros.h"
+#include "execution/expressions/column_value_expression.h"
+#include "execution/expressions/comparison_expression.h"
+#include "execution/expressions/constant_value_expression.h"
+#include "execution/plans/abstract_plan.h"
+#include "execution/plans/filter_plan.h"
+#include "execution/plans/hash_join_plan.h"
+#include "execution/plans/nested_index_join_plan.h"
+#include "execution/plans/nested_loop_join_plan.h"
+#include "execution/plans/projection_plan.h"
+#include "execution/plans/seq_scan_plan.h"
+#include "optimizer/optimizer.h"
+#include "type/type_id.h"
+
+namespace bustub {
+
+auto Optimizer::MatchIndex(const std::string &table_name, uint32_t index_key_idx)
+    -> std::optional<std::tuple<index_oid_t, std::string>> {
+  const auto key_attrs = std::vector{index_key_idx};
+  for (const auto *index_info : catalog_.GetTableIndexes(table_name)) {
+    if (key_attrs == index_info->index_->GetKeyAttrs()) {
+      return std::make_optional(std::make_tuple(index_info->index_oid_, index_info->name_));
+    }
+  }
+  return std::nullopt;
+}
+
+auto Optimizer::OptimizeNLJAsIndexJoin(const AbstractPlanNodeRef &plan) -> AbstractPlanNodeRef {
+  std::vector<AbstractPlanNodeRef> children;
+  for (const auto &child : plan->GetChildren()) {
+    children.emplace_back(OptimizeNLJAsIndexJoin(child));
+  }
+  auto optimized_plan = plan->CloneWithChildren(std::move(children));
+
+  if (optimized_plan->GetType() == PlanType::NestedLoopJoin) {
+    const auto &nlj_plan = dynamic_cast<const NestedLoopJoinPlanNode &>(*optimized_plan);
+    // Has exactly two children
+    BUSTUB_ENSURE(nlj_plan.children_.size() == 2, "NLJ should have exactly 2 children.");
+    // Check if expr is equal condition where one is for the left table, and one is for the right table.
+    if (const auto *expr = dynamic_cast<const ComparisonExpression *>(&nlj_plan.Predicate()); expr != nullptr) {
+      if (expr->comp_type_ == ComparisonType::Equal) {
+        if (const auto *left_expr = dynamic_cast<const ColumnValueExpression *>(expr->children_[0].get());
+            left_expr != nullptr) {
+          if (const auto *right_expr = dynamic_cast<const ColumnValueExpression *>(expr->children_[1].get());
+              right_expr != nullptr) {
+            // Ensure both exprs have tuple_id == 0
+            auto left_expr_tuple_0 =
+                std::make_shared<ColumnValueExpression>(0, left_expr->GetColIdx(), left_expr->GetReturnType());
+            auto right_expr_tuple_0 =
+                std::make_shared<ColumnValueExpression>(0, right_expr->GetColIdx(), right_expr->GetReturnType());
+            // Now it's in form of <column_expr> = <column_expr>. Let's match an index for them.
+
+            // Ensure right child is table scan
+            if (nlj_plan.GetRightPlan()->GetType() == PlanType::SeqScan) {
+              const auto &right_seq_scan = dynamic_cast<const SeqScanPlanNode &>(*nlj_plan.GetRightPlan());
+              if (left_expr->GetTupleIdx() == 0 && right_expr->GetTupleIdx() == 1) {
+                if (auto index = MatchIndex(right_seq_scan.table_name_, right_expr->GetColIdx());
+                    index != std::nullopt) {
+                  auto [index_oid, index_name] = *index;
+                  return std::make_shared<NestedIndexJoinPlanNode>(
+                      nlj_plan.output_schema_, nlj_plan.GetLeftPlan(), std::move(left_expr_tuple_0),
+                      right_seq_scan.GetTableOid(), index_oid, std::move(index_name), right_seq_scan.table_name_,
+                      right_seq_scan.output_schema_);
+                }
+              }
+              if (left_expr->GetTupleIdx() == 1 && right_expr->GetTupleIdx() == 0) {
+                if (auto index = MatchIndex(right_seq_scan.table_name_, left_expr->GetColIdx());
+                    index != std::nullopt) {
+                  auto [index_oid, index_name] = *index;
+                  return std::make_shared<NestedIndexJoinPlanNode>(
+                      nlj_plan.output_schema_, nlj_plan.GetLeftPlan(), std::move(right_expr_tuple_0),
+                      right_seq_scan.GetTableOid(), index_oid, std::move(index_name), right_seq_scan.table_name_,
+                      right_seq_scan.output_schema_);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return optimized_plan;
+}
+
+}  // namespace bustub

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -6,9 +6,10 @@ namespace bustub {
 auto Optimizer::Optimize(const AbstractPlanNodeRef &plan) -> AbstractPlanNodeRef {
   auto p1 = OptimizeMergeProjection(plan);
   auto p2 = OptimizeMergeFilterNLJ(p1);
-  auto p3 = OptimizeNLJAsHashJoin(p2);
-  auto p4 = OptimizeOrderByAsIndexScan(p3);
-  return p4;
+  auto p3 = OptimizeNLJAsIndexJoin(p2);
+  auto p4 = OptimizeNLJAsHashJoin(p3);
+  auto p5 = OptimizeOrderByAsIndexScan(p4);
+  return p5;
 }
 
 }  // namespace bustub

--- a/src/planner/plan_table_ref.cpp
+++ b/src/planner/plan_table_ref.cpp
@@ -102,7 +102,7 @@ auto Planner::PlanBaseTableRef(const BoundBaseTableRef &table_ref) -> AbstractPl
   }
   // Otherwise, plan as normal SeqScan.
   return std::make_shared<SeqScanPlanNode>(std::make_shared<Schema>(SeqScanPlanNode::InferScanSchema(table_ref)),
-                                           nullptr, table->oid_);
+                                           table->oid_, table->name_);
 }
 
 auto Planner::PlanCrossProductRef(const BoundCrossProductRef &table_ref) -> AbstractPlanNodeRef {


### PR DESCRIPTION
```
bustub> create table t1(v1 int, v2 int);
Table created with id = 3
bustub> create table t2(v3 int, v4 int);
Table created with id = 4
bustub> create index t1v1 on t1(v1);
Index created with id = 0
bustub> explain select * from t2 inner join t1 on v1=v3;
=== BINDER ===
BoundExplain {
  statement=BoundSelect {
    table=BoundJoin { type=Join, left=BoundBaseTableRef { table=t2, oid=4 }, right=BoundBaseTableRef { table=t1, oid=3 }, condition=(t1.v1=t2.v3) },
    columns=[t2.v3, t2.v4, t1.v1, t1.v2],
    groupBy=[],
    having=,
    where=,
    limit=,
    offset=,
    order_by=[],
    is_distinct=false,
  },
}
=== PLANNER ===
Projection { exprs=[#0.0, #0.1, #0.2, #0.3] } | (t2.v3:INTEGER, t2.v4:INTEGER, t1.v1:INTEGER, t1.v2:INTEGER)
  NestedLoopJoin { predicate=#1.0=#0.0 } | (t2.v3:INTEGER, t2.v4:INTEGER, t1.v1:INTEGER, t1.v2:INTEGER)
    SeqScan { table=t2 } | (t2.v3:INTEGER, t2.v4:INTEGER)
    SeqScan { table=t1 } | (t1.v1:INTEGER, t1.v2:INTEGER)
=== OPTIMIZER ===
NestedIndexJoin { key_predicate=#0.0, index=t1v1, index_table=t1 } | (t2.v3:INTEGER, t2.v4:INTEGER, t1.v1:INTEGER, t1.v2:INTEGER)
  SeqScan { table=t2 } | (t2.v3:INTEGER, t2.v4:INTEGER)
bustub> 
```

We will match index and optimize NLJ into index join in the optimizer.

close https://github.com/cmu-db/bustub/issues/386