### PR TITLE
Update package.sh. On MacOS, If you already have other versions of git, no longer install via brew.

### DIFF
--- a/build_support/packages.sh
+++ b/build_support/packages.sh
@@ -79,7 +79,7 @@ install_mac() {
   brew ls --versions cmake || brew install cmake
   brew ls --versions coreutils || brew install coreutils
   brew ls --versions doxygen || brew install doxygen
-  brew ls --versions git || brew install git
+  git --version || brew install git
   (brew ls --versions llvm | grep 12) || brew install llvm@12
 }
 


### PR DESCRIPTION
If you already have other versions of git, no longer install via brew.
Most mac os systems have git pre-installed (apple git), I don't think installing git via brew is necessary. Should we use git --version to verify that git is already installed?
