### PR TITLE
change return type uint32_t -> page_id_t for func GetDirectoryPageId

### DIFF
--- a/src/include/storage/page/extendible_htable_header_page.h
+++ b/src/include/storage/page/extendible_htable_header_page.h
@@ -56,7 +56,7 @@ class ExtendibleHTableHeaderPage {
    * @param directory_idx index in the directory page id array
    * @return directory page_id at index
    */
-  auto GetDirectoryPageId(uint32_t directory_idx) const -> uint32_t;
+  auto GetDirectoryPageId(uint32_t directory_idx) const -> page_id_t;
 
   /**
    * @brief Set the directory page id at an index

--- a/src/storage/page/extendible_htable_header_page.cpp
+++ b/src/storage/page/extendible_htable_header_page.cpp
@@ -22,7 +22,7 @@ void ExtendibleHTableHeaderPage::Init(uint32_t max_depth) {
 
 auto ExtendibleHTableHeaderPage::HashToDirectoryIndex(uint32_t hash) const -> uint32_t { return 0; }
 
-auto ExtendibleHTableHeaderPage::GetDirectoryPageId(uint32_t directory_idx) const -> uint32_t { return 0; }
+auto ExtendibleHTableHeaderPage::GetDirectoryPageId(uint32_t directory_idx) const -> page_id_t { return 0; }
 
 void ExtendibleHTableHeaderPage::SetDirectoryPageId(uint32_t directory_idx, page_id_t directory_page_id) {
   throw NotImplementedException("ExtendibleHTableHeaderPage is not implemented");


### PR DESCRIPTION
An error type return by GetDirectoryPageId confused me for a long time, maybe there are also some who is not so familiar with CPP encountered this too. It return `INVALID_PAGE_ID(-1)` as uint32_t and get a super max one. Hope this can be fixed soon.

#625