### PR TITLE
fix(run_clang_format.py): Add early return for empty `formatted_filenames` in check()

### DIFF
--- a/build_support/run_clang_format.py
+++ b/build_support/run_clang_format.py
@@ -40,6 +40,8 @@ def check(arguments, source_dir):
             [filename for filename in source_files
              if not any((fnmatch.fnmatch(filename, exclude_glob)
                          for exclude_glob in exclude_globs))])
+    if len(formatted_filenames) == 0:
+        return
 
     if arguments.fix:
         if not arguments.quiet:


### PR DESCRIPTION
If `formatted_filenames` is empty, it will run `clang-format` with the `-i` flag on an empty list, resulting `error: cannot use -i when reading from stdin`

DO NOT PUSH PROJECT SOLUTIONS PUBLICLY.

And especially do NOT open pull requests with project solutions!

Please be considerate of this free educational resource.
