### PR TITLE
style: rename child -> child_executor to keep consistency

### DIFF
--- a/src/execution/aggregation_executor.cpp
+++ b/src/execution/aggregation_executor.cpp
@@ -17,13 +17,13 @@
 namespace bustub {
 
 AggregationExecutor::AggregationExecutor(ExecutorContext *exec_ctx, const AggregationPlanNode *plan,
-                                         std::unique_ptr<AbstractExecutor> &&child)
+                                         std::unique_ptr<AbstractExecutor> &&child_executor)
     : AbstractExecutor(exec_ctx) {}
 
 void AggregationExecutor::Init() {}
 
 auto AggregationExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
 
-auto AggregationExecutor::GetChildExecutor() const -> const AbstractExecutor * { return child_.get(); }
+auto AggregationExecutor::GetChildExecutor() const -> const AbstractExecutor * { return child_executor_.get(); }
 
 }  // namespace bustub

--- a/src/include/execution/executors/aggregation_executor.h
+++ b/src/include/execution/executors/aggregation_executor.h
@@ -157,7 +157,7 @@ class AggregationExecutor : public AbstractExecutor {
    * @param child_executor The child executor from which inserted tuples are pulled (may be `nullptr`)
    */
   AggregationExecutor(ExecutorContext *exec_ctx, const AggregationPlanNode *plan,
-                      std::unique_ptr<AbstractExecutor> &&child);
+                      std::unique_ptr<AbstractExecutor> &&child_executor);
 
   /** Initialize the aggregation */
   void Init() override;
@@ -199,7 +199,7 @@ class AggregationExecutor : public AbstractExecutor {
   /** The aggregation plan node */
   const AggregationPlanNode *plan_;
   /** The child executor that produces tuples over which the aggregation is computed */
-  std::unique_ptr<AbstractExecutor> child_;
+  std::unique_ptr<AbstractExecutor> child_executor_;
   /** Simple aggregation hash table */
   // TODO(Student): Uncomment SimpleAggregationHashTable aht_;
   /** Simple aggregation hash table iterator */


### PR DESCRIPTION
In the AggregationExecutor class, rename child to child_executor for better consistency with the comments and other executors.