### PR TITLE
add UpdateTupleMetaTs() and UpdateTupleMetaIsDelete() methods

### DIFF
--- a/src/include/storage/page/table_page.h
+++ b/src/include/storage/page/table_page.h
@@ -81,6 +81,16 @@ class TablePage {
   void UpdateTupleMeta(const TupleMeta &meta, const RID &rid);
 
   /**
+   * Update timestamp of the meta of a tuple.
+   */
+  void UpdateTupleMetaTs(timestamp_t ts, const RID &rid);
+
+  /**
+   * Update is_deleted of the meta of a tuple.
+   */
+  void UpdateTupleMetaIsDeleted(bool is_deleted, const RID &rid);
+
+  /**
    * Read a tuple from a table.
    */
   auto GetTuple(const RID &rid) const -> std::pair<TupleMeta, Tuple>;

--- a/src/include/storage/table/table_heap.h
+++ b/src/include/storage/table/table_heap.h
@@ -65,6 +65,20 @@ class TableHeap {
   void UpdateTupleMeta(const TupleMeta &meta, RID rid);
 
   /**
+   * Update timestamp of the meta of a tuple.
+   * @param ts new timestamp of meta
+   * @param rid the rid of the inserted tuple
+   */
+  void UpdateTupleMetaTs(timestamp_t ts, RID rid);
+
+  /**
+   * Update is_deleted of the meta of a tuple.
+   * @param is_deleted new is_deleted
+   * @param rid the rid of the inserted tuple
+   */
+  void UpdateTupleMetaIsDelete(bool is_deleted, RID rid);
+
+  /**
    * Read a tuple from the table.
    * @param rid rid of the tuple to read
    * @return the meta and tuple

--- a/src/storage/page/table_page.cpp
+++ b/src/storage/page/table_page.cpp
@@ -68,6 +68,29 @@ void TablePage::UpdateTupleMeta(const TupleMeta &meta, const RID &rid) {
   tuple_info_[tuple_id] = std::make_tuple(offset, size, meta);
 }
 
+void TablePage::UpdateTupleMetaTs(timestamp_t ts, const RID &rid) {
+  auto tuple_id = rid.GetSlotNum();
+  if (tuple_id >= num_tuples_) {
+    throw bustub::Exception("Tuple ID out of range");
+  }
+  auto &[offset, size, old_meta] = tuple_info_[tuple_id];
+  TupleMeta new_meta = {ts, old_meta.is_deleted_};
+  tuple_info_[tuple_id] = std::make_tuple(offset, size, new_meta);
+}
+
+void TablePage::UpdateTupleMetaIsDeleted(bool is_deleted, const RID &rid) {
+  auto tuple_id = rid.GetSlotNum();
+  if (tuple_id >= num_tuples_) {
+    throw bustub::Exception("Tuple ID out of range");
+  }
+  auto &[offset, size, old_meta] = tuple_info_[tuple_id];
+  if (!old_meta.is_deleted_ && is_deleted) {
+    num_deleted_tuples_++;
+  }
+  TupleMeta new_meta = {old_meta.ts_, is_deleted};
+  tuple_info_[tuple_id] = std::make_tuple(offset, size, new_meta);
+}
+
 auto TablePage::GetTuple(const RID &rid) const -> std::pair<TupleMeta, Tuple> {
   auto tuple_id = rid.GetSlotNum();
   if (tuple_id >= num_tuples_) {

--- a/src/storage/table/table_heap.cpp
+++ b/src/storage/table/table_heap.cpp
@@ -93,6 +93,18 @@ void TableHeap::UpdateTupleMeta(const TupleMeta &meta, RID rid) {
   page->UpdateTupleMeta(meta, rid);
 }
 
+void TableHeap::UpdateTupleMetaTs(timestamp_t ts, RID rid) {
+  auto page_guard = bpm_->WritePage(rid.GetPageId());
+  auto page = page_guard.AsMut<TablePage>();
+  page->UpdateTupleMetaTs(ts, rid);
+}
+
+void TableHeap::UpdateTupleMetaIsDelete(bool is_deleted, RID rid) {
+  auto page_guard = bpm_->WritePage(rid.GetPageId());
+  auto page = page_guard.AsMut<TablePage>();
+  page->UpdateTupleMetaIsDeleted(is_deleted, rid);
+}
+
 auto TableHeap::GetTuple(RID rid) -> std::pair<TupleMeta, Tuple> {
   auto page_guard = bpm_->ReadPage(rid.GetPageId());
   auto page = page_guard.As<TablePage>();


### PR DESCRIPTION
When we only need to update timestamp or is_deleted of TupleMeta, we can directly update meta without getting old meta first.