### PR TITLE
feat: Add support to `module 'sre_compile' is deprecated`

### DIFF
--- a/build_support/cpplint.py
+++ b/build_support/cpplint.py
@@ -49,7 +49,6 @@ import itertools
 import math  # for log
 import os
 import re
-import sre_compile
 import string
 import sys
 import sysconfig
@@ -800,7 +799,7 @@ def Match(pattern, s):
   # performance reasons; factoring it out into a separate function turns out
   # to be noticeably expensive.
   if pattern not in _regexp_compile_cache:
-    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+    _regexp_compile_cache[pattern] = re._compiler.compile(pattern)
   return _regexp_compile_cache[pattern].match(s)
 
 
@@ -818,14 +817,14 @@ def ReplaceAll(pattern, rep, s):
     string with replacements made (or original string if no replacements)
   """
   if pattern not in _regexp_compile_cache:
-    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+    _regexp_compile_cache[pattern] = re._compiler.compile(pattern)
   return _regexp_compile_cache[pattern].sub(rep, s)
 
 
 def Search(pattern, s):
   """Searches the string for the pattern, caching the compiled regexp."""
   if pattern not in _regexp_compile_cache:
-    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+    _regexp_compile_cache[pattern] = re._compiler.compile(pattern)
   return _regexp_compile_cache[pattern].search(s)
 
 


### PR DESCRIPTION
when I run `make check-lint`, I got
```
build_support/cpplint.py:52: DeprecationWarning: module 'sre_compile' is deprecated
import sre_compile
```
this python module has been deprecated

## fix bug
sre_* modules like `sre_constants`, `sre_compile`, and `sre_parse` were deprecated in [3.11](https://github.com/python/cpython/commit/1be3260a90f16aae334d993aecf7b70426f98013)

I use `re._compiler` instead, and it works!

### reference
https://github.com/python/cpython/issues/105456