### PR TITLE
fix: make HashUtil::HashBytes more platform independent

### DIFF
--- a/src/include/common/util/hash_util.h
+++ b/src/include/common/util/hash_util.h
@@ -33,7 +33,7 @@ class HashUtil {
     // https://github.com/greenplum-db/gpos/blob/b53c1acd6285de94044ff91fbee91589543feba1/libgpos/src/utils.cpp#L126
     hash_t hash = length;
     for (size_t i = 0; i < length; ++i) {
-      hash = ((hash << 5) ^ (hash >> 27)) ^ bytes[i];
+      hash = ((hash << 5) ^ (hash >> 27)) ^ static_cast<int8_t>(bytes[i]);
     }
     return hash;
   }


### PR DESCRIPTION
https://github.com/polyominal/bustub/blob/9988c8503cc3e5107cc750c651ebeaef2efe8ce6/src/include/common/util/hash_util.h#L32-L39

The hash function uses raw `bytes[i]` in `char`. This creates a subtle bug. C++ doesn't define whether `char` is signed or unsigned.

For byte values over 127, this matters:
- Signed platforms: values become negative (the expected behavior)
- Unsigned platforms: values stay positive (0-255)

This bit me during [HyperLogLog project](https://15445.courses.cs.cmu.edu/fall2024/project0/):
https://github.com/polyominal/bustub/blob/9988c8503cc3e5107cc750c651ebeaef2efe8ce6/test/primer/hyperloglog_test.cpp#L58-L108

My code failed on my machine (unsigned `char`) but passed elsewhere (signed `char`).

Proposed fix: Cast to `int8_t` for consistent behavior.
```cpp
hash = ((hash << 5) ^ (hash >> 27)) ^ static_cast<int8_t>(bytes[i]);
```
This should enable more machines to work. Any downsides to consider?