### PR TITLE
Guard StringUtil::StartsWith against prefix longer than string

### DIFF
--- a/src/common/util/string_util.cpp
+++ b/src/common/util/string_util.cpp
@@ -63,6 +63,9 @@ auto StringUtil::Indent(int num_indent) -> std::string { return std::string(num_
 
 /** @return true if target string starts with given prefix, false otherwise */
 auto StringUtil::StartsWith(const std::string &str, const std::string &prefix) -> bool {
+  if (prefix.size() > str.size()) {
+    return false;
+  }
   return std::equal(prefix.begin(), prefix.end(), str.begin());
 }
 


### PR DESCRIPTION
### Bug

\`StringUtil::StartsWith\` in \`src/common/util/string_util.cpp\` uses the 3-argument form of \`std::equal\`:

\`\`\`cpp
auto StringUtil::StartsWith(const std::string &str, const std::string &prefix) -> bool {
  return std::equal(prefix.begin(), prefix.end(), str.begin());
}
\`\`\`

When \`prefix.size() > str.size()\`, this reads \`prefix.size()\` characters starting at \`str.begin()\`, walking past the end of \`str\`. That's undefined behaviour.

### Root cause

No length check. The sibling \`EndsWith\` just below it already has the guard:

\`\`\`cpp
auto StringUtil::EndsWith(const std::string &str, const std::string &suffix) -> bool {
  if (suffix.size() > str.size()) {
    return false;
  }
  return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
}
\`\`\`

\`StartsWith\` was written without it.

The bad path is trivially reachable from the interactive shells. In \`tools/shell/shell.cpp\` and \`tools/nc-shell/nc-shell.cpp\` the read loop ends when:

\`\`\`cpp
if (bustub::StringUtil::EndsWith(query, \";\") || bustub::StringUtil::StartsWith(query, \"\\\\\")) {
  break;
}
\`\`\`

and \`query\` can still be empty (e.g. the user presses Enter on a fresh prompt), which means \`StartsWith(\"\", \"\\\\\")\` reads one byte past the start of an empty string. Other call sites (\`bustub_instance.cpp\` checking \`\\\\dbgmvcc\`/\`\\\\txn\`, \`plan_table_ref.cpp\` checking \`__\`/\`__mock\` table-name prefixes, \`bind_insert.cpp\`, \`sqllogictest/sqllogictest.cpp\` option parsing) all pass user-controlled strings that can be shorter than the prefix.

### Fix

Add the same size guard \`EndsWith\` already uses:

\`\`\`cpp
if (prefix.size() > str.size()) {
  return false;
}
\`\`\`

3 lines added, matches the \`EndsWith\` pattern a few lines below, keeps behaviour identical whenever \`str\` is at least as long as \`prefix\`.