### PR TITLE
Add stream-style logging macros

### DIFF
--- a/src/include/common/macros.h
+++ b/src/include/common/macros.h
@@ -14,11 +14,45 @@
 
 #include <cassert>
 #include <exception>
+#include <sstream>
 #include <stdexcept>
 
 namespace bustub {
 
 #define BUSTUB_ASSERT(expr, message) assert((expr) && (message))
+
+namespace internal {
+
+// An internal stream, used to take C++ stream-style parameters for display, and exit the program with `std::abort`.
+class LogFatalStream {
+ public:
+  LogFatalStream(const char *file, int line) : file_(file), line_(line) {}
+
+  ~LogFatalStream() {
+    std::cerr << file_ << ":" << line_ << ": " << log_stream_.str() << std::endl;
+    std::abort();
+  }
+
+  template <typename T>
+  LogFatalStream &operator<<(const T &val) {
+    log_stream_ << val;
+    return *this;
+  }
+
+ private:
+  const char *file_;
+  int line_;
+  std::ostringstream log_stream_;
+};
+
+}  // namespace internal
+
+// A macro which checks `expr` value and performs assert.
+// Different from `BUSTUB_ASSERT`, it takes stream-style parameters.
+#define BUSTUB_ASSERT_AND_LOG(expr)             \
+  if (bool val = (expr); !val) LogFatalStream { \
+      __FILE__, __LINE__                        \
+    }
 
 #define UNIMPLEMENTED(message) throw std::logic_error(message)
 


### PR DESCRIPTION
Problem statement:
- Existing logging and assertion is kind of awkward, for example, it doesn't accept stream-style operation, meanwhile it uses string as the macro parameter, which means we have to concatenate the message beforehand.
  + (minor) It might hurts performance, I see a lot of the message construction is made by `operator+`, which could create temporary strings
  + (major) it reduces logging util usability

In this PR, I propose to add a new macro, which combines both assertion and logging with stream style operation.