### PR TITLE
fix(typo): remove incorrect unused tag

### DIFF
--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -154,7 +154,7 @@ class Index {
   /**
    * Insert an entry into the index.
    * @param key The index key
-   * @param rid The RID associated with the key (unused)
+   * @param rid The RID associated with the key
    * @param transaction The transaction context
    */
   virtual void InsertEntry(const Tuple &key, RID rid, Transaction *transaction) = 0;


### PR DESCRIPTION
Signed-off-by: El-even-11 <zhao_ziqian@sjtu.edu.cn>

Remove incorrect unused tag from `InsertEntry()` comments.
