### PR TITLE
Add missing #include <cstdint> in string_util.h

### DIFF
--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary

- Adds the missing `#include <cstdint>` to `src/include/common/util/string_util.h`
- The header uses `uint64_t` (in `FormatSize`) without including `<cstdint>`, which causes build failures on systems where this type is not transitively included (e.g., Fedora 43 with GCC 15)

## Details

On most platforms, `uint64_t` happens to be pulled in transitively through other standard headers, but this is not guaranteed by the C++ standard. Fedora 43 ships a newer GCC/libstdc++ that no longer transitively includes `<cstdint>` from `<string>` or `<vector>`, causing the build to fail with:

```
error: 'uint64_t' was not declared in this scope
```

The fix is a one-line addition of `#include <cstdint>` alongside the existing includes.

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)