### PR TITLE
tools/terrier_bench: call TxnCommitted() only after Commit() in Bench2TaskTransfer

### DIFF
--- a/tools/terrier_bench/terrier.cpp
+++ b/tools/terrier_bench/terrier.cpp
@@ -275,7 +275,6 @@ void Bench2TaskTransfer(const int thread_id, const int terrier_num, const uint64
       fmt::print(stderr, "unexpected result when update \"{}\" != 1\n", result);
       exit(1);
     }
-    metrics.TxnCommitted();
 
     if (!bustub->txn_manager_->Commit(txn)) {
       metrics.TxnAborted();


### PR DESCRIPTION
- Bench2TaskTransfer() calls metrics.TxnCommitted() before txn_manager_->Commit(txn) and again after it, which double-counts on success and miscounts on failure.
- This pr removes the early call so metrics reflect only successfully committed transactions.
