### PR TITLE
fix memory leak of vector type

### DIFF
--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -28,6 +28,7 @@ Value::Value(const Value &other) {
   value_ = other.value_;
   switch (type_id_) {
     case TypeId::VARCHAR:
+    case TypeId::VECTOR:
       if (size_.len_ == BUSTUB_VALUE_NULL) {
         value_.varlen_ = nullptr;
       } else {
@@ -278,6 +279,7 @@ Value::Value(TypeId type, const std::vector<double> &data) : Value(type) {
 Value::~Value() {
   switch (type_id_) {
     case TypeId::VARCHAR:
+    case TypeId::VECTOR:
       if (manage_data_) {
         delete[] value_.varlen_;
       }


### PR DESCRIPTION
backport from https://github.com/skyzh/bustub-vectordb/pull/1 @UnpureRationalist

---

Hi there,

Thanks for your excellent tutotial for vector database beginners. When I follow your tutorial and test my implementions using the commands [here](https://skyzh.github.io/write-you-a-vector-db/cpp-02-setup.html#testing), memory leak was reported by AddressSanitizer.

After debugging, I found the destructor of class `Value` was not implemented well for `VECTOR` type. So this PR fixed the bug by modifying destructor along with the copy constructor (The copy assignment operator do not need to change since it is pass by  value).

After fixing the bug, the test can passed correctly without memory leak.