### PR TITLE
fix: do more appropriate space check when inserting a tuple

### DIFF
--- a/src/storage/page/table_page.cpp
+++ b/src/storage/page/table_page.cpp
@@ -39,7 +39,7 @@ auto TablePage::InsertTuple(const Tuple &tuple, RID *rid, Transaction *txn, Lock
                             LogManager *log_manager) -> bool {
   BUSTUB_ASSERT(tuple.size_ > 0, "Cannot have empty tuples.");
   // If there is not enough space, then return false.
-  if (GetFreeSpaceRemaining() < tuple.size_ + SIZE_TUPLE) {
+  if (GetFreeSpaceRemaining() < tuple.size_) {
     return false;
   }
 


### PR DESCRIPTION
When inserting a tuple, it will try to find a free slot to reuse, so the space checks at the beginning of the method should not consider the space of the slot. The check of the slot space will be done after the reuse fails.