### PR TITLE
add(p2): test for deleting the only remaining node

### DIFF
--- a/test/storage/b_plus_tree_delete_test.cpp
+++ b/test/storage/b_plus_tree_delete_test.cpp
@@ -81,6 +81,13 @@ TEST(BPlusTreeTests, DISABLED_DeleteTestNoIterator) {
     }
   }
   EXPECT_EQ(size, 1);
+
+  // Remove the remaining key
+  index_key.SetFromInteger(2);
+  tree.Remove(index_key);
+  auto root_page_id = tree.GetRootPageId();
+  ASSERT_EQ(root_page_id, INVALID_PAGE_ID);
+
   delete bpm;
 }
 


### PR DESCRIPTION
Add the test for the case where the only node in B+Tree is deleted. The original tests do not handle this scenario, and if students fail to handle this properly, their P3 will be affected.
