### PR TITLE
p1: tiny fix of array usage in a test

### DIFF
--- a/test/storage/disk_scheduler_test.cpp
+++ b/test/storage/disk_scheduler_test.cpp
@@ -38,8 +38,8 @@ TEST(DiskSchedulerTest, DISABLED_ScheduleWriteReadPageTest) {
   auto promise2 = disk_scheduler->CreatePromise();
   auto future2 = promise2.get_future();
 
-  disk_scheduler->Schedule({/*is_write=*/true, reinterpret_cast<char *>(&data), /*page_id=*/0, std::move(promise1)});
-  disk_scheduler->Schedule({/*is_write=*/false, reinterpret_cast<char *>(&buf), /*page_id=*/0, std::move(promise2)});
+  disk_scheduler->Schedule({/*is_write=*/true, data, /*page_id=*/0, std::move(promise1)});
+  disk_scheduler->Schedule({/*is_write=*/false, buf, /*page_id=*/0, std::move(promise2)});
 
   ASSERT_TRUE(future1.get());
   ASSERT_TRUE(future2.get());


### PR DESCRIPTION
array used as a parameter decays to the address of its first element. No need to reinterpret cast it.

DO NOT PUSH PROJECT SOLUTIONS PUBLICLY.

And especially do NOT open pull requests with project solutions!

Please be considerate of this free educational resource.
