### PR TITLE
Fix compilation with newer compilers: GCC-14 and CLANG-16

### DIFF
--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -115,7 +115,7 @@ auto TimestampType::ToString(const Value &val) const -> std::string {
   tm /= 32;
   auto month = static_cast<uint16_t>(tm);
   const size_t date_str_len = 30;
-  const size_t zone_len = 5;
+  const size_t zone_len = 6;
   char str[date_str_len];
   char zone[zone_len];
   snprintf(str, date_str_len, "%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, min, sec, micro);
@@ -127,7 +127,7 @@ auto TimestampType::ToString(const Value &val) const -> std::string {
   if (tz < 0) {
     tz = -tz;
   }
-  snprintf(zone, zone_len, "%02d", tz);  // NOLINT
+  snprintf(zone, std::min(zone_len, sizeof(zone)), "%02d", tz);  // NOLINT
   str[27] = 0;
   return std::string(std::string(str) + std::string(zone));
 }

--- a/third_party/backward-cpp/backward.hpp
+++ b/third_party/backward-cpp/backward.hpp
@@ -2443,8 +2443,8 @@ private:
         // If we have a valid elf handle, return the new elf handle
         // and file handle and discard the original ones
         if (debuglink_elf) {
-          elf_handle = move(debuglink_elf);
-          file_handle = move(debuglink_file);
+          elf_handle = std::move(debuglink_elf);
+          file_handle = std::move(debuglink_file);
         }
       }
     }
@@ -2466,9 +2466,9 @@ private:
 
     dwarf_handle.reset(dwarf_debug);
 
-    r.file_handle = move(file_handle);
-    r.elf_handle = move(elf_handle);
-    r.dwarf_handle = move(dwarf_handle);
+    r.file_handle = std::move(file_handle);
+    r.elf_handle = std::move(elf_handle);
+    r.dwarf_handle = std::move(dwarf_handle);
 
     return r;
   }

--- a/third_party/fmt/include/fmt/ranges.h
+++ b/third_party/fmt/include/fmt/ranges.h
@@ -212,7 +212,7 @@ class is_tuple_formattable_ {
 template <typename T, typename C> class is_tuple_formattable_<T, C, true> {
   template <std::size_t... Is>
   static std::true_type check2(index_sequence<Is...>,
-                               integer_sequence<bool, (Is == Is)...>);
+                               integer_sequence<bool, (Is >= 0)...>);
   static std::false_type check2(...);
   template <std::size_t... Is>
   static decltype(check2(


### PR DESCRIPTION
These changes are letting the project be compiled with the current Debian Testing, where Clang-16 and GCC-14.2 are default versions.