### PR TITLE
Fixed a potential bug that could cause a segment fault when insert a large tuple.

### DIFF
--- a/src/storage/page/table_page.cpp
+++ b/src/storage/page/table_page.cpp
@@ -38,7 +38,7 @@ auto TablePage::GetNextTupleOffset(const TupleMeta &meta, const Tuple &tuple) co
   }
   auto tuple_offset = slot_end_offset - tuple.GetLength();
   auto offset_size = TABLE_PAGE_HEADER_SIZE + TUPLE_INFO_SIZE * (num_tuples_ + 1);
-  if (tuple_offset < offset_size) {
+  if (tuple_offset < offset_size || tuple_offset >= BUSTUB_PAGE_SIZE) {
     return std::nullopt;
   }
   return tuple_offset;


### PR DESCRIPTION
## Statement
In the file `src/storage/page/table_page.cpp`, Here is a `TablePage::GetNextTupleOffset` function.

```cpp
  // Warning: slot_end_offset may be smaller than tuple.GetLength()
  auto tuple_offset = slot_end_offset - tuple.GetLength();

  auto offset_size = TABLE_PAGE_HEADER_SIZE + TUPLE_INFO_SIZE * (num_tuples_ + 1);
  if (tuple_offset < offset_size) {
    return std::nullopt;
  }
```

Since `tuple_offset` is unsigned long, tuple_offset will be greater than the value of offset_size after underflow occurs. Therefore, the condition of `if` clause is not satisfied, we will return an error tuple_offset(the value of tuple_offset exceeds the page size). When we insert a tuple at this position, a segment fault occurs.

## How to hack it
I reproduced this fault using [BusTub Web Shell(Fall 2023)](https://15445.courses.cs.cmu.edu/fall2023/bustub/).

First, create a table with larger schema.

```sql
CREATE TABLE my_table (
    myname VARCHAR(2500),
);
```

Then, insert some tuples into it. In this example, I inserted $3$ tuples of $2500$ bytes long.

```sql
INSERT INTO my_table VALUES ('chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|');

INSERT INTO my_table VALUES ('chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|');

INSERT INTO my_table VALUES ('chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|chenyujie|');
```

Then, You should be able to observe that the program has failed.
![pic](https://github.com/cmu-db/bustub/assets/78433231/535d3c6a-04ca-40ed-9f0b-c1d4a39707f6)

