### PR TITLE
Add missing #include <cstdint> to string_util.h

### DIFF
--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- Adds `#include <cstdint>` to `src/include/common/util/string_util.h` to fix build failure on Fedora 43+ where `uint64_t` is not implicitly declared

Fixes #856

## Test plan
- Build should succeed on Fedora 43 with GCC 15+ where `<cstdint>` is no longer transitively included

🤖 Generated with [Claude Code](https://claude.com/claude-code)