### PR TITLE
fix(p4): potential race in lock manager

### DIFF
--- a/src/include/concurrency/lock_manager.h
+++ b/src/include/concurrency/lock_manager.h
@@ -300,12 +300,12 @@ class LockManager {
  private:
   /** Fall 2022 */
   /** Structure that holds lock requests for a given table oid */
-  std::unordered_map<table_oid_t, LockRequestQueue> table_lock_map_;
+  std::unordered_map<table_oid_t, std::shared_ptr<LockRequestQueue>> table_lock_map_;
   /** Coordination */
   std::mutex table_lock_map_latch_;
 
   /** Structure that holds lock requests for a given RID */
-  std::unordered_map<RID, LockRequestQueue> row_lock_map_;
+  std::unordered_map<RID, std::shared_ptr<LockRequestQueue>> row_lock_map_;
   /** Coordination */
   std::mutex row_lock_map_latch_;
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

The original starter code is implying that students can hold a reference to the unordered_map, which is wrong and might cause race condition.