### PR TITLE
p1: use owned promise for disk scheduler

### DIFF
--- a/src/include/storage/disk/disk_scheduler.h
+++ b/src/include/storage/disk/disk_scheduler.h
@@ -39,7 +39,7 @@ struct DiskRequest {
   page_id_t page_id_;
 
   /** Callback used to signal to the request issuer when the request has been completed. */
-  std::promise<bool> &callback_;
+  std::promise<bool> callback_;
 };
 
 /**

--- a/test/storage/disk_scheduler_test.cpp
+++ b/test/storage/disk_scheduler_test.cpp
@@ -38,8 +38,8 @@ TEST(DiskSchedulerTest, DISABLED_ScheduleWriteReadPageTest) {
   auto promise2 = disk_scheduler->CreatePromise();
   auto future2 = promise2.get_future();
 
-  disk_scheduler->Schedule({/*is_write=*/true, reinterpret_cast<char *>(&data), /*page_id=*/0, promise1});
-  disk_scheduler->Schedule({/*is_write=*/false, reinterpret_cast<char *>(&buf), /*page_id=*/0, promise2});
+  disk_scheduler->Schedule({/*is_write=*/true, reinterpret_cast<char *>(&data), /*page_id=*/0, std::move(promise1)});
+  disk_scheduler->Schedule({/*is_write=*/false, reinterpret_cast<char *>(&buf), /*page_id=*/0, std::move(promise2)});
 
   ASSERT_TRUE(future1.get());
   ASSERT_TRUE(future2.get());


### PR DESCRIPTION
after a second thought it would be a better idea to pass the promise with ownership