### PR TITLE
fix: change the dereference of IndexIterator from return-by-reference…

### DIFF
--- a/src/include/storage/index/index_iterator.h
+++ b/src/include/storage/index/index_iterator.h
@@ -28,7 +28,7 @@ class IndexIterator {
 
   auto IsEnd() -> bool;
 
-  auto operator*() -> const MappingType &;
+  auto operator*() -> MappingType;
 
   auto operator++() -> IndexIterator &;
 

--- a/src/storage/index/index_iterator.cpp
+++ b/src/storage/index/index_iterator.cpp
@@ -21,7 +21,7 @@ INDEX_TEMPLATE_ARGUMENTS
 auto INDEXITERATOR_TYPE::IsEnd() -> bool { throw std::runtime_error("unimplemented"); }
 
 INDEX_TEMPLATE_ARGUMENTS
-auto INDEXITERATOR_TYPE::operator*() -> const MappingType & { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::operator*() -> MappingType { throw std::runtime_error("unimplemented"); }
 
 INDEX_TEMPLATE_ARGUMENTS
 auto INDEXITERATOR_TYPE::operator++() -> INDEXITERATOR_TYPE & { throw std::runtime_error("unimplemented"); }


### PR DESCRIPTION
In the multi-threaded case, if a reference is returned without a lock, it may not be safe to read.