### PR TITLE
Fix missing null check and wrong cast in TimestampType comparisons

### DIFF
--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -31,7 +31,7 @@ auto TimestampType::CompareEquals(const Value &left, const Value &right) const -
 
 auto TimestampType::CompareNotEquals(const Value &left, const Value &right) const -> CmpBool {
   assert(left.CheckComparable(right));
-  if (right.IsNull()) {
+  if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
   }
   return GetCmpBool(left.GetAs<uint64_t>() != right.GetAs<uint64_t>());
@@ -58,7 +58,7 @@ auto TimestampType::CompareGreaterThan(const Value &left, const Value &right) co
   if (left.IsNull() || right.IsNull()) {
     return CmpBool::CmpNull;
   }
-  return GetCmpBool(left.GetAs<int64_t>() > right.GetAs<int64_t>());
+  return GetCmpBool(left.GetAs<uint64_t>() > right.GetAs<uint64_t>());
 }
 
 auto TimestampType::CompareGreaterThanEquals(const Value &left, const Value &right) const -> CmpBool {


### PR DESCRIPTION
## Summary

Two correctness bugs in `timestamp_type.cpp`:

### 1. `CompareNotEquals` missing `left.IsNull()` check (line 34)

Only `right.IsNull()` is checked. If `left` is NULL and `right` is not, the function reads the NULL value's bit pattern and returns `CmpTrue`/`CmpFalse` instead of `CmpNull`. This violates SQL null semantics (`NULL != x` must be `NULL`). Every other `Compare*` method in this file checks `left.IsNull() || right.IsNull()`.

### 2. `CompareGreaterThan` uses `int64_t` instead of `uint64_t` (line 61)

Timestamps are stored as `uint64_t`. Signed comparison via `int64_t` causes values with bit 63 set to be interpreted as negative, inverting the ordering for large timestamps. Every other `Compare*` method uses `uint64_t`.

## Test plan
- [x] Verified all 6 Compare* methods — only these two are inconsistent
- [x] Confirmed timestamps use `uint64_t` storage (`value_.timestamp_`, SerializeTo, DeserializeFrom)
- [x] 2-line fix, pattern-consistent with sibling methods