### PR TITLE
p4: misc fixes for tests

### DIFF
--- a/src/common/bustub_instance.cpp
+++ b/src/common/bustub_instance.cpp
@@ -45,7 +45,7 @@ auto BustubInstance::MakeExecutorContext(Transaction *txn, bool is_modify) -> st
                                            lock_manager_.get(), is_modify);
 }
 
-BustubInstance::BustubInstance(const std::string &db_file_name) {
+BustubInstance::BustubInstance(const std::string &db_file_name, size_t bpm_size) {
   enable_logging = false;
 
   // Storage related.
@@ -60,7 +60,7 @@ BustubInstance::BustubInstance(const std::string &db_file_name) {
   // buffer pool size specified in `config.h`.
   try {
     buffer_pool_manager_ =
-        std::make_unique<BufferPoolManager>(128, disk_manager_.get(), LRUK_REPLACER_K, log_manager_.get());
+        std::make_unique<BufferPoolManager>(bpm_size, disk_manager_.get(), LRUK_REPLACER_K, log_manager_.get());
   } catch (NotImplementedException &e) {
     std::cerr << "BufferPoolManager is not implemented, only mock tables are supported." << std::endl;
     buffer_pool_manager_ = nullptr;
@@ -98,7 +98,7 @@ BustubInstance::BustubInstance(const std::string &db_file_name) {
   execution_engine_ = std::make_unique<ExecutionEngine>(buffer_pool_manager_.get(), txn_manager_.get(), catalog_.get());
 }
 
-BustubInstance::BustubInstance() {
+BustubInstance::BustubInstance(size_t bpm_size) {
   enable_logging = false;
 
   // Storage related.
@@ -113,7 +113,7 @@ BustubInstance::BustubInstance() {
   // buffer pool size specified in `config.h`.
   try {
     buffer_pool_manager_ =
-        std::make_unique<BufferPoolManager>(128, disk_manager_.get(), LRUK_REPLACER_K, log_manager_.get());
+        std::make_unique<BufferPoolManager>(bpm_size, disk_manager_.get(), LRUK_REPLACER_K, log_manager_.get());
   } catch (NotImplementedException &e) {
     std::cerr << "BufferPoolManager is not implemented, only mock tables are supported." << std::endl;
     buffer_pool_manager_ = nullptr;

--- a/src/include/common/bustub_instance.h
+++ b/src/include/common/bustub_instance.h
@@ -243,7 +243,7 @@ class BustubInstance {
  public:
   explicit BustubInstance(const std::string &db_file_name, size_t bpm_size = 128);
 
-  BustubInstance(size_t bpm_size = 128);
+  explicit BustubInstance(size_t bpm_size = 128);
 
   ~BustubInstance();
 

--- a/src/include/common/bustub_instance.h
+++ b/src/include/common/bustub_instance.h
@@ -241,9 +241,9 @@ class BustubInstance {
   auto MakeExecutorContext(Transaction *txn, bool is_modify) -> std::unique_ptr<ExecutorContext>;
 
  public:
-  explicit BustubInstance(const std::string &db_file_name);
+  explicit BustubInstance(const std::string &db_file_name, size_t bpm_size = 128);
 
-  BustubInstance();
+  BustubInstance(size_t bpm_size = 128);
 
   ~BustubInstance();
 

--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -158,6 +158,13 @@ class Transaction {
     return undo_logs_.size();
   }
 
+  /** Use this function in leaderboard benchmarks for online garbage collection. For stop-the-world GC, simply remove
+   * the txn from the txn_map. */
+  inline auto ClearUndoLog() -> size_t {
+    std::scoped_lock<std::mutex> lck(latch_);
+    return undo_logs_.size();
+  }
+
   void SetTainted();
 
  private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,6 @@ foreach (bustub_test_source ${BUSTUB_TEST_SOURCES})
 
     gtest_discover_tests(${bustub_test_name}
             EXTRA_ARGS
-            --gtest_color=auto
             --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${bustub_test_name}.xml
             --gtest_catch_exceptions=0
             DISCOVERY_TIMEOUT 120

--- a/test/txn/txn_common.h
+++ b/test/txn/txn_common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <src/gtest-internal-inl.h>
 #include <algorithm>
 #include <chrono>  // NOLINT
 #include <cstdio>
@@ -51,6 +52,30 @@ auto BoolNull() -> Value { return ValueFactory::GetNullValueByType(TypeId::BOOLE
 
 auto CompareValue(const Value &v1, const Value &v2) -> bool {
   return v1.CompareEquals(v2) == CmpBool::CmpTrue || (v1.IsNull() && v2.IsNull());
+}
+
+auto StatusSuccess(const std::string &str) -> std::string {
+  static const bool use_color = testing::internal::ShouldUseColor(true);
+  if (use_color) {
+    return "\033[0;32m" + str + "\033[0m";
+  }
+  return str;
+}
+
+auto StatusFail(const std::string &str) -> std::string {
+  static const bool use_color = testing::internal::ShouldUseColor(true);
+  if (use_color) {
+    return "\033[0;31m" + str + "\033[0m";
+  }
+  return str;
+}
+
+auto Header(const std::string &str) -> std::string {
+  static const bool use_color = testing::internal::ShouldUseColor(true);
+  if (use_color) {
+    return "\033[1m" + str + "\033[0m";
+  }
+  return str;
 }
 
 void VerifyTuple(const Schema *schema, const Tuple &tuple, const std::vector<Value> &values) {
@@ -114,22 +139,23 @@ auto ExpectResult(const std::vector<std::vector<std::string>> &actual_result,
     auto actual_result_str = ResultVecToString(actual_result);
     if (show_result) {
       if (!newline) {
-        fmt::println(stderr, "-- error :(");
+        fmt::println(stderr, "{}", StatusFail("-- error :("));
       }
-      fmt::print(stderr, "ERROR: result mismatch\n--- EXPECTED ---\n{}\n\n--- ACTUAL ---\n{}\n\n", expected_result_str,
-                 actual_result_str);
+      fmt::print(stderr, "{} result mismatch\n--- EXPECTED ---\n{}\n\n--- ACTUAL ---\n{}\n\n", StatusFail("ERROR:"),
+                 expected_result_str, actual_result_str);
     } else {
       if (!newline) {
-        fmt::println(stderr, "-- error :(");
+        fmt::println(stderr, "{}", StatusFail("-- error :("));
       }
-      fmt::print(stderr, "ERROR: result mismatch\n--- EXPECTED ---\n<hidden>\n\n--- ACTUAL ---\n{}\n\n",
-                 actual_result_str);
+      fmt::print(stderr, "{} result mismatch\n--- EXPECTED ---\n<hidden>\n\n--- ACTUAL ---\n{}\n\n",
+                 StatusFail("ERROR:"), actual_result_str);
     }
   } else {
     if (!newline) {
-      fmt::print(stderr, "-");
+      fmt::println(stderr, "{}", StatusSuccess("-- pass check :)"));
+    } else {
+      fmt::println(stderr, "{}", StatusSuccess("- pass check :)"));
     }
-    fmt::print(stderr, "- pass check :)\n");
   }
   return actual_result_rows == expected_result_rows;
 }
@@ -139,7 +165,7 @@ void Query(BustubInstance &instance, const std::string &txn_var_name, Transactio
            const std::vector<std::vector<T>> &expected_rows, bool show_result) {
   std::stringstream ss;
   auto writer = bustub::StringVectorWriter();
-  fmt::print(stderr, "- query var={} id={} status={} read_ts={} query=\"{}\" ", txn_var_name,
+  fmt::print(stderr, "- {} var={} id={} status={} read_ts={} query=\"{}\" ", Header("query"), txn_var_name,
              txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs(), query);
   if (txn->GetTransactionState() != TransactionState::RUNNING) {
     fmt::println(stderr, "txn not running");
@@ -167,18 +193,21 @@ void QueryShowResult(BustubInstance &instance, const std::string &txn_var_name, 
 }
 
 void CheckUndoLogNum(BustubInstance &instance, const std::string &txn_var_name, Transaction *txn, size_t expected_num) {
-  fmt::println(stderr, "- check_undo_log var={} id={} status={} read_ts={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={}", Header("check_undo_log"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs());
   auto undo_log_num = txn->GetUndoLogNum();
   if (undo_log_num != expected_num) {
     fmt::println(stderr, "Error: expected to have {} undo logs in txn, found {}", expected_num, undo_log_num);
+    std::cerr << "hint: please refer to the writeup delete and update section. one transaction holds at most one undo "
+                 "log for a tuple. newly-inserted tuple does not need to have an undo log."
+              << std::endl;
     std::terminate();
   }
 }
 
 void CheckUndoLogColumn(BustubInstance &instance, const std::string &txn_var_name, Transaction *txn,
                         size_t expected_columns) {
-  fmt::println(stderr, "- check_undo_log var={} id={} status={} read_ts={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={}", Header("check_undo_log"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs());
   auto undo_log_num = txn->GetUndoLogNum();
   if (undo_log_num != 1) {
@@ -191,6 +220,9 @@ void CheckUndoLogColumn(BustubInstance &instance, const std::string &txn_var_nam
   if (cnt != expected_columns) {
     fmt::println(stderr, "Error: expected undo log to have {} columns, found {} (modified_fields=[{}])",
                  expected_columns, cnt, fmt::join(undo_log.modified_fields_, ","));
+    std::cerr << "hint: please refer to the writeup delete and update section. you should generate a partial tuple, "
+                 "keep adding things to the tuple when updating, and never remove things from it."
+              << std::endl;
     std::terminate();
   }
 }
@@ -204,7 +236,7 @@ void CheckUndoLogColumn(BustubInstance &instance, const std::string &txn_var_nam
 
 void Execute(BustubInstance &instance, const std::string &query, bool log = true) {
   if (log) {
-    fmt::println(stderr, "- execute sql=\"{}\"", query);
+    fmt::println(stderr, "- {} sql=\"{}\"", Header("execute"), query);
   }
   NoopWriter writer;
   if (!instance.ExecuteSql(query, writer)) {
@@ -229,13 +261,17 @@ void TableHeapEntryNoMoreThan(BustubInstance &instance, TableInfo *table_info, s
   auto cnt = TableHeapEntry(instance, table_info);
   if (cnt > upper_limit) {
     fmt::println(stderr, " -- error: expect table heap to contain at most {} elements, found {}", upper_limit, cnt);
+    std::cerr
+        << "hint: this is likely because you did not maintain the version chain correctly. you might have "
+           "implemented your update as delete + insert, so that a new tuple is created every time a tuple gets updated."
+        << std::endl;
     std::terminate();
   }
   fmt::println(stderr, "");
 }
 
 void ExecuteTxn(BustubInstance &instance, const std::string &txn_var_name, Transaction *txn, const std::string &query) {
-  fmt::println(stderr, "- execute var={} id={} status={} read_ts={} sql=\"{}\"", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={} sql=\"{}\"", Header("execute"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs(), query);
   if (txn->GetTransactionState() != TransactionState::RUNNING) {
     fmt::println(stderr, "txn not running");
@@ -251,7 +287,7 @@ void ExecuteTxn(BustubInstance &instance, const std::string &txn_var_name, Trans
 auto BeginTxn(BustubInstance &instance, const std::string &txn_var_name,
               IsolationLevel iso_lvl = IsolationLevel::SNAPSHOT_ISOLATION) -> Transaction * {
   auto txn = instance.txn_manager_->Begin(iso_lvl);
-  fmt::println(stderr, "- txn_begin var={} id={} status={} read_ts={} iso_lvl={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={} iso_lvl={}", Header("txn_begin"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs(),
                txn->GetIsolationLevel());
   return txn;
@@ -278,21 +314,21 @@ auto CommitTxn(BustubInstance &instance, const std::string &txn_var_name, Transa
       fmt::println(stderr, "should set to committed state var={} id={}", txn_var_name, txn->GetTransactionId());
       std::terminate();
     }
-    fmt::println(stderr, "- txn_commit var={} id={} status={} read_ts={} commit_ts={}", txn_var_name,
+    fmt::println(stderr, "- {} var={} id={} status={} read_ts={} commit_ts={}", Header("txn_commit"), txn_var_name,
                  txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs(),
                  txn->GetCommitTs());
     return;
   }
   if (res) {
-    fmt::println(stderr, "expect txn fail to commit, but committed: var={} id={}", txn_var_name,
-                 txn->GetTransactionId());
+    fmt::println(stderr, "{} expect txn fail to commit, but committed: var={} id={}", StatusFail("ERROR:"),
+                 txn_var_name, txn->GetTransactionId());
     std::terminate();
   }
   if (txn->GetTransactionState() != TransactionState::ABORTED) {
     fmt::println(stderr, "should set to aborted state var={} id={}", txn_var_name, txn->GetTransactionId());
     std::terminate();
   }
-  fmt::println(stderr, "- txn_commit_fail var={} id={} status={} read_ts={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={}", Header("txn_commit_fail"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs());
 }
 
@@ -307,7 +343,7 @@ auto AbortTxn(BustubInstance &instance, const std::string &txn_var_name, Transac
     fmt::println(stderr, "should set to aborted state var={} id={}", txn_var_name, txn->GetTransactionId());
     std::terminate();
   }
-  fmt::println(stderr, "- txn_abort var={} id={} status={} read_ts={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={}", Header("txn_abort"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs());
 }
 
@@ -316,7 +352,7 @@ auto CheckTainted(BustubInstance &instance, const std::string &txn_var_name, Tra
     fmt::println(stderr, "should set to tainted state var={} id={}", txn_var_name, txn->GetTransactionId());
     std::terminate();
   }
-  fmt::println(stderr, "- txn_tainted var={} id={} status={} read_ts={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={}", Header("txn_tainted"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs());
 }
 
@@ -329,30 +365,32 @@ auto CommitTaintedTxn(BustubInstance &instance, const std::string &txn_var_name,
     fmt::println(stderr, "should set to tainted state var={} id={}", txn_var_name, txn->GetTransactionId());
     std::terminate();
   }
-  fmt::println(stderr, "- txn_committed_tainted var={} id={} status={} read_ts={}", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={}", Header("txn_committed_tainted"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs());
 }
 
 void ExecuteTxnTainted(BustubInstance &instance, const std::string &txn_var_name, Transaction *txn,
                        const std::string &query) {
-  fmt::println(stderr, "- execute var={} id={} status={} read_ts={} sql=\"{}\"", txn_var_name,
+  fmt::println(stderr, "- {} var={} id={} status={} read_ts={} sql=\"{}\"", Header("execute"), txn_var_name,
                txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs(), query);
   NoopWriter writer;
   if (instance.ExecuteSqlTxn(query, writer, txn)) {
     std::cerr << "sql should not execute successfully -- there should be a write-write conflict" << std::endl;
+    std::cerr << "hint: if you want to taint a txn, you should both SetTainted + throw ExecutionException."
+              << std::endl;
     std::terminate();
   }
   CheckTainted(instance, txn_var_name, txn);
 }
 
 void GarbageCollection(BustubInstance &instance) {
-  fmt::println(stderr, "- garbage_collection");
+  fmt::println(stderr, "- {}", Header("garbage_collection"));
   instance.txn_manager_->GarbageCollection();
 }
 
 void EnsureTxnGCed(BustubInstance &instance, const std::string &txn_var_name, txn_id_t txn_id) {
-  fmt::println(stderr, "- ensure_txn_gc_ed var={} id={} watermark={}", txn_var_name, txn_id ^ TXN_START_ID,
-               instance.txn_manager_->GetWatermark());
+  fmt::println(stderr, "- {} var={} id={} watermark={}", Header("ensure_txn_gc_ed"), txn_var_name,
+               txn_id ^ TXN_START_ID, instance.txn_manager_->GetWatermark());
   const auto &txn_map = instance.txn_manager_->txn_map_;
   if (txn_map.find(txn_id) != txn_map.end()) {
     std::cerr << "txn not garbage collected" << std::endl;
@@ -361,8 +399,8 @@ void EnsureTxnGCed(BustubInstance &instance, const std::string &txn_var_name, tx
 }
 
 void EnsureTxnExists(BustubInstance &instance, const std::string &txn_var_name, txn_id_t txn_id) {
-  fmt::println(stderr, "- ensure_txn_exists var={} id={} watermark={}", txn_var_name, txn_id ^ TXN_START_ID,
-               instance.txn_manager_->GetWatermark());
+  fmt::println(stderr, "- {} var={} id={} watermark={}", Header("ensure_txn_exists"), txn_var_name,
+               txn_id ^ TXN_START_ID, instance.txn_manager_->GetWatermark());
   const auto &txn_map = instance.txn_manager_->txn_map_;
   if (txn_map.find(txn_id) == txn_map.end()) {
     std::cerr << "txn not exist" << std::endl;
@@ -377,7 +415,7 @@ void BumpCommitTs(BustubInstance &instance, int by = 1) {
     instance.txn_manager_->Commit(txn);
   }
   auto after_commit_ts = instance.txn_manager_->last_commit_ts_.load();
-  fmt::println(stderr, "- bump_commit_ts from={} to={} watermark={}", before_commit_ts, after_commit_ts,
+  fmt::println(stderr, "- {} from={} to={} watermark={}", Header("bump_commit_ts"), before_commit_ts, after_commit_ts,
                instance.txn_manager_->GetWatermark());
 }
 
@@ -400,7 +438,7 @@ void EnsureIndexScan(BustubInstance &instance) {
     auto *txn = instance.txn_manager_->Begin();
     res = instance.ExecuteSqlTxn("EXPLAIN SELECT * FROM pk_test_table_n WHERE pk = 1", writer_ss, txn);
     if (!StringUtil::Contains(ss.str(), "IndexScan")) {
-      fmt::println("index scan not found in plan:\n{}\n", ss.str());
+      fmt::println(stderr, "{} index scan not found in plan:\n{}\n", StatusFail("ERROR:"), ss.str());
       std::terminate();
     }
   }
@@ -413,7 +451,7 @@ void QueryIndex(BustubInstance &instance, const std::string &txn_var_name, Trans
                 const std::string &pk_column, const std::vector<T> &expected_pk,
                 const std::vector<std::vector<T>> &expected_rows) {
   assert(expected_pk.size() == expected_rows.size());
-  fmt::print(stderr, "- query_index var={} id={} status={} read_ts={} query=\"{}\" pk={}", txn_var_name,
+  fmt::print(stderr, "- {} var={} id={} status={} read_ts={} query=\"{}\" pk={}", Header("query_index"), txn_var_name,
              txn->GetTransactionIdHumanReadable(), txn->GetTransactionState(), txn->GetReadTs(), query,
              fmt::join(expected_pk, ","));
   if (txn->GetTransactionState() != TransactionState::RUNNING) {
@@ -424,29 +462,29 @@ void QueryIndex(BustubInstance &instance, const std::string &txn_var_name, Trans
     StringVectorWriter writer;
     auto res = instance.ExecuteSqlTxn(fmt::format("{} WHERE {} = {}", query, pk_column, expected_pk[i]), writer, txn);
     if (!res) {
-      fmt::println("failed to execute query when {} = {}", pk_column, expected_pk[i]);
+      fmt::println(stderr, "{} failed to execute query when {} = {}", StatusFail("ERROR:"), pk_column, expected_pk[i]);
       std::terminate();
     }
     if (expected_rows[i].empty()) {
       if (!writer.values_.empty()) {
-        fmt::println("ERROR: expect {} = {} to have 0 rows, found ({})", pk_column, expected_pk[i],
-                     fmt::join(writer.values_[0], ","));
+        fmt::println(stderr, "{} expect {} = {} to have 0 rows, found ({})", StatusFail("ERROR:"), pk_column,
+                     expected_pk[i], fmt::join(writer.values_[0], ","));
         std::terminate();
       }
     } else {
       if (writer.values_.size() != 1) {
-        fmt::println("ERROR: expect {} = {} to have 1 row, found {} rows", pk_column, expected_pk[i],
-                     writer.values_.size());
+        fmt::println(stderr, "{} expect {} = {} to have 1 row, found {} rows", StatusFail("ERROR:"), pk_column,
+                     expected_pk[i], writer.values_.size());
         std::terminate();
       }
       if (writer.values_[0] != VecToVecString(expected_rows[i])) {
-        fmt::println("ERROR: expect {} = {} to be ({}), found ({})", pk_column, expected_pk[i],
-                     fmt::join(expected_rows[0], ","), fmt::join(writer.values_[0], ","));
+        fmt::println(stderr, "{} expect {} = {} to be ({}), found ({})", StatusFail("ERROR:"), pk_column,
+                     expected_pk[i], fmt::join(expected_rows[0], ","), fmt::join(writer.values_[0], ","));
         std::terminate();
       }
     }
   }
-  fmt::println(" -- pass check :)");
+  fmt::println(stderr, "{}", StatusSuccess(" -- pass check :)"));
 }
 
 using IntResult = std::vector<std::vector<int>>;

--- a/test/txn/txn_index_concurrent_test.cpp
+++ b/test/txn/txn_index_concurrent_test.cpp
@@ -87,7 +87,7 @@ TEST(TxnIndexTest, DISABLED_IndexConcurrentInsertTest) {  // NOLINT
     auto query_txn = BeginTxn(*bustub, "query_txn");
     WithTxn(query_txn, QueryShowResult(*bustub, _var, _txn, "SELECT * FROM maintable", expected_rows));
     auto entry = TableHeapEntry(*bustub, bustub->catalog_->GetTable("maintable"));
-    fmt::println("{} entries in the table heap", entry);
+    fmt::println(stderr, "{} entries in the table heap", entry);
     if (n == trials - 1) {
       SimpleStreamWriter writer(std::cerr);
       fmt::println(stderr, "--- the following data might be manually inspected by TAs ---");

--- a/test/txn/txn_index_test.cpp
+++ b/test/txn/txn_index_test.cpp
@@ -152,7 +152,7 @@ TEST(TxnIndexTest, DISABLED_UpdateTest) {  // NOLINT
   };
 
   {
-    fmt::println("---- UpdateTest1: insert, update, and commit ----");
+    fmt::println(stderr, "---- UpdateTest1: insert, update, and commit ----");
     auto bustub = std::make_unique<BustubInstance>();
     EnsureIndexScan(*bustub);
     Execute(*bustub, "CREATE TABLE maintable(col1 int primary key, col2 int)");

--- a/tools/terrier_bench/terrier.cpp
+++ b/tools/terrier_bench/terrier.cpp
@@ -142,7 +142,7 @@ void Bench1TaskTransfer(const int thread_id, const int terrier_num, const uint64
   std::uniform_int_distribution<int> terrier_uniform_dist(0, terrier_num - 1);
   std::uniform_int_distribution<int> money_transfer_dist(5, max_transfer_amount);
 
-  TerrierMetrics metrics(fmt::format("Xfr {}", thread_id), duration_ms);
+  TerrierMetrics metrics(fmt::format("Xfr  {}", thread_id), duration_ms);
   metrics.Begin();
 
   while (!metrics.ShouldFinish()) {
@@ -201,7 +201,7 @@ void Bench2TaskTransfer(const int thread_id, const int terrier_num, const uint64
   std::uniform_int_distribution<int> money_transfer_dist(5, max_transfer_amount);
   int adjustment = 0;
 
-  TerrierMetrics metrics(fmt::format("Xfr {}", thread_id), duration_ms);
+  TerrierMetrics metrics(fmt::format("Xfr  {}", thread_id), duration_ms);
   metrics.Begin();
 
   while (!metrics.ShouldFinish()) {
@@ -467,6 +467,7 @@ auto main(int argc, char **argv) -> int {
 
   size_t bustub_terrier_num = 10;
   size_t bustub_thread_cnt = 2;
+  const size_t bpm_size = 4096; // ensure benchmark does not hit BPM
 
   try {
     program.parse_args(argc, argv);
@@ -475,7 +476,7 @@ auto main(int argc, char **argv) -> int {
     return 1;
   }
 
-  auto bustub = std::make_unique<bustub::BustubInstance>();
+  auto bustub = std::make_unique<bustub::BustubInstance>(bpm_size);
   auto writer = bustub::SimpleStreamWriter(std::cerr);
 
   if (program.present("--terriers")) {


### PR DESCRIPTION
* enlarge BPM size for p4, no eviction for terrier benchmark to avoid contention on BPM
* colorize test output to make it easier to read
* misc format fixes and redirect output to stderr