### PR TITLE
feat: Add a private ctor in TableHeap to avoid nullptr table when running binder tests

### DIFF
--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -132,11 +132,13 @@ class Catalog {
     // Construct the table heap
     std::unique_ptr<TableHeap> table = nullptr;
 
-    // TODO(Wan,chi): This should be refactored into a private ctor for the binder tests, we shouldn't allow nullptr.
     // When create_table_heap == false, it means that we're running binder tests (where no txn will be provided) or
     // we are running shell without buffer pool. We don't need to create TableHeap in this case.
     if (create_table_heap) {
       table = std::make_unique<TableHeap>(bpm_);
+    } else {
+      // Otherwise, create an empty heap only for binder tests
+      table = TableHeap::CreateEmptyHeap(create_table_heap);
     }
 
     // Fetch the table OID for the new table

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -62,7 +62,7 @@ class PlannerContext {
 
   /**
    * In the second phase of aggregation planning, we plan agg calls from `aggregations_`, and generate
-   * an aggregation plan node. The expressions in thie vector should be used over the output from the
+   * an aggregation plan node. The expressions in the vector should be used over the output from the
    * aggregation plan node.
    */
   std::vector<AbstractExpressionRef> expr_in_agg_;

--- a/src/include/storage/table/table_heap.h
+++ b/src/include/storage/table/table_heap.h
@@ -92,7 +92,17 @@ class TableHeap {
    */
   void UpdateTupleInPlaceUnsafe(const TupleMeta &meta, const Tuple &tuple, RID rid);
 
+  /** For binder tests */
+  static auto CreateEmptyHeap(bool create_table_heap = false) -> std::unique_ptr<TableHeap> {
+    // The input parameter should be false in order to generate a empty heap
+    assert(!create_table_heap);
+    return std::unique_ptr<TableHeap>(new TableHeap(create_table_heap));
+  }
+
  private:
+  /** Used for binder tests */
+  explicit TableHeap(bool create_table_heap = false);
+
   BufferPoolManager *bpm_;
   page_id_t first_page_id_{INVALID_PAGE_ID};
 

--- a/src/include/storage/table/table_heap.h
+++ b/src/include/storage/table/table_heap.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>  // NOLINT
 #include <optional>
 #include <utility>

--- a/src/storage/table/table_heap.cpp
+++ b/src/storage/table/table_heap.cpp
@@ -36,6 +36,8 @@ TableHeap::TableHeap(BufferPoolManager *bpm) : bpm_(bpm) {
   first_page->Init();
 }
 
+TableHeap::TableHeap(bool create_table_heap) : bpm_(nullptr) {}
+
 auto TableHeap::InsertTuple(const TupleMeta &meta, const Tuple &tuple, LockManager *lock_mgr, Transaction *txn,
                             table_oid_t oid) -> std::optional<RID> {
   std::unique_lock<std::mutex> guard(latch_);


### PR DESCRIPTION
To mention, the private ctor will initialize the underlying `bpm_` to `nullptr`, and left the `page_id` to be `INVALID_PAGE_ID`
