### PR TITLE
Fix incorrect class names in destructor doc comments

### DIFF
--- a/src/include/buffer/arc_replacer.h
+++ b/src/include/buffer/arc_replacer.h
@@ -50,7 +50,7 @@ class ArcReplacer {
   /**
    * TODO(P1): Add implementation
    *
-   * @brief Destroys the LRUReplacer.
+   * @brief Destroys the ArcReplacer.
    */
   ~ArcReplacer() = default;
 

--- a/src/include/buffer/lru_k_replacer.h
+++ b/src/include/buffer/lru_k_replacer.h
@@ -56,7 +56,7 @@ class LRUKReplacer {
   /**
    * TODO(P1): Add implementation
    *
-   * @brief Destroys the LRUReplacer.
+   * @brief Destroys the LRUKReplacer.
    */
   ~LRUKReplacer() = default;
 


### PR DESCRIPTION
## Summary
- The destructor `@brief` comments in `ArcReplacer` (`arc_replacer.h`) and `LRUKReplacer` (`lru_k_replacer.h`) both incorrectly say "Destroys the LRUReplacer" instead of referencing their own class names.
- This is a copy-paste artifact from the original `LRUReplacer` class. Updated to say "Destroys the ArcReplacer" and "Destroys the LRUKReplacer" respectively.

## Test plan
- No behavioral change; documentation-only fix.
- Verified the comments now match the enclosing class names.