### PR TITLE
fix(logging): LOG_LEVEL doesn't work

### DIFF
--- a/src/include/common/logger.h
+++ b/src/include/common/logger.h
@@ -54,13 +54,13 @@ static constexpr auto PastLastSlash(cstr a) -> cstr { return PastLastSlash(a, a)
   })
 
 // Log levels.
-static constexpr int LOG_LEVEL_OFF = 1000;
-static constexpr int LOG_LEVEL_ERROR = 500;
-static constexpr int LOG_LEVEL_WARN = 400;
-static constexpr int LOG_LEVEL_INFO = 300;
-static constexpr int LOG_LEVEL_DEBUG = 200;
-static constexpr int LOG_LEVEL_TRACE = 100;
-static constexpr int LOG_LEVEL_ALL = 0;
+#define LOG_LEVEL_OFF 1000
+#define LOG_LEVEL_ERROR 500
+#define LOG_LEVEL_WARN 400
+#define LOG_LEVEL_INFO 300
+#define LOG_LEVEL_DEBUG 200
+#define LOG_LEVEL_TRACE 100
+#define LOG_LEVEL_ALL 0
 
 #define LOG_LOG_TIME_FORMAT "%Y-%m-%d %H:%M:%S"
 #define LOG_OUTPUT_STREAM stdout
@@ -71,11 +71,11 @@ static constexpr int LOG_LEVEL_ALL = 0;
 // #pragma message("Warning: LOG_LEVEL compile option was not explicitly
 // given.")
 #ifndef NDEBUG
+#define LOG_LEVEL LOG_LEVEL_DEBUG
 // #pragma message("LOG_LEVEL_DEBUG is used instead as DEBUG option is on.")
-static constexpr int LOG_LEVEL = LOG_LEVEL_DEBUG;
 #else
 // #pragma message("LOG_LEVEL_WARN is used instead as DEBUG option is off.")
-static constexpr int LOG_LEVEL = LOG_LEVEL_INFO;
+#define LOG_LEVEL LOG_LEVEL_INFO
 #endif
 // #pragma message("Give LOG_LEVEL compile option to overwrite the default
 // level.")


### PR DESCRIPTION
The ` #if `  command only finds the macro definition. If it is not found, it defaults to 0. But ` LOG_LEVEL ` is a C++'s constexpr variable which the compiler will process after the ` #if ` command. So what ever the LOG_LEVEL is , the logger will print all log.
If you still want to use constexpr variable , maybe you should use the template technology instead of `#if`.
In my opinion, it is feasible and inexpensive to simply replace it with a macro definition.
Finally, a new function suggests that for concurrent programs, the log should carry the thread id, and users can simply control the format, log level filtering, or users prefer streaming output log, and so on. If you need, I can provide header-only one.