### PR TITLE
fix: missing NumTombs in LeafPage alias

### DIFF
--- a/src/include/storage/index/b_plus_tree.h
+++ b/src/include/storage/index/b_plus_tree.h
@@ -75,7 +75,7 @@ class Context {
 FULL_INDEX_TEMPLATE_ARGUMENTS_DEFN
 class BPlusTree {
   using InternalPage = BPlusTreeInternalPage<KeyType, page_id_t, KeyComparator>;
-  using LeafPage = BPlusTreeLeafPage<KeyType, ValueType, KeyComparator>;
+  using LeafPage = BPlusTreeLeafPage<KeyType, ValueType, KeyComparator, NumTombs>;
 
  public:
   explicit BPlusTree(std::string name, page_id_t header_page_id, BufferPoolManager *buffer_pool_manager,


### PR DESCRIPTION
`NumToms` is missing from LeafPage, which makes `NumTombs` always default to 0.

To reproduce run b_plus_tree_printer.

Based on the current configuration https://github.com/cmu-db/bustub/blob/master/tools/b_plus_tree_printer/b_plus_tree_printer.cpp#L82, NumTombs = 2, but the default value is used instead.