### PR TITLE
fix(p2): fix wrong definition of function

### DIFF
--- a/src/include/storage/page/extendible_htable_header_page.h
+++ b/src/include/storage/page/extendible_htable_header_page.h
@@ -56,7 +56,7 @@ class ExtendibleHTableHeaderPage {
    * @param directory_idx index in the directory page id array
    * @return directory page_id at index
    */
-  auto GetDirectoryPageId(uint32_t directory_idx) const -> uint32_t;
+  auto GetDirectoryPageId(uint32_t directory_idx) const -> page_id_t;
 
   /**
    * @brief Set the directory page id at an index

--- a/src/storage/page/extendible_htable_header_page.cpp
+++ b/src/storage/page/extendible_htable_header_page.cpp
@@ -12,6 +12,7 @@
 
 #include "storage/page/extendible_htable_header_page.h"
 
+#include "common/config.h"
 #include "common/exception.h"
 
 namespace bustub {
@@ -22,7 +23,7 @@ void ExtendibleHTableHeaderPage::Init(uint32_t max_depth) {
 
 auto ExtendibleHTableHeaderPage::HashToDirectoryIndex(uint32_t hash) const -> uint32_t { return 0; }
 
-auto ExtendibleHTableHeaderPage::GetDirectoryPageId(uint32_t directory_idx) const -> uint32_t { return 0; }
+auto ExtendibleHTableHeaderPage::GetDirectoryPageId(uint32_t directory_idx) const -> page_id_t { return 0; }
 
 void ExtendibleHTableHeaderPage::SetDirectoryPageId(uint32_t directory_idx, page_id_t directory_page_id) {
   throw NotImplementedException("ExtendibleHTableHeaderPage is not implemented");


### PR DESCRIPTION
Modify the return value type of the `ExtendibleHTableHeaderPage::GetDirectoryPageId(uint32_t directory_idx) const -> uint32_t` function to `page_id_t`.

before:  Using this function get pageid requires type conversion.
After: The function return value conforms to the definition of the function name.

this function in `bustub/src/storage/page/extendible_htable_header_page.cpp`.