### PR TITLE
Fix llvm version check in packages.sh

### DIFF
--- a/build_support/packages.sh
+++ b/build_support/packages.sh
@@ -78,7 +78,7 @@ install_mac() {
   brew ls --versions coreutils || brew install coreutils
   brew ls --versions doxygen || brew install doxygen
   brew ls --versions git || brew install git
-  (brew ls --versions llvm | grep ${CLANG_VERSION}) || brew install llvm@${CLANG_VERSION}
+  brew ls --versions llvm@${CLANG_VERSION} || brew install llvm@${CLANG_VERSION}
   brew ls --versions libelf || brew install libelf
 }
 

--- a/src/include/common/util/string_util.h
+++ b/src/include/common/util/string_util.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- Fixed the `brew ls --versions` check for llvm in `build_support/packages.sh`
- The old command `(brew ls --versions llvm | grep ${CLANG_VERSION})` always printed nothing because `brew ls --versions llvm` does not list versioned formulae like `llvm@15`
- Replaced with `brew ls --versions llvm@${CLANG_VERSION}` which correctly checks whether the versioned formula is installed

Fixes #805

## Test plan
- [ ] Run `build_support/packages.sh` on macOS with llvm@15 already installed — should detect it and skip installation
- [ ] Run `build_support/packages.sh` on macOS without llvm@15 — should install it

🤖 Generated with [Claude Code](https://claude.com/claude-code)