### PR TITLE
refactor: return const references from page accessor methods

### DIFF
--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -52,7 +52,7 @@ class BPlusTreeInternalPage : public BPlusTreePage {
 
   void Init(int max_size = INTERNAL_PAGE_SLOT_CNT);
 
-  auto KeyAt(int index) const -> KeyType;
+  auto KeyAt(int index) const -> const KeyType &;
 
   void SetKeyAt(int index, const KeyType &key);
 
@@ -62,7 +62,7 @@ class BPlusTreeInternalPage : public BPlusTreePage {
    */
   auto ValueIndex(const ValueType &value) const -> int;
 
-  auto ValueAt(int index) const -> ValueType;
+  auto ValueAt(int index) const -> const ValueType &;
 
   /**
    * @brief For test only, return a string representing all keys in

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -60,7 +60,7 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   // Helper methods
   auto GetNextPageId() const -> page_id_t;
   void SetNextPageId(page_id_t next_page_id);
-  auto KeyAt(int index) const -> KeyType;
+  auto KeyAt(int index) const -> const KeyType &;
 
   /**
    * @brief For test only return a string representing all keys in

--- a/src/storage/page/b_plus_tree_internal_page.cpp
+++ b/src/storage/page/b_plus_tree_internal_page.cpp
@@ -41,7 +41,7 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Init(int max_size) { UNIMPLEMENTED("TODO(P2
  * @return Key at index
  */
 INDEX_TEMPLATE_ARGUMENTS
-auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::KeyAt(int index) const -> KeyType {
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::KeyAt(int index) const -> const KeyType & {
   UNIMPLEMENTED("TODO(P2): Add implementation.");
 }
 
@@ -64,7 +64,7 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::SetKeyAt(int index, const KeyType &key) {
  * @return Value at index
  */
 INDEX_TEMPLATE_ARGUMENTS
-auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const -> ValueType {
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const -> const ValueType & {
   UNIMPLEMENTED("TODO(P2): Add implementation.");
 }
 

--- a/src/storage/page/b_plus_tree_leaf_page.cpp
+++ b/src/storage/page/b_plus_tree_leaf_page.cpp
@@ -50,7 +50,9 @@ void B_PLUS_TREE_LEAF_PAGE_TYPE::SetNextPageId(page_id_t next_page_id) {
  * array offset)
  */
 INDEX_TEMPLATE_ARGUMENTS
-auto B_PLUS_TREE_LEAF_PAGE_TYPE::KeyAt(int index) const -> KeyType { UNIMPLEMENTED("TODO(P2): Add implementation."); }
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::KeyAt(int index) const -> const KeyType & {
+  UNIMPLEMENTED("TODO(P2): Add implementation.");
+}
 
 template class BPlusTreeLeafPage<GenericKey<4>, RID, GenericComparator<4>>;
 template class BPlusTreeLeafPage<GenericKey<8>, RID, GenericComparator<8>>;


### PR DESCRIPTION
Common sense:
```cpp
auto KeyAt(int index) const -> const KeyType&;
```
is a strictly better interface than
```cpp
auto KeyAt(int index) const -> KeyType;
```
(I thought it was obvious that these methods should return values whose lifetime is bound to the page object.)

FYI this is largely motivated by troubleshooting UB from writing something like
```cpp
auto INDEXITERATOR_TYPE::operator*() -> std::pair<const KeyType &, const ValueType &> {
  return {page_guard.As<Page>()->KeyAt(index_), page_guard.As<Page>()->ValueAt(index_)};
}
```
in the B+tree iterator implementation 🫠.