### PR TITLE
remove MacOS 12 (Monterey) CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,12 +35,6 @@ jobs:
               tidy: "/usr/bin/clang-tidy-14",
             }
           - {
-              name: "macOS 12 (Monterey) AppleClang",
-              os: macos-12,
-              format: "/usr/local/opt/llvm@14/bin/clang-format",
-              tidy: "/usr/local/opt/llvm@14/bin/clang-tidy",
-            }
-          - {
               name: "macOS 13 (Ventura) AppleClang",
               os: macos-13,
               format: "/usr/local/opt/llvm@14/bin/clang-format",

--- a/build_support/packages.sh
+++ b/build_support/packages.sh
@@ -8,8 +8,7 @@
 ##
 ## Supported environments:
 ##  * Ubuntu 22.04 (x86-64)
-##  * macOS 11 Big Sur (x86-64 or ARM)
-##  * macOS 12 Monterey (x86-64 or ARM)
+##  * macOS 13 Ventura (x86-64 or ARM)
 ## =================================================================
 
 main() {

--- a/third_party/argparse/.github/workflows/ci.yml
+++ b/third_party/argparse/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
 
         toolchain:
           - macos-latest-clang
-          - macos-12-clang
           - ubuntu-latest-clang
           - ubuntu-latest-gcc
           - windows-2019-msvc
@@ -25,11 +24,6 @@ jobs:
 
         include:
           - toolchain: macos-latest-clang
-            os: macos-latest
-            c_compiler: clang
-            cxx_compiler: clang++
-
-          - toolchain: macos-12-clang
             os: macos-latest
             c_compiler: clang
             cxx_compiler: clang++


### PR DESCRIPTION
MacOS 12 CI is deprecated. Remove it for unnecessary failures.