### PR TITLE
test: cover serializable validation after transaction GC

### DIFF
--- a/test/txn/txn_abort_serializable_test.cpp
+++ b/test/txn/txn_abort_serializable_test.cpp
@@ -99,6 +99,26 @@ TEST(TxnSerializableTest, DISABLED_ConcurrentSerializableTest) {  // NOLINT
   }
 }
 
+TEST(TxnSerializableTest, DISABLED_GcMustNotEraseCommittedWriteSetNeededForValidation) {  // NOLINT
+  auto bustub = std::make_unique<BusTubInstance>();
+  Execute(*bustub, "CREATE TABLE maintable(a int, b int)");
+
+  auto txn1 = BeginTxnSerializable(*bustub, "txn1");
+  WithTxn(txn1,
+          QueryShowResult(*bustub, _var, _txn, "SELECT * FROM maintable WHERE a > 20", IntResult{}));
+
+  auto txn2 = BeginTxn(*bustub, "txn2");
+  WithTxn(txn2, ExecuteTxn(*bustub, _var, _txn, "INSERT INTO maintable VALUES (30, 1)"));
+  const auto txn2_id = txn2->GetTransactionId();
+  WithTxn(txn2, CommitTxn(*bustub, _var, _txn));
+
+  WithTxn(txn1, ExecuteTxn(*bustub, _var, _txn, "INSERT INTO maintable VALUES (10, 1)"));
+  GarbageCollection(*bustub);
+  EnsureTxnGCed(*bustub, "txn2", txn2_id);
+
+  EXPECT_FALSE(bustub->txn_manager_->Commit(txn1));
+}
+
 TEST(TxnAbortTest, DISABLED_SimpleAbortTest) {  // NOLINT
   fmt::println(stderr, "--- SimpleAbortTest: Setup without primary key ---");
   auto bustub = std::make_unique<BusTubInstance>();

--- a/test/txn/txn_abort_serializable_test.cpp
+++ b/test/txn/txn_abort_serializable_test.cpp
@@ -107,7 +107,7 @@ TEST(TxnSerializableTest, DISABLED_GcMustNotEraseCommittedWriteSetNeededForValid
   WithTxn(txn1,
           QueryShowResult(*bustub, _var, _txn, "SELECT * FROM maintable WHERE a > 20", IntResult{}));
 
-  auto txn2 = BeginTxn(*bustub, "txn2");
+  auto txn2 = BeginTxnSerializable(*bustub, "txn2");
   WithTxn(txn2, ExecuteTxn(*bustub, _var, _txn, "INSERT INTO maintable VALUES (30, 1)"));
   const auto txn2_id = txn2->GetTransactionId();
   WithTxn(txn2, CommitTxn(*bustub, _var, _txn));


### PR DESCRIPTION
## Summary

This PR adds a disabled Project 4 regression test covering the interaction between serializable validation and transaction garbage collection.

## Motivation

The existing tests cover serializable validation and garbage collection separately, but do not test what happens when garbage collection runs before an older serializable transaction commits.

This matters because a newly inserted tuple has no previous version and therefore may not create an `UndoLog`. After the inserting transaction commits and garbage collection runs, the system must still preserve enough information for an older serializable transaction to detect that the insertion changed the result of its earlier predicate scan.

Without this coverage, an implementation may pass both the existing serializable and garbage-collection tests while incorrectly accepting a non-serializable execution.

## Test Scenario

1. A serializable transaction scans an empty predicate (`a > 20`).
2. Another transaction inserts a tuple matching that predicate and commits.
3. The first transaction performs a non-conflicting write.
4. Transaction garbage collection runs.
5. The first transaction attempts to commit.

The final commit must fail because the concurrent insertion introduces a phantom that changes the result of the earlier predicate scan.

The test is disabled by default, consistent with the existing Project 4 transaction tests.