### PR TITLE
Fix build on Fedora 43: add missing <cstdint> include

### DIFF
--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- Add `#include <cstdint>` to `string_util.h` which uses `uint64_t` in the `FormatSize()` declaration
- On Fedora 43 (GCC 15), `<cstdint>` is no longer transitively included, causing a build failure

Fixes #856.

## Test plan
- [x] Verified `uint64_t` is the only type from `<cstdint>` used in this header
- [x] Include is placed in alphabetical order with existing includes