### PR TITLE
feat(sqllogictest): support query statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # Includes.
 set(BUSTUB_SRC_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/src/include)
 set(BUSTUB_TEST_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/test/include)
-set(BUSTUB_THIRD_PARTY_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/third_party ${PROJECT_SOURCE_DIR}/third_party/fmt/include ${PROJECT_SOURCE_DIR}/third_party/libpg_query/include)
+set(BUSTUB_THIRD_PARTY_INCLUDE_DIR
+    ${PROJECT_SOURCE_DIR}/third_party
+    ${PROJECT_SOURCE_DIR}/third_party/fmt/include
+    ${PROJECT_SOURCE_DIR}/third_party/libpg_query/include
+    ${PROJECT_SOURCE_DIR}/third_party/argparse/include
+)
 
 include_directories(${BUSTUB_SRC_INCLUDE_DIR} ${BUSTUB_TEST_INCLUDE_DIR} ${BUSTUB_THIRD_PARTY_INCLUDE_DIR})
 include_directories(BEFORE src) # This is needed for gtest.

--- a/src/include/common/bustub_instance.h
+++ b/src/include/common/bustub_instance.h
@@ -56,17 +56,28 @@ class ResultWriter {
 
 class SimpleStreamWriter : public ResultWriter {
  public:
-  explicit SimpleStreamWriter(std::ostream &stream) : stream_(stream) {}
+  explicit SimpleStreamWriter(std::ostream &stream, bool disable_header = false)
+      : stream_(stream), disable_header_(disable_header) {}
   static auto BoldOn(std::ostream &os) -> std::ostream & { return os << "\e[1m"; }
   static auto BoldOff(std::ostream &os) -> std::ostream & { return os << "\e[0m"; }
-  void WriteCell(const std::string &cell) override { stream_ << BoldOn << cell << BoldOff << "\t"; }
-  void WriteHeaderCell(const std::string &cell) override { stream_ << cell << "\t"; }
+  void WriteCell(const std::string &cell) override { stream_ << cell << "\t"; }
+  void WriteHeaderCell(const std::string &cell) override {
+    if (!disable_header_) {
+      stream_ << BoldOn << cell << BoldOff << "\t";
+    }
+  }
   void BeginHeader() override {}
-  void EndHeader() override { stream_ << std::endl; }
+  void EndHeader() override {
+    if (!disable_header_) {
+      stream_ << std::endl;
+    }
+  }
   void BeginRow() override {}
   void EndRow() override { stream_ << std::endl; }
   void BeginTable(bool simplified_output) override {}
   void EndTable() override {}
+
+  bool disable_header_;
   std::ostream &stream_;
 };
 

--- a/src/include/common/bustub_instance.h
+++ b/src/include/common/bustub_instance.h
@@ -57,7 +57,7 @@ class ResultWriter {
 class SimpleStreamWriter : public ResultWriter {
  public:
   explicit SimpleStreamWriter(std::ostream &stream, bool disable_header = false)
-      : stream_(stream), disable_header_(disable_header) {}
+      : disable_header_(disable_header), stream_(stream) {}
   static auto BoldOn(std::ostream &os) -> std::ostream & { return os << "\e[1m"; }
   static auto BoldOff(std::ostream &os) -> std::ostream & { return os << "\e[0m"; }
   void WriteCell(const std::string &cell) override { stream_ << cell << "\t"; }

--- a/test/sql/baby_arithmetic.slt
+++ b/test/sql/baby_arithmetic.slt
@@ -1,29 +1,47 @@
-statement ok
+query
 select 1 + 2;
+----
+3
 
-statement ok
+query
 select 1 + 2 + 3;
+----
+6
 
-statement ok
+query
 select 1 - 2 + 5 - 10;
+----
+-6
 
-statement ok
+query
 select 1 + 2 + 3 + null;
+----
+integer_null
 
-statement ok
+query
 select 1 > 2 and 2 > 3;
+----
+false
 
-statement ok
+query
 select null > 2 and 2 > 3;
+----
+false
 
-statement ok
+query
 select null < 2 and 2 < 3;
+----
+boolean_null
 
-statement ok
+query
 select null > 2 or 2 > 3;
+----
+boolean_null
 
-statement ok
+query
 select null < 2 or 2 < 3;
+----
+true
 
 statement ok
 select colA + colB, colA, colB, colA - colB from __mock_table_1;

--- a/tools/sqllogictest/parser.cpp
+++ b/tools/sqllogictest/parser.cpp
@@ -96,6 +96,7 @@ auto ParseInner(const std::string &filename, const std::string &script) -> std::
         sql += "\n";
         line_iter++;
       }
+      StringUtil::RTrim(&sql);
       records.emplace_back(std::make_unique<StatementRecord>(loc, error, std::move(sql)));
       if (line_iter == lines.cend()) {
         break;
@@ -147,13 +148,16 @@ auto ParseInner(const std::string &filename, const std::string &script) -> std::
         if (line.empty()) {
           break;
         }
-        expected_result += line;
+        auto line_copied = line;
+        StringUtil::RTrim(&line_copied);
+        expected_result += line_copied;
         expected_result += "\n";
         line_iter++;
       }
       if (line_iter == lines.cend()) {
         throw bustub::Exception("unexpected end");
       }
+      StringUtil::RTrim(&sql);
       records.emplace_back(std::make_unique<QueryRecord>(loc, sort_mode, std::move(sql), std::move(expected_result)));
     }
     line_iter++;

--- a/tools/sqllogictest/parser.h
+++ b/tools/sqllogictest/parser.h
@@ -72,7 +72,7 @@ class StatementRecord : public Record {
       : Record{RecordType::STATEMENT, std::move(loc)}, is_error_(is_error), sql_(std::move(sql)){};
 
   auto ToString() const -> std::string override {
-    return fmt::format("Statement {{ is_error={}, sql={} }}", is_error_, sql_);
+    return fmt::format("Statement {{\nis_error={},\nsql={}\n}}", is_error_, sql_);
   }
 
   bool is_error_;

--- a/tools/sqllogictest/sqllogictest.cpp
+++ b/tools/sqllogictest/sqllogictest.cpp
@@ -1,19 +1,79 @@
 #include <fstream>
+#include <ios>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 
+#include "argparse/argparse.hpp"
 #include "common/bustub_instance.h"
 #include "common/exception.h"
+#include "common/util/string_util.h"
 #include "parser.h"
 
+auto SplitLines(const std::string &lines) -> std::vector<std::string> {
+  std::stringstream linestream(lines);
+  std::vector<std::string> result;
+  std::string line;
+  while (std::getline(linestream, line, '\n')) {
+    bustub::StringUtil::RTrim(&line);
+    if (!line.empty()) {
+      result.emplace_back(std::exchange(line, std::string{}));
+    }
+  }
+  return result;
+}
+
+auto ResultCompare(const std::string &produced_result, const std::string &expected_result, bustub::SortMode sort_mode,
+                   bool dump_diff) -> bool {
+  auto a_lines = SplitLines(produced_result);
+  auto b_lines = SplitLines(expected_result);
+  if (sort_mode == bustub::SortMode::ROWSORT) {
+    std::sort(a_lines.begin(), a_lines.end());
+    std::sort(b_lines.begin(), b_lines.end());
+  }
+  bool cmp_result = a_lines == b_lines;
+  if (!cmp_result && dump_diff) {
+    std::ofstream r("result.log", std::ios_base::out | std::ios_base::trunc);
+    if (!r) {
+      throw bustub::Exception("cannot open file");
+    }
+    for (const auto &x : a_lines) {
+      r << x << std::endl;
+    }
+    r.close();
+
+    std::ofstream e("expected.log", std::ios_base::out | std::ios_base::trunc);
+    if (!e) {
+      throw bustub::Exception("cannot open file");
+    }
+    for (const auto &x : b_lines) {
+      e << x << std::endl;
+    }
+    e.close();
+  }
+
+  return cmp_result;
+}
+
 auto main(int argc, char **argv) -> int {  // NOLINT
-  if (argc != 2) {
-    std::cerr << "Invalid number of args";
+  argparse::ArgumentParser program("bustub-sqllogictest");
+  program.add_argument("file").help("the sqllogictest file to run");
+  program.add_argument("--verbose").help("increase output verbosity").default_value(false).implicit_value(true);
+  program.add_argument("-d", "--diff").help("write diff file").default_value(false).implicit_value(true);
+
+  try {
+    program.parse_args(argc, argv);
+  } catch (const std::runtime_error &err) {
+    std::cerr << err.what() << std::endl;
+    std::cerr << program;
     return 1;
   }
-  std::string filename = argv[1];
+
+  bool verbose = program.get<bool>("verbose");
+  bool diff = program.get<bool>("diff");
+  std::string filename = program.get<std::string>("file");
   std::ifstream t(filename);
   std::string script((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
   t.close();
@@ -25,6 +85,9 @@ auto main(int argc, char **argv) -> int {  // NOLINT
 
   for (const auto &record : result) {
     fmt::print("{}\n", record->loc_);
+    if (verbose) {
+      fmt::print("{}\n", record->ToString());
+    }
     switch (record->type_) {
       case bustub::RecordType::HALT: {
         return 0;
@@ -40,17 +103,46 @@ auto main(int argc, char **argv) -> int {  // NOLINT
           std::stringstream result;
           auto writer = bustub::SimpleStreamWriter(result);
           bustub->ExecuteSql(statement.sql_, writer);
-          std::cout << result.str();
+          if (verbose) {
+            fmt::print("{}\n", result.str());
+          }
           if (statement.is_error_) {
-            std::cerr << "statement should error" << std::endl;
+            fmt::print("statement should error\n");
             return 1;
           }
         } catch (bustub::Exception &ex) {
-          std::cerr << ex.what() << std::endl;
           if (!statement.is_error_) {
-            std::cerr << "statement should not error" << std::endl;
+            fmt::print("unexpected error: {}", ex.what());
             return 1;
           }
+          if (verbose) {
+            fmt::print("statement errored with {}", ex.what());
+          }
+        }
+        continue;
+      }
+      case bustub::RecordType::QUERY: {
+        const auto &query = dynamic_cast<const bustub::QueryRecord &>(*record);
+        try {
+          std::stringstream result;
+          auto writer = bustub::SimpleStreamWriter(result, true);
+          bustub->ExecuteSql(query.sql_, writer);
+          if (verbose) {
+            fmt::print("{}\n", result.str());
+          }
+          if (!ResultCompare(result.str(), query.expected_result_, query.sort_mode_, diff)) {
+            if (diff) {
+              fmt::print("wrong result (with sort_mode={}) dumped to result.log and expected.log\n", query.sort_mode_);
+            } else {
+              fmt::print(
+                  "wrong result (with sort_mode={}), use `-d` to store your result and expected result in a file\n",
+                  query.sort_mode_);
+            }
+            return 1;
+          }
+        } catch (bustub::Exception &ex) {
+          fmt::print("unexpected error: {} \n", ex.what());
+          return 1;
         }
         continue;
       }


### PR DESCRIPTION
Example:

```
query
select 1 + 2;
----
3

query
select 1 + 2 + 3;
----
6

query
select 1 - 2 + 5 - 10;
----
-6

query
select 1 + 2 + 3 + null;
----
integer_null

query
select 1 > 2 and 2 > 3;
----
false

query
select null > 2 and 2 > 3;
----
false

query
select null < 2 and 2 < 3;
----
boolean_null

query
select null > 2 or 2 > 3;
----
boolean_null

query
select null < 2 or 2 < 3;
----
true

statement ok
select colA + colB, colA, colB, colA - colB from __mock_table_1;
```

close https://github.com/cmu-db/bustub/issues/343