### PR TITLE
clang-tidy update + small fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,7 @@ Checks:     '
             -bugprone-reserved-identifier,
             -bugprone-signed-char-misuse,
             -bugprone-suspicious-include,
+            -bugprone-unchecked-optional-access,
             -bugprone-unhandled-self-assignment,
             -clang-analyzer-cplusplus.NewDelete,
             -clang-analyzer-cplusplus.NewDeleteLeaks,

--- a/src/binder/fmt_impl.cpp
+++ b/src/binder/fmt_impl.cpp
@@ -45,7 +45,8 @@ auto BoundCTERef::ToString() const -> std::string {
 }
 
 auto BoundSubqueryRef::ToString() const -> std::string {
-  std::vector<std::string> columns(select_list_name_.size());
+  std::vector<std::string> columns;
+  columns.reserve(select_list_name_.size());
   for (const auto &name : select_list_name_) {
     columns.push_back(fmt::format("{}", fmt::join(name, ".")));
   }
@@ -54,12 +55,14 @@ auto BoundSubqueryRef::ToString() const -> std::string {
 }
 
 auto BoundWindow::ToString() const -> std::string {
-  std::vector<std::string> partition_by(partition_by_.size());
+  std::vector<std::string> partition_by;
+  partition_by.reserve(partition_by_.size());
   for (const auto &expr : partition_by_) {
     partition_by.push_back(expr->ToString());
   }
 
-  std::vector<std::string> order_bys(order_bys_.size());
+  std::vector<std::string> order_bys;
+  order_bys.reserve(order_bys_.size());
   for (const auto &expr : order_bys_) {
     order_bys.push_back(expr->ToString());
   }

--- a/src/catalog/table_generator.cpp
+++ b/src/catalog/table_generator.cpp
@@ -78,7 +78,8 @@ void TableGenerator::FillTable(const std::shared_ptr<TableInfo> &info, TableInse
   uint32_t num_inserted = 0;
   uint32_t batch_size = 128;
   while (num_inserted < table_meta->num_rows_) {
-    std::vector<std::vector<Value>> values(table_meta->col_meta_.size());
+    std::vector<std::vector<Value>> values;
+    values.reserve(table_meta->col_meta_.size());
     uint32_t num_values = std::min(batch_size, table_meta->num_rows_ - num_inserted);
     for (auto &col_meta : table_meta->col_meta_) {
       values.emplace_back(MakeValues(&col_meta, num_values));

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -360,7 +360,8 @@ class Catalog {
   }
 
   auto GetTableNames() -> std::vector<std::string> {
-    std::vector<std::string> result(table_names_.size());
+    std::vector<std::string> result;
+    result.reserve(table_names_.size());
     for (const auto &x : table_names_) {
       result.push_back(x.first);
     }


### PR DESCRIPTION
Fixing bugs introduced when adding support for Ubuntu 24.0.4

Remove `bugprone-unchecked-optional-access` check from clang-tidy