### PR TITLE
change non const `Tuple::KeyFromTuple` to const method #699

### DIFF
--- a/src/include/storage/table/tuple.h
+++ b/src/include/storage/table/tuple.h
@@ -99,7 +99,8 @@ class Tuple {
   auto GetValue(const Schema *schema, uint32_t column_idx) const -> Value;
 
   // Generates a key tuple given schemas and attributes
-  auto KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs) -> Tuple;
+  auto KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs) const
+      -> Tuple;
 
   // Is the column value null ?
   inline auto IsNull(const Schema *schema, uint32_t column_idx) const -> bool {

--- a/src/storage/table/tuple.cpp
+++ b/src/storage/table/tuple.cpp
@@ -68,7 +68,7 @@ auto Tuple::GetValue(const Schema *schema, const uint32_t column_idx) const -> V
   return Value::DeserializeFrom(data_ptr, column_type);
 }
 
-auto Tuple::KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs)
+auto Tuple::KeyFromTuple(const Schema &schema, const Schema &key_schema, const std::vector<uint32_t> &key_attrs) const
     -> Tuple {
   std::vector<Value> values;
   values.reserve(key_attrs.size());


### PR DESCRIPTION
fix #699 
`Tuple::KeyFromTuple` doesn't  modify any members and call any non const methods. So it should be defined as a const class methods.
