### PR TITLE
Fixes p4 bugs

### DIFF
--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -160,9 +160,9 @@ class Transaction {
 
   /** Use this function in leaderboard benchmarks for online garbage collection. For stop-the-world GC, simply remove
    * the txn from the txn_map. */
-  inline auto ClearUndoLog() -> size_t {
+  inline auto ClearUndoLog() -> void {
     std::scoped_lock<std::mutex> lck(latch_);
-    return undo_logs_.size();
+    undo_logs_.clear();
   }
 
   void SetTainted();

--- a/tools/terrier_bench/terrier.cpp
+++ b/tools/terrier_bench/terrier.cpp
@@ -481,6 +481,7 @@ void PrintPlan(bustub::BusTubInstance &instance, const std::string &query, bool 
         std::terminate();
       }
     }
+    instance.txn_manager_->Commit(txn);
   }
 }
 


### PR DESCRIPTION
p4 fixes for leaderboard tests:
- Adds txn commit to PrintPlan() in terrier.cpp. Before, the watermark would get stuck due to the uncommitted transaction, making garbage collection much harder.
- Changes ClearUndoLogs in transaction.h to clear vector undo_logs_ and return void

