### PR TITLE
chore: sleep verify thread in release mode

### DIFF
--- a/test/concurrency/deadlock_detection_test.cpp
+++ b/test/concurrency/deadlock_detection_test.cpp
@@ -16,7 +16,6 @@ TEST(LockManagerDeadlockDetectionTest, DISABLED_EdgeTest) {
   LockManager lock_mgr{};
   TransactionManager txn_mgr{&lock_mgr};
   lock_mgr.txn_manager_ = &txn_mgr;
-  lock_mgr.StartDeadlockDetection();
 
   const int num_nodes = 100;
   const int num_edges = num_nodes / 2;

--- a/tools/terrier_bench/terrier.cpp
+++ b/tools/terrier_bench/terrier.cpp
@@ -499,6 +499,14 @@ auto main(int argc, char **argv) -> int {
       bustub->ExecuteSqlTxn(sql, writer, txn);
       cnt += std::stoi(ss.str());
     }
+
+    {
+      auto writer = bustub::SimpleStreamWriter(std::cout, true);
+      auto sql = "SELECT count(*) FROM nft WHERE terrier = 0";
+      std::cout << "SELECT count(*) FROM nft WHERE terrier = 0: ";
+      bustub->ExecuteSqlTxn(sql, writer, txn);
+    }
+
     bustub->txn_manager_->Commit(txn);
     delete txn;
     if (cnt != bustub_nft_num) {

--- a/tools/terrier_bench/terrier.cpp
+++ b/tools/terrier_bench/terrier.cpp
@@ -462,6 +462,11 @@ auto main(int argc, char **argv) -> int {
       delete txn;
 
       metrics.Report();
+
+      if (bustub_nft_num > 1000) {
+        // if NFT num is large, sleep this thread to avoid lock contention
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+      }
     }
 
     total_metrics.ReportVerify(metrics.aborted_txn_cnt_, metrics.committed_txn_cnt_);


### PR DESCRIPTION
Otherwise all rows will be locked and it's hard to optimize.