### PR TITLE
Feat: improve the interactivity of the b_plus_tree_printer

### DIFF
--- a/tools/b_plus_tree_printer/b_plus_tree_printer.cpp
+++ b/tools/b_plus_tree_printer/b_plus_tree_printer.cpp
@@ -123,6 +123,15 @@ auto main(int argc, char **argv) -> int {
         std::cin >> filename;
         tree.Draw(bpm, filename);
         break;
+
+      case 's':
+        //std::cin >> filename;
+        tree.Draw(bpm, filename);
+        filename="my-tree.dot";
+        system((std::string("dot -Tpng -O ")+filename).c_str());
+        system((std::string("open -a preview ./")+filename+std::string(".png")).c_str());
+        break;
+
       case '?':
         std::cout << UsageMessage();
         break;

--- a/tools/b_plus_tree_printer/b_plus_tree_printer.cpp
+++ b/tools/b_plus_tree_printer/b_plus_tree_printer.cpp
@@ -40,6 +40,7 @@ auto UsageMessage() -> std::string {
       "\tg <filename>.dot  -- Output the tree in graph format to a dot file\n"
       "\tp -- Print the B+ tree.\n"
       "\tq -- Quit. (Or use Ctl-D.)\n"
+      "\ts -- Save and visualize the tree(macos).\n"
       "\t? -- Print this help message.\n\n"
       "Please Enter Leaf node max size and Internal node max size:\n"
       "Example: 5 5\n"


### PR DESCRIPTION
This PR(for macos)aims at improving the interactivity of the b_plus_tree_printer running on our local machine. At present, every time we want to show our result of a bpt, we need to use the command `g my-tree.dot`, then type `dot -Tpng -O my-tree.dot` in another terminal. Finally, we should open/refresh the PNG image to show the results. It wastes a lot of time if we want to examine our implementation step by step. 

This PR adds a new command 's' in the b_plus_tree_printer.cpp. After typing 's', the tree will be stored and converted to the png file. Then the tree image will be open/refresh on the screen. We can split the image to the right side of the screen and print step by step.
<img width="1280" alt="p2" src="https://github.com/cmu-db/bustub/assets/55371663/1fcbac4f-10ad-4433-b0c8-506c6a8df497">
<img width="1280" alt="p3" src="https://github.com/cmu-db/bustub/assets/55371663/a0d363ff-baaa-424a-bf9c-23e7eaa5d456">
