### PR TITLE
add new sql test "partition by combined with rank"

### DIFF
--- a/test/sql/p3.20-window-function.slt
+++ b/test/sql/p3.20-window-function.slt
@@ -98,3 +98,36 @@ select sum(v2) over (partition by v1 order by v2), sum(v2) over (order by v2) fr
 600 600
 400 1000
 900 1500
+
+# Create table t3
+statement ok
+create table t3(v1 int, v2 int);
+
+# Insert something
+query
+insert into t3 values (2, 3), (3, 2), (1, 2), (3, 1), (3, 1), (2, 2), (1, 1),(1, 3), (3, 1), (2, 1), (3, 1), (1, 1);
+----
+12
+
+# partition by combined with rank
+query rank_partition
+select *
+from (
+    select v1, v2, rank() OVER (PARTITION BY v1 ORDER BY v2) AS rank
+    FROM t3
+) as subquery
+order by v1, rank;
+----
+1 1 1
+1 1 1
+1 2 3
+1 3 4
+2 1 1 
+2 2 2
+2 3 3
+3 1 1
+3 1 1
+3 1 1
+3 1 1
+3 2 5
+


### PR DESCRIPTION
While working on project 3, I discovered that my implementation of window_function was incorrect, but it still passed all the tests including p3.20-window-function. After investigating, I found that this was due to the absence of a test case combining the PARTITION BY clause with a RANK query.

Specifically, when PARTITION BY and RANK are used together, ranking should be done within each partitioned group. However, my incorrect implementation performed ranking without considering the partitions. Despite this, it still passed all the current tests in p3.20-window-function. To address this, I have added a new test case that ensures the proper behavior when PARTITION BY and RANK are used together.

Although the combination of PARTITION BY and RANK appears in the p3.leaderboard-q1-window.slt tests, these leaderboard tests are optional. Therefore, if someone does not attempt the leaderboard tests, they might not notice similar issues in their implementation, as I did.
