### PR TITLE
editor: Suppport `.clangd` and `.editorconfig`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+CompileFlags:
+  CompilationDatabase: build/       # Search build/ directory for compile_commands.json
+Diagnostics:
+  UnusedIncludes: None

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This PR add two small files to make it more friendly for editors (like Neovim)

1. .editorconfig - Sets basic indendation and style for this repository
2. .clangd - Helps to discover local and third-party header files via `compile_commands.json`

Without (1), my default 4 spaces makes it weird. This config will keep the spaces consistent in the editor as per the existing code in this repository.

Without (2), my editor (Neovim) failing to find the non-standard header files.

Both (1) and (2) are inspired from Neovim repository itself and also looked pretty standard for C++ projects.
1. https://github.com/neovim/neovim/blob/master/.editorconfig
2. https://github.com/neovim/neovim/blob/master/.clangd

I kept the configs to bare minimum. Happy to add additional flags `--std=c++20` in `.clangd` if needed to enforce C++20 standard for editor's LSP client for this repository as mentioned in the CMU Database course https://15445.courses.cs.cmu.edu/fall2025/faq.html#q5

DO NOT PUSH PROJECT SOLUTIONS PUBLICLY.

And especially do NOT open pull requests with project solutions!

Please be considerate of this free educational resource.
