### PR TITLE
Update comments relating to DeallocatePage

### DIFF
--- a/src/buffer/buffer_pool_manager.cpp
+++ b/src/buffer/buffer_pool_manager.cpp
@@ -130,14 +130,7 @@ auto BufferPoolManager::NewPage() -> page_id_t { UNIMPLEMENTED("TODO(P1): Add im
  * function. You will probably want to implement this function _after_ you have implemented `CheckedReadPage` and
  * `CheckedWritePage`.
  *
- * Ideally, we would want to ensure that all space on disk is used efficiently. That would mean the space that deleted
- * pages on disk used to occupy should somehow be made available to new pages allocated by `NewPage`.
- *
- * If you would like to attempt this, you are free to do so. However, for this implementation, you are allowed to
- * assume you will not run out of disk space and simply keep allocating disk space upwards in `NewPage`.
- *
- * For (nonexistent) style points, you can still call `DeallocatePage` in case you want to implement something slightly
- * more space-efficient in the future.
+ * You should call `DeallocatePage` in the disk scheduler to make the space available for new pages.
  *
  * TODO(P1): Add implementation.
  *

--- a/src/include/storage/disk/disk_scheduler.h
+++ b/src/include/storage/disk/disk_scheduler.h
@@ -72,7 +72,6 @@ class DiskScheduler {
    * @brief Deallocates a page on disk.
    *
    * Note: You should look at the documentation for `DeletePage` in `BufferPoolManager` before using this method.
-   * Also note: This is a no-op without a more complex data structure to track deallocated pages.
    *
    * @param page_id The page ID of the page to deallocate from disk.
    */


### PR DESCRIPTION
The disk manager now keeps track of deallocated pages and uses the space for new pages, so update the comments for buffer pool manager to reflect that. This should also help students in project 3 where deallocating is necessary.