### PR TITLE
fix(f24 p4): misleading error

### DIFF
--- a/test/txn/txn_index_concurrent_test.cpp
+++ b/test/txn/txn_index_concurrent_test.cpp
@@ -150,7 +150,8 @@ TEST(TxnIndexTest, DISABLED_IndexConcurrentUpdateTest) {  // NOLINT
           if (add_delete_insert) {
             StringVectorWriter data_writer;
             BUSTUB_ENSURE(bustub->ExecuteSqlTxn(generate_select_sql(i), data_writer, txn), "cannot retrieve data");
-            BUSTUB_ENSURE(data_writer.values_.size() == 1, "more than 1 row fetched??");
+            BUSTUB_ENSURE(data_writer.values_.size() > 1, "more than one row fetched??");
+            BUSTUB_ENSURE(!data_writer.values_.empty(), "no row fetched??");
             const auto b_val = std::stoi(data_writer.values_[0][0]);
             BUSTUB_ENSURE(bustub->ExecuteSqlTxn(generate_delete_sql(i), data_writer, txn), "cannot delete data");
             BUSTUB_ENSURE(bustub->ExecuteSqlTxn(generate_txn_insert_sql(b_val, i), data_writer, txn),

--- a/test/txn/txn_index_concurrent_test.cpp
+++ b/test/txn/txn_index_concurrent_test.cpp
@@ -150,8 +150,8 @@ TEST(TxnIndexTest, DISABLED_IndexConcurrentUpdateTest) {  // NOLINT
           if (add_delete_insert) {
             StringVectorWriter data_writer;
             BUSTUB_ENSURE(bustub->ExecuteSqlTxn(generate_select_sql(i), data_writer, txn), "cannot retrieve data");
-            BUSTUB_ENSURE(data_writer.values_.size() > 1, "more than one row fetched??");
             BUSTUB_ENSURE(!data_writer.values_.empty(), "no row fetched??");
+            BUSTUB_ENSURE(data_writer.values_.size() == 1, "more than one row fetched??");
             const auto b_val = std::stoi(data_writer.values_[0][0]);
             BUSTUB_ENSURE(bustub->ExecuteSqlTxn(generate_delete_sql(i), data_writer, txn), "cannot delete data");
             BUSTUB_ENSURE(bustub->ExecuteSqlTxn(generate_txn_insert_sql(b_val, i), data_writer, txn),


### PR DESCRIPTION
The original error message is a bit misleading. One student came to my OH with his data_writer being empty. But the error message still said "more than one row fetched". It took me a while to figure it out...
