### PR TITLE
fix(interface): modified ExtendibleHashTable::Insert() return type

### DIFF
--- a/src/container/hash/extendible_hash_table.cpp
+++ b/src/container/hash/extendible_hash_table.cpp
@@ -75,7 +75,7 @@ auto ExtendibleHashTable<K, V>::Remove(const K &key) -> bool {
 }
 
 template <typename K, typename V>
-void ExtendibleHashTable<K, V>::Insert(const K &key, const V &value) {
+auto ExtendibleHashTable<K, V>::Insert(const K &key, const V &value) -> bool {
   UNREACHABLE("not implemented");
 }
 

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -92,7 +92,7 @@ class ExtendibleHashTable : public HashTable<K, V> {
    * @param key The key to be inserted.
    * @param value The value to be inserted.
    */
-  void Insert(const K &key, const V &value) override;
+  auto Insert(const K &key, const V &value) -> bool override;
 
   /**
    *

--- a/src/include/container/hash/extendible_hash_table.h
+++ b/src/include/container/hash/extendible_hash_table.h
@@ -82,7 +82,7 @@ class ExtendibleHashTable : public HashTable<K, V> {
    * TODO(P1): Add implementation
    *
    * @brief Insert the given key-value pair into the hash table.
-   * If a key already exists, the value should be updated.
+   * If a key already exists, the value should be updated and return true.
    * If the bucket is full and can't be inserted, do the following steps before retrying:
    *    1. If the local depth of the bucket is equal to the global depth,
    *        increment the global depth and double the size of the directory.
@@ -91,6 +91,7 @@ class ExtendibleHashTable : public HashTable<K, V> {
    *
    * @param key The key to be inserted.
    * @param value The value to be inserted.
+   * @return True if the key is inserted, false otherwise.
    */
   auto Insert(const K &key, const V &value) -> bool override;
 

--- a/src/include/container/hash/hash_table.h
+++ b/src/include/container/hash/hash_table.h
@@ -27,7 +27,7 @@ class HashTable {
   // lookup and modifier
   virtual auto Find(const K &key, V &value) -> bool = 0;
   virtual auto Remove(const K &key) -> bool = 0;
-  virtual void Insert(const K &key, const V &value) = 0;
+  virtual auto Insert(const K &key, const V &value) -> bool = 0;
 };
 
 }  // namespace bustub


### PR DESCRIPTION
From CMU 15-445 2022 fall [Project Webpage](https://15445.courses.cs.cmu.edu/fall2022/project1/#buffer-pool-instance), `ExtendibleHash::Insert()` method need return a `bool` type instead of `void`.

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/55288101/204110339-2fdff240-928e-42e9-8def-84a56ae34f81.png">