### PR TITLE
Fix misleading doc comment in ReaderWriterLatch

### DIFF
--- a/src/include/common/rwlatch.h
+++ b/src/include/common/rwlatch.h
@@ -20,7 +20,7 @@
 namespace bustub {
 
 /**
- * Reader-Writer latch backed by std::mutex.
+ * Reader-Writer latch backed by std::shared_mutex.
  */
 class ReaderWriterLatch {
  public:


### PR DESCRIPTION
## Summary
- The class-level documentation for `ReaderWriterLatch` in `rwlatch.h` states it is "backed by std::mutex", but the actual underlying member is `std::shared_mutex`.
- This is misleading because `std::mutex` does not support shared/reader locking, while `std::shared_mutex` does -- which is the whole point of the class.
- Updated the comment to correctly say "backed by std::shared_mutex".

## Test plan
- No behavioral change; documentation-only fix.
- Verified the comment now matches the actual member type (`std::shared_mutex mutex_`).