### PR TITLE
Fix typo in AddElem documentation: change 'Ddds' to 'Adds'

### DIFF
--- a/src/include/primer/hyperloglog.h
+++ b/src/include/primer/hyperloglog.h
@@ -34,7 +34,7 @@ class HyperLogLog {
   auto GetCardinality() { return cardinality_; }
 
   /**
-   * @brief Ddds a value into the HyperLogLog.
+   * @brief Adds a value into the HyperLogLog.
    *
    * @param[in] val - value that's added into hyperloglog
    */


### PR DESCRIPTION
Fix typo in AddElem documentation: change 'Ddds' to 'Adds'